### PR TITLE
Remove register configuration stuff from RequestContext

### DIFF
--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -7,7 +7,7 @@ import io.dropwizard.db.DataSourceFactory;
 import uk.gov.mint.auth.MintAuthenticatorFactory;
 import uk.gov.organisation.client.GovukClientConfiguration;
 import uk.gov.register.configuration.RegisterNameConfiguration;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.config.ResourceConfiguration;
 
 import javax.validation.Valid;

--- a/src/main/java/uk/gov/register/configuration/RegisterDomainConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/RegisterDomainConfiguration.java
@@ -1,4 +1,4 @@
-package uk.gov.register.presentation.config;
+package uk.gov.register.configuration;
 
 import org.jvnet.hk2.annotations.Contract;
 

--- a/src/main/java/uk/gov/register/presentation/ItemConverter.java
+++ b/src/main/java/uk/gov/register/presentation/ItemConverter.java
@@ -6,7 +6,7 @@ import org.jvnet.hk2.annotations.Service;
 import uk.gov.register.Cardinality;
 import uk.gov.register.Field;
 import uk.gov.register.FieldsConfiguration;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import javax.inject.Inject;

--- a/src/main/java/uk/gov/register/presentation/ItemConverter.java
+++ b/src/main/java/uk/gov/register/presentation/ItemConverter.java
@@ -6,6 +6,7 @@ import org.jvnet.hk2.annotations.Service;
 import uk.gov.register.Cardinality;
 import uk.gov.register.Field;
 import uk.gov.register.FieldsConfiguration;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import javax.inject.Inject;
@@ -17,12 +18,15 @@ import static uk.gov.register.Cardinality.ONE;
 public class ItemConverter {
     private final FieldsConfiguration fieldsConfiguration;
     private final RequestContext requestContext;
+    private final String registerDomain;
 
     @Inject
     public ItemConverter(FieldsConfiguration fieldsConfiguration,
-                         RequestContext requestContext) {
+                         RequestContext requestContext,
+                         RegisterDomainConfiguration registerDomainConfiguration) {
         this.fieldsConfiguration = fieldsConfiguration;
         this.requestContext = requestContext;
+        this.registerDomain = registerDomainConfiguration.getRegisterDomain();
     }
 
     public FieldValue convert(Map.Entry<String, JsonNode> mapEntry) {
@@ -57,11 +61,11 @@ public class ItemConverter {
         private FieldValue convertScalar(JsonNode value) {
             if (field.getDatatype().getName().equals("curie")) {
                 if (value.textValue().contains(":")) {
-                    return new LinkValue.CurieValue(value.textValue(), requestContext.getRegisterDomain(), requestContext.getScheme());
+                    return new LinkValue.CurieValue(value.textValue(), registerDomain, requestContext.getScheme());
                 } 
-                return new LinkValue(field.getRegister().get(), requestContext.getRegisterDomain(), requestContext.getScheme(), value.textValue());
+                return new LinkValue(field.getRegister().get(), registerDomain, requestContext.getScheme(), value.textValue());
             } else if (field.getRegister().isPresent()) {
-                return new LinkValue(field.getRegister().get(), requestContext.getRegisterDomain(), requestContext.getScheme(), value.textValue());
+                return new LinkValue(field.getRegister().get(), registerDomain, requestContext.getScheme(), value.textValue());
                 //Note: the equals check below must be replaced with the specified datatype, instead of doing string comparision
                 // We should replace this once the datatype register is available
             } else {

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/EntryListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/EntryListTurtleWriter.java
@@ -4,7 +4,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.presentation.RegisterData;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.presentation.view.EntryListView;

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/EntryListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/EntryListTurtleWriter.java
@@ -2,6 +2,9 @@ package uk.gov.register.presentation.representations.turtle;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import uk.gov.register.configuration.RegisterNameConfiguration;
+import uk.gov.register.presentation.RegisterData;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.presentation.view.EntryListView;
@@ -16,16 +19,23 @@ import java.util.stream.Collectors;
 @Produces(ExtraMediaType.TEXT_TTL)
 public class EntryListTurtleWriter extends TurtleRepresentationWriter<EntryListView> {
 
+    private RegisterDomainConfiguration registerDomainConfiguration;
+    private RegisterData registerData;
+    private RegisterNameConfiguration registerNameConfiguration;
+
     @Inject
-    public EntryListTurtleWriter(RequestContext requestContext) {
-        super(requestContext);
+    public EntryListTurtleWriter(RequestContext requestContext, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData, RegisterNameConfiguration registerNameConfiguration) {
+        super(requestContext, registerDomainConfiguration, registerNameConfiguration);
+        this.registerDomainConfiguration = registerDomainConfiguration;
+        this.registerData = registerData;
+        this.registerNameConfiguration = registerNameConfiguration;
     }
 
     @Override
     protected Model rdfModelFor(EntryListView view) {
         Model model = ModelFactory.createDefaultModel();
-        for (EntryView entryView : view.getEntries().stream().map(e -> new EntryView(requestContext, view.getCustodian(), view.getBranding(), e)).collect(Collectors.toList())) {
-            model.add(new EntryTurtleWriter(requestContext).rdfModelFor(entryView));
+        for (EntryView entryView : view.getEntries().stream().map(e -> new EntryView(requestContext, view.getCustodian(), view.getBranding(), e, registerDomainConfiguration, registerData)).collect(Collectors.toList())) {
+            model.add(new EntryTurtleWriter(requestContext, registerDomainConfiguration, registerNameConfiguration).rdfModelFor(entryView));
         }
         return model;
     }

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/EntryTurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/EntryTurtleWriter.java
@@ -4,7 +4,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import uk.gov.register.configuration.RegisterNameConfiguration;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.presentation.view.EntryView;

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/EntryTurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/EntryTurtleWriter.java
@@ -3,6 +3,8 @@ package uk.gov.register.presentation.representations.turtle;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
+import uk.gov.register.configuration.RegisterNameConfiguration;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.presentation.view.EntryView;
@@ -16,8 +18,8 @@ import javax.ws.rs.ext.Provider;
 public class EntryTurtleWriter extends TurtleRepresentationWriter<EntryView> {
 
     @Inject
-    public EntryTurtleWriter(RequestContext requestContext) {
-        super(requestContext);
+    public EntryTurtleWriter(RequestContext requestContext, RegisterDomainConfiguration registerDomainConfiguration, RegisterNameConfiguration registerNameConfiguration) {
+        super(requestContext, registerDomainConfiguration, registerNameConfiguration);
     }
 
     @Override

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/ItemTurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/ItemTurtleWriter.java
@@ -8,7 +8,7 @@ import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.presentation.FieldValue;
 import uk.gov.register.presentation.LinkValue;
 import uk.gov.register.presentation.ListValue;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.presentation.view.ItemView;

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/ItemTurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/ItemTurtleWriter.java
@@ -4,9 +4,11 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
+import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.presentation.FieldValue;
 import uk.gov.register.presentation.LinkValue;
 import uk.gov.register.presentation.ListValue;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.presentation.view.ItemView;
@@ -18,11 +20,11 @@ import java.util.Map;
 
 @Provider
 @Produces(ExtraMediaType.TEXT_TTL)
-public class ItemTurtleWiter extends TurtleRepresentationWriter<ItemView> {
+public class ItemTurtleWriter extends TurtleRepresentationWriter<ItemView> {
 
     @Inject
-    public ItemTurtleWiter(RequestContext requestContext) {
-        super(requestContext);
+    public ItemTurtleWriter(RequestContext requestContext, RegisterDomainConfiguration registerDomainConfiguration, RegisterNameConfiguration registerNameConfiguration) {
+        super(requestContext, registerDomainConfiguration, registerNameConfiguration);
     }
 
     @Override

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/RecordListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/RecordListTurtleWriter.java
@@ -2,7 +2,10 @@ package uk.gov.register.presentation.representations.turtle;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.presentation.ItemConverter;
+import uk.gov.register.presentation.RegisterData;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.presentation.view.RecordListView;
@@ -16,17 +19,23 @@ import javax.ws.rs.ext.Provider;
 public class RecordListTurtleWriter extends TurtleRepresentationWriter<RecordListView> {
 
     private final ItemConverter itemConverter;
+    private RegisterDomainConfiguration registerDomainConfiguration;
+    private RegisterData registerData;
+    private RegisterNameConfiguration registerNameConfiguration;
 
     @Inject
-    public RecordListTurtleWriter(RequestContext requestContext, ItemConverter itemConverter) {
-        super(requestContext);
+    public RecordListTurtleWriter(RequestContext requestContext, ItemConverter itemConverter, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData, RegisterNameConfiguration registerNameConfiguration) {
+        super(requestContext, registerDomainConfiguration, registerNameConfiguration);
         this.itemConverter = itemConverter;
+        this.registerDomainConfiguration = registerDomainConfiguration;
+        this.registerData = registerData;
+        this.registerNameConfiguration = registerNameConfiguration;
     }
 
     @Override
     protected Model rdfModelFor(RecordListView view) {
         Model model = ModelFactory.createDefaultModel();
-        view.getRecords().stream().forEach(r -> model.add(new RecordTurtleWriter(requestContext, itemConverter).rdfModelFor(r)));
+        view.getRecords().stream().forEach(r -> model.add(new RecordTurtleWriter(requestContext, itemConverter, registerDomainConfiguration, registerData, registerNameConfiguration).rdfModelFor(r)));
         return model;
     }
 }

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/RecordListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/RecordListTurtleWriter.java
@@ -5,7 +5,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.presentation.ItemConverter;
 import uk.gov.register.presentation.RegisterData;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.presentation.view.RecordListView;

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/RecordTurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/RecordTurtleWriter.java
@@ -4,7 +4,7 @@ import org.apache.jena.rdf.model.*;
 import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.presentation.ItemConverter;
 import uk.gov.register.presentation.RegisterData;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.presentation.view.ItemView;

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/RecordTurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/RecordTurtleWriter.java
@@ -1,7 +1,10 @@
 package uk.gov.register.presentation.representations.turtle;
 
 import org.apache.jena.rdf.model.*;
+import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.presentation.ItemConverter;
+import uk.gov.register.presentation.RegisterData;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.presentation.view.ItemView;
@@ -18,21 +21,27 @@ import java.util.Map;
 public class RecordTurtleWriter extends TurtleRepresentationWriter<RecordView> {
 
     private final ItemConverter itemConverter;
+    private final RegisterDomainConfiguration registerDomainConfiguration;
+    private RegisterData registerData;
+    private RegisterNameConfiguration registerNameConfiguration;
 
     @Inject
-    public RecordTurtleWriter(RequestContext requestContext, ItemConverter itemConverter) {
-        super(requestContext);
+    public RecordTurtleWriter(RequestContext requestContext, ItemConverter itemConverter, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData, RegisterNameConfiguration registerNameConfiguration) {
+        super(requestContext, registerDomainConfiguration, registerNameConfiguration);
         this.itemConverter = itemConverter;
+        this.registerDomainConfiguration = registerDomainConfiguration;
+        this.registerData = registerData;
+        this.registerNameConfiguration = registerNameConfiguration;
     }
 
     @Override
     protected Model rdfModelFor(RecordView view) {
-        EntryView entryView = new EntryView(requestContext, view.getCustodian(), view.getBranding(), view.getRecord().entry);
-        ItemView itemView = new ItemView(requestContext, view.getCustodian(), view.getBranding(), itemConverter, view.getRecord().item);
+        EntryView entryView = new EntryView(requestContext, view.getCustodian(), view.getBranding(), view.getRecord().entry, registerDomainConfiguration, registerData);
+        ItemView itemView = new ItemView(requestContext, view.getCustodian(), view.getBranding(), itemConverter, view.getRecord().item, registerDomainConfiguration, registerData);
 
         Model recordModel = ModelFactory.createDefaultModel();
-        Model entryModel = new EntryTurtleWriter(requestContext).rdfModelFor(entryView);
-        Model itemModel = new ItemTurtleWiter(requestContext).rdfModelFor(itemView);
+        Model entryModel = new EntryTurtleWriter(requestContext, registerDomainConfiguration, registerNameConfiguration).rdfModelFor(entryView);
+        Model itemModel = new ItemTurtleWriter(requestContext, registerDomainConfiguration, registerNameConfiguration).rdfModelFor(itemView);
 
         Resource recordResource = recordModel.createResource(recordUri(view.getPrimaryKey()).toString());
         addPropertiesToResource(recordResource, entryModel.getResource(entryUri(entryView.getEntry().entryNumber).toString()));

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/TurtleRepresentationWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/TurtleRepresentationWriter.java
@@ -2,6 +2,8 @@ package uk.gov.register.presentation.representations.turtle;
 
 import io.dropwizard.views.View;
 import org.apache.jena.rdf.model.Model;
+import uk.gov.register.configuration.RegisterNameConfiguration;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.RepresentationWriter;
 import uk.gov.register.presentation.resource.RequestContext;
 
@@ -21,9 +23,13 @@ public abstract class TurtleRepresentationWriter<T extends View> extends Represe
     protected static final String ENTRY_PREFIX = "//%1$s.%2$s/entry/";
     protected static final String ITEM_PREFIX = "//%1$s.%2$s/item/";
     private static final String RECORD_PREFIX = "//%1$s.%2$s/record/";
+    private String registerDomain;
+    private String registerPrimaryKey;
 
-    protected TurtleRepresentationWriter(RequestContext requestContext) {
+    protected TurtleRepresentationWriter(RequestContext requestContext, RegisterDomainConfiguration registerDomainConfiguration, RegisterNameConfiguration registerNameConfiguration) {
         this.requestContext = requestContext;
+        this.registerDomain = registerDomainConfiguration.getRegisterDomain();
+        this.registerPrimaryKey = registerNameConfiguration.getRegister();
     }
 
     @Override
@@ -34,22 +40,22 @@ public abstract class TurtleRepresentationWriter<T extends View> extends Represe
     protected abstract Model rdfModelFor(T view);
 
     protected URI entryUri(String entryNumber) {
-        String path = String.format(ENTRY_PREFIX, requestContext.getRegisterPrimaryKey(), requestContext.getRegisterDomain());
+        String path = String.format(ENTRY_PREFIX, registerPrimaryKey, registerDomain);
         return uriWithScheme(path).path(entryNumber).build();
     }
 
     protected URI itemUri(String itemHash) {
-        String path = String.format(ITEM_PREFIX, requestContext.getRegisterPrimaryKey(), requestContext.getRegisterDomain());
+        String path = String.format(ITEM_PREFIX, registerPrimaryKey, registerDomain);
         return uriWithScheme(path).path(itemHash).build();
     }
 
     protected URI recordUri(String primaryKey) {
-        String path = String.format(RECORD_PREFIX, requestContext.getRegisterPrimaryKey(), requestContext.getRegisterDomain());
+        String path = String.format(RECORD_PREFIX, registerPrimaryKey, registerDomain);
         return uriWithScheme(path).path(primaryKey).build();
     }
 
     protected URI fieldUri() {
-        String path = String.format(ITEM_FIELD_PREFIX, requestContext.getRegisterDomain());
+        String path = String.format(ITEM_FIELD_PREFIX, registerDomain);
         return uriWithScheme(path).build();
     }
 

--- a/src/main/java/uk/gov/register/presentation/representations/turtle/TurtleRepresentationWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/turtle/TurtleRepresentationWriter.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation.representations.turtle;
 import io.dropwizard.views.View;
 import org.apache.jena.rdf.model.Model;
 import uk.gov.register.configuration.RegisterNameConfiguration;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.RepresentationWriter;
 import uk.gov.register.presentation.resource.RequestContext;
 

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -1,6 +1,7 @@
 package uk.gov.register.presentation.resource;
 
 import io.dropwizard.views.View;
+import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.presentation.ArchiveCreator;
 import uk.gov.register.presentation.RegisterDetail;
 import uk.gov.register.presentation.dao.*;
@@ -20,17 +21,17 @@ import java.util.Collection;
 public class DataResource {
     protected final ViewFactory viewFactory;
     private final ItemQueryDAO itemDAO;
-    private RequestContext requestContext;
     private RecordQueryDAO recordDAO;
     private final EntryQueryDAO entryDAO;
+    private String registerPrimaryKey;
 
     @Inject
-    public DataResource(ViewFactory viewFactory, RequestContext requestContext, RecordQueryDAO recordDAO, EntryQueryDAO entryDAO, ItemQueryDAO itemDAO) {
+    public DataResource(ViewFactory viewFactory, RecordQueryDAO recordDAO, EntryQueryDAO entryDAO, ItemQueryDAO itemDAO, RegisterNameConfiguration registerNameConfiguration) {
         this.viewFactory = viewFactory;
-        this.requestContext = requestContext;
         this.recordDAO = recordDAO;
         this.entryDAO = entryDAO;
         this.itemDAO = itemDAO;
+        this.registerPrimaryKey = registerNameConfiguration.getRegister();
     }
 
     @GET
@@ -53,7 +54,7 @@ public class DataResource {
 
         return Response
                 .ok(new ArchiveCreator().create(registerDetail, entries, items))
-                .header("Content-Disposition", String.format("attachment; filename=%s-%d.zip", requestContext.getRegisterPrimaryKey(), System.currentTimeMillis()))
+                .header("Content-Disposition", String.format("attachment; filename=%s-%d.zip", registerPrimaryKey, System.currentTimeMillis()))
                 .header("Content-Transfer-Encoding", "binary")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM)
                 .build();

--- a/src/main/java/uk/gov/register/presentation/resource/EntryResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/EntryResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.presentation.resource;
 
+import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.presentation.dao.Entry;
 import uk.gov.register.presentation.dao.EntryQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
@@ -20,13 +21,15 @@ public class EntryResource {
     private final ViewFactory viewFactory;
     private final RequestContext requestContext;
     private final HttpServletResponseAdapter httpServletResponseAdapter;
+    private final String registerPrimaryKey;
 
     @Inject
-    public EntryResource(EntryQueryDAO entryDAO, ViewFactory viewFactory, RequestContext requestContext) {
+    public EntryResource(EntryQueryDAO entryDAO, ViewFactory viewFactory, RequestContext requestContext, RegisterNameConfiguration registerNameConfiguration) {
         this.entryDAO = entryDAO;
         this.viewFactory = viewFactory;
         this.requestContext = requestContext;
         this.httpServletResponseAdapter = new HttpServletResponseAdapter(requestContext.httpServletResponse);
+        this.registerPrimaryKey = registerNameConfiguration.getRegister();
     }
 
     @GET
@@ -53,7 +56,7 @@ public class EntryResource {
 
     private void setHeaders(NewPagination newPagination) {
         requestContext.resourceExtension().ifPresent(
-                ext -> httpServletResponseAdapter.addContentDispositionHeader(requestContext.getRegisterPrimaryKey() + "-entries." + ext)
+                ext -> httpServletResponseAdapter.addContentDispositionHeader(registerPrimaryKey + "-entries." + ext)
         );
 
         if (newPagination.hasNextPage()) {

--- a/src/main/java/uk/gov/register/presentation/resource/RequestContext.java
+++ b/src/main/java/uk/gov/register/presentation/resource/RequestContext.java
@@ -1,11 +1,6 @@
 package uk.gov.register.presentation.resource;
 
 import org.jvnet.hk2.annotations.Service;
-import uk.gov.register.presentation.RegisterData;
-import uk.gov.register.presentation.RegisterNameExtractor;
-import uk.gov.register.presentation.config.Register;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
-import uk.gov.register.presentation.config.RegistersConfiguration;
 
 import javax.inject.Inject;
 import javax.servlet.ServletContext;
@@ -26,18 +21,8 @@ public class RequestContext {
     @Context
     HttpServletResponse httpServletResponse;
 
-    private final RegisterData registerData;
-
-    private final String registerDomain;
-
     @Inject
-    public RequestContext(RegisterData registerData, RegisterDomainConfiguration domainConfiguration) {
-        this.registerData = registerData;
-        this.registerDomain = domainConfiguration.getRegisterDomain();
-    }
-
-    public String getRegisterPrimaryKey() {
-        return registerData.getRegister().getRegisterName();
+    public RequestContext() {
     }
 
     public String getScheme() {
@@ -54,18 +39,6 @@ public class RequestContext {
 
     public HttpServletResponse getHttpServletResponse() {
         return httpServletResponse;
-    }
-
-    public Register getRegister() {
-        return registerData.getRegister();
-    }
-
-    public RegisterData getRegisterData() {
-        return registerData;
-    }
-
-    public String getRegisterDomain() {
-        return registerDomain;
     }
 
     public Optional<String> resourceExtension() {

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.presentation.resource;
 
+import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 
 import javax.inject.Inject;
@@ -19,17 +20,19 @@ import java.nio.charset.StandardCharsets;
 public class SearchResource {
 
     protected final RequestContext requestContext;
+    private final String registerPrimaryKey;
 
     @Inject
-    public SearchResource(RequestContext requestContext) {
+    public SearchResource(RequestContext requestContext, RegisterNameConfiguration registerNameConfiguration) {
         this.requestContext = requestContext;
+        registerPrimaryKey = registerNameConfiguration.getRegister();
     }
 
     @GET
     @Path("/{key}/{value}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public Object find(@PathParam("key") String key, @PathParam("value") String value) throws Exception {
-        String redirectUrl = key.equals(requestContext.getRegisterPrimaryKey()) ?
+        String redirectUrl = key.equals(registerPrimaryKey) ?
                 String.format("/record/%s", encodeUrlValue(value)) :
                 String.format("/records/%s/%s", key, encodeUrlValue(value));
 

--- a/src/main/java/uk/gov/register/presentation/view/AttributionView.java
+++ b/src/main/java/uk/gov/register/presentation/view/AttributionView.java
@@ -2,7 +2,7 @@ package uk.gov.register.presentation.view;
 
 import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.thymeleaf.ThymeleafView;

--- a/src/main/java/uk/gov/register/presentation/view/AttributionView.java
+++ b/src/main/java/uk/gov/register/presentation/view/AttributionView.java
@@ -1,6 +1,8 @@
 package uk.gov.register.presentation.view;
 
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.thymeleaf.ThymeleafView;
@@ -13,8 +15,8 @@ public class AttributionView extends ThymeleafView {
 
     private final Optional<GovukOrganisation.Details> custodianBranding;
 
-    public AttributionView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, String templateName) {
-        super(requestContext, templateName);
+    public AttributionView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, String templateName, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData) {
+        super(requestContext, templateName, registerData, registerDomainConfiguration);
         this.custodian = custodian;
         this.custodianBranding = custodianBranding;
     }

--- a/src/main/java/uk/gov/register/presentation/view/BadRequestExceptionView.java
+++ b/src/main/java/uk/gov/register/presentation/view/BadRequestExceptionView.java
@@ -1,5 +1,7 @@
 package uk.gov.register.presentation.view;
 
+import uk.gov.register.presentation.RegisterData;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
@@ -8,8 +10,8 @@ import javax.ws.rs.BadRequestException;
 public class BadRequestExceptionView extends ThymeleafView {
     private final BadRequestException exception;
 
-    public BadRequestExceptionView(RequestContext requestContext, BadRequestException exception) {
-        super(requestContext, "400.html");
+    public BadRequestExceptionView(RequestContext requestContext, BadRequestException exception, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData) {
+        super(requestContext, "400.html", registerData, registerDomainConfiguration);
         this.exception = exception;
     }
 

--- a/src/main/java/uk/gov/register/presentation/view/BadRequestExceptionView.java
+++ b/src/main/java/uk/gov/register/presentation/view/BadRequestExceptionView.java
@@ -1,7 +1,7 @@
 package uk.gov.register.presentation.view;
 
 import uk.gov.register.presentation.RegisterData;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.ThymeleafView;
 

--- a/src/main/java/uk/gov/register/presentation/view/CsvRepresentationView.java
+++ b/src/main/java/uk/gov/register/presentation/view/CsvRepresentationView.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation.view;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.RequestContext;
 

--- a/src/main/java/uk/gov/register/presentation/view/CsvRepresentationView.java
+++ b/src/main/java/uk/gov/register/presentation/view/CsvRepresentationView.java
@@ -1,7 +1,9 @@
 package uk.gov.register.presentation.view;
 
 import uk.gov.organisation.client.GovukOrganisation;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.RequestContext;
 
@@ -9,8 +11,8 @@ import java.util.Optional;
 
 public abstract class CsvRepresentationView<T> extends AttributionView {
 
-    public CsvRepresentationView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, String templateName) {
-        super(requestContext, custodian, custodianBranding, templateName);
+    public CsvRepresentationView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, String templateName, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData) {
+        super(requestContext, custodian, custodianBranding, templateName, registerDomainConfiguration, registerData);
     }
 
     public abstract CsvRepresentation<T> csvRepresentation();

--- a/src/main/java/uk/gov/register/presentation/view/EntryListView.java
+++ b/src/main/java/uk/gov/register/presentation/view/EntryListView.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Entry;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.IPagination;

--- a/src/main/java/uk/gov/register/presentation/view/EntryListView.java
+++ b/src/main/java/uk/gov/register/presentation/view/EntryListView.java
@@ -2,7 +2,9 @@ package uk.gov.register.presentation.view;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.organisation.client.GovukOrganisation;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Entry;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.IPagination;
@@ -16,15 +18,15 @@ public class EntryListView extends CsvRepresentationView {
     private Collection<Entry> entries;
     private final Optional<String> recordKey;
 
-    public EntryListView(RequestContext requestContext, IPagination pagination, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Collection<Entry> entries) {
-        super(requestContext, custodian, custodianBranding, "entries.html");
+    public EntryListView(RequestContext requestContext, IPagination pagination, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Collection<Entry> entries, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData) {
+        super(requestContext, custodian, custodianBranding, "entries.html", registerDomainConfiguration, registerData);
         this.pagination = pagination;
         this.entries = entries;
         this.recordKey = Optional.empty();
     }
 
-    public EntryListView(RequestContext requestContext, IPagination pagination, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Collection<Entry> entries, String recordKey) {
-        super(requestContext, custodian, custodianBranding, "entries.html");
+    public EntryListView(RequestContext requestContext, IPagination pagination, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Collection<Entry> entries, String recordKey, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData) {
+        super(requestContext, custodian, custodianBranding, "entries.html", registerDomainConfiguration, registerData);
         this.pagination = pagination;
         this.entries = entries;
         this.recordKey = Optional.of(recordKey);

--- a/src/main/java/uk/gov/register/presentation/view/EntryView.java
+++ b/src/main/java/uk/gov/register/presentation/view/EntryView.java
@@ -2,7 +2,9 @@ package uk.gov.register.presentation.view;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.organisation.client.GovukOrganisation;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Entry;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.RequestContext;
@@ -12,8 +14,8 @@ import java.util.Optional;
 public class EntryView extends CsvRepresentationView<Entry> {
     private Entry entry;
 
-    public EntryView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Entry entry) {
-        super(requestContext, custodian, custodianBranding, "entry.html");
+    public EntryView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Entry entry, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData) {
+        super(requestContext, custodian, custodianBranding, "entry.html", registerDomainConfiguration, registerData);
         this.entry = entry;
     }
 

--- a/src/main/java/uk/gov/register/presentation/view/EntryView.java
+++ b/src/main/java/uk/gov/register/presentation/view/EntryView.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Entry;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.RequestContext;

--- a/src/main/java/uk/gov/register/presentation/view/HomePageView.java
+++ b/src/main/java/uk/gov/register/presentation/view/HomePageView.java
@@ -1,7 +1,9 @@
 package uk.gov.register.presentation.view;
 
 import uk.gov.organisation.client.GovukOrganisation;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import java.time.Instant;
@@ -27,13 +29,12 @@ public class HomePageView extends AttributionView {
             int totalRecords,
             int totalEntries,
             Instant lastUpdated,
-            String registerDomain
-    ) {
-        super(requestContext, custodian, custodianBranding, "home.html");
+            RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData) {
+        super(requestContext, custodian, custodianBranding, "home.html", registerDomainConfiguration, registerData);
         this.totalRecords = totalRecords;
         this.totalEntries = totalEntries;
         this.lastUpdated = lastUpdated;
-        this.registerDomain = registerDomain;
+        this.registerDomain = registerDomainConfiguration.getRegisterDomain();
     }
 
     @SuppressWarnings("unused, used from template")

--- a/src/main/java/uk/gov/register/presentation/view/HomePageView.java
+++ b/src/main/java/uk/gov/register/presentation/view/HomePageView.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation.view;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import java.time.Instant;

--- a/src/main/java/uk/gov/register/presentation/view/ItemView.java
+++ b/src/main/java/uk/gov/register/presentation/view/ItemView.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.ItemConverter;
 import uk.gov.register.presentation.FieldValue;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.RequestContext;
@@ -17,8 +19,8 @@ public class ItemView extends CsvRepresentationView {
     private ItemConverter itemConverter;
     private Item item;
 
-    public ItemView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Item item) {
-        super(requestContext, custodian, branding, "item.html");
+    public ItemView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Item item, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData) {
+        super(requestContext, custodian, branding, "item.html", registerDomainConfiguration, registerData);
         this.itemConverter = itemConverter;
         this.item = item;
     }

--- a/src/main/java/uk/gov/register/presentation/view/ItemView.java
+++ b/src/main/java/uk/gov/register/presentation/view/ItemView.java
@@ -6,7 +6,7 @@ import uk.gov.register.presentation.ItemConverter;
 import uk.gov.register.presentation.FieldValue;
 import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.RequestContext;

--- a/src/main/java/uk/gov/register/presentation/view/RecordListView.java
+++ b/src/main/java/uk/gov/register/presentation/view/RecordListView.java
@@ -5,7 +5,7 @@ import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.ItemConverter;
 import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Record;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.Pagination;

--- a/src/main/java/uk/gov/register/presentation/view/RecordListView.java
+++ b/src/main/java/uk/gov/register/presentation/view/RecordListView.java
@@ -3,7 +3,9 @@ package uk.gov.register.presentation.view;
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.ItemConverter;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Record;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.Pagination;
@@ -16,15 +18,19 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class RecordListView extends CsvRepresentationView {
+    private final RegisterData registerData;
     private Pagination pagination;
     private ItemConverter itemConverter;
     private List<Record> records;
+    private final RegisterDomainConfiguration registerDomainConfiguration;
 
-    public RecordListView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Pagination pagination, ItemConverter itemConverter, List<Record> records) {
-        super(requestContext, custodian, custodianBranding, "records.html");
+    public RecordListView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Pagination pagination, ItemConverter itemConverter, List<Record> records, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData) {
+        super(requestContext, custodian, custodianBranding, "records.html", registerDomainConfiguration, registerData);
         this.pagination = pagination;
         this.itemConverter = itemConverter;
         this.records = records;
+        this.registerDomainConfiguration = registerDomainConfiguration;
+        this.registerData = registerData;
     }
 
     @JsonValue
@@ -33,7 +39,7 @@ public class RecordListView extends CsvRepresentationView {
     }
 
     public List<RecordView> getRecords() {
-        return records.stream().map(r -> new RecordView(requestContext, getCustodian(), getBranding(), itemConverter, r)).collect(Collectors.toList());
+        return records.stream().map(r -> new RecordView(requestContext, getCustodian(), getBranding(), itemConverter, r, registerDomainConfiguration, registerData)).collect(Collectors.toList());
     }
 
     public Pagination getPagination() {

--- a/src/main/java/uk/gov/register/presentation/view/RecordView.java
+++ b/src/main/java/uk/gov/register/presentation/view/RecordView.java
@@ -7,7 +7,9 @@ import io.dropwizard.jackson.Jackson;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.ItemConverter;
 import uk.gov.register.presentation.FieldValue;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Record;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.RequestContext;
@@ -17,17 +19,19 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class RecordView extends CsvRepresentationView {
+    private final String registerPrimaryKey;
     private ItemConverter itemConverter;
     private final Record record;
 
-    public RecordView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, ItemConverter itemConverter, Record record) {
-        super(requestContext, custodian, custodianBranding, "record.html");
+    public RecordView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, ItemConverter itemConverter, Record record, RegisterDomainConfiguration registerDomainConfiguration, RegisterData registerData) {
+        super(requestContext, custodian, custodianBranding, "record.html", registerDomainConfiguration, registerData);
         this.itemConverter = itemConverter;
         this.record = record;
+        this.registerPrimaryKey = registerData.getRegister().getRegisterName();
     }
 
     public String getPrimaryKey() {
-        return record.item.content.get(requestContext.getRegisterPrimaryKey()).textValue();
+        return record.item.content.get(registerPrimaryKey).textValue();
     }
 
     @SuppressWarnings("unused, used to create the json representation of this class")

--- a/src/main/java/uk/gov/register/presentation/view/RecordView.java
+++ b/src/main/java/uk/gov/register/presentation/view/RecordView.java
@@ -9,7 +9,7 @@ import uk.gov.register.presentation.ItemConverter;
 import uk.gov.register.presentation.FieldValue;
 import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBody;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Record;
 import uk.gov.register.presentation.representations.CsvRepresentation;
 import uk.gov.register.presentation.resource.RequestContext;

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -4,6 +4,7 @@ import org.jvnet.hk2.annotations.Service;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.organisation.client.GovukOrganisationClient;
 import uk.gov.register.presentation.ItemConverter;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
 import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.config.RegisterDomainConfiguration;
@@ -29,66 +30,71 @@ public class ViewFactory {
     private final PublicBodiesConfiguration publicBodiesConfiguration;
     private final GovukOrganisationClient organisationClient;
     private final String registerDomain;
+    private final RegisterData registerData;
+    private final RegisterDomainConfiguration registerDomainConfiguration;
 
     @Inject
     public ViewFactory(RequestContext requestContext,
                        ItemConverter itemConverter,
                        PublicBodiesConfiguration publicBodiesConfiguration,
                        GovukOrganisationClient organisationClient,
-                       RegisterDomainConfiguration domainConfiguration) {
+                       RegisterDomainConfiguration domainConfiguration,
+                       RegisterData registerData) {
         this.requestContext = requestContext;
         this.itemConverter = itemConverter;
         this.publicBodiesConfiguration = publicBodiesConfiguration;
         this.organisationClient = organisationClient;
         this.registerDomain = domainConfiguration.getRegisterDomain();
+        this.registerDomainConfiguration = domainConfiguration;
+        this.registerData = registerData;
     }
 
     public ThymeleafView thymeleafView(String templateName) {
-        return new ThymeleafView(requestContext, templateName);
+        return new ThymeleafView(requestContext, templateName, registerData, registerDomainConfiguration);
     }
 
     public BadRequestExceptionView badRequestExceptionView(BadRequestException e) {
-        return new BadRequestExceptionView(requestContext, e);
+        return new BadRequestExceptionView(requestContext, e, registerDomainConfiguration, registerData);
     }
 
     public HomePageView homePageView(int totalRecords, int totalEntries, Instant lastUpdated) {
-        return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, totalEntries, lastUpdated, registerDomain);
+        return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, totalEntries, lastUpdated, registerDomainConfiguration, registerData);
     }
 
     public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, int totalItems, Instant lastUpdated) {
-        return new RegisterDetailView(totalRecords, totalEntries, totalItems, lastUpdated, requestContext.getRegisterData(), registerDomain);
+        return new RegisterDetailView(totalRecords, totalEntries, totalItems, lastUpdated, registerData, registerDomain);
     }
 
     public ItemView getItemView(Item item) {
-        return new ItemView(requestContext, getCustodian(), getBranding(), itemConverter, item);
+        return new ItemView(requestContext, getCustodian(), getBranding(), itemConverter, item, registerDomainConfiguration, registerData);
     }
 
     public EntryView getEntryView(Entry entry) {
-        return new EntryView(requestContext, getCustodian(), getBranding(), entry);
+        return new EntryView(requestContext, getCustodian(), getBranding(), entry, registerDomainConfiguration, registerData);
     }
 
     public EntryListView getEntriesView(Collection<Entry> entries, IPagination pagination) {
-        return new EntryListView(requestContext, pagination, getCustodian(), getBranding(), entries);
+        return new EntryListView(requestContext, pagination, getCustodian(), getBranding(), entries, registerDomainConfiguration, registerData);
     }
 
     public EntryListView getRecordEntriesView(String recordKey, Collection<Entry> entries, IPagination pagination) {
-        return new EntryListView(requestContext, pagination, getCustodian(), getBranding(), entries, recordKey);
+        return new EntryListView(requestContext, pagination, getCustodian(), getBranding(), entries, recordKey, registerDomainConfiguration, registerData);
     }
 
     public RecordView getRecordView(Record record) {
-        return new RecordView(requestContext, getCustodian(), getBranding(), itemConverter, record);
+        return new RecordView(requestContext, getCustodian(), getBranding(), itemConverter, record, registerDomainConfiguration, registerData);
     }
 
     public RecordListView getRecordListView(List<Record> records, Pagination pagination) {
-        return new RecordListView(requestContext, getCustodian(), getBranding(), pagination, itemConverter, records);
+        return new RecordListView(requestContext, getCustodian(), getBranding(), pagination, itemConverter, records, registerDomainConfiguration, registerData);
     }
 
     private PublicBody getCustodian() {
-        return publicBodiesConfiguration.getPublicBody(requestContext.getRegister().getRegistry());
+        return publicBodiesConfiguration.getPublicBody(registerData.getRegister().getRegistry());
     }
 
     private Optional<GovukOrganisation.Details> getBranding() {
-        Optional<GovukOrganisation> organisation = organisationClient.getOrganisation(requestContext.getRegister().getRegistry());
+        Optional<GovukOrganisation> organisation = organisationClient.getOrganisation(registerData.getRegister().getRegistry());
         return organisation.map(GovukOrganisation::getDetails);
     }
 }

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -7,7 +7,7 @@ import uk.gov.register.presentation.ItemConverter;
 import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
 import uk.gov.register.presentation.config.PublicBody;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Entry;
 import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.dao.Record;

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
@@ -3,7 +3,9 @@ package uk.gov.register.thymeleaf;
 import io.dropwizard.views.View;
 import org.apache.commons.lang3.StringUtils;
 import org.markdownj.MarkdownProcessor;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.Register;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import javax.servlet.ServletContext;
@@ -14,12 +16,16 @@ import java.util.Optional;
 
 public class ThymeleafView extends View {
     protected final RequestContext requestContext;
+    private final RegisterData registerData;
+    private final String registerDomain;
     private String thymeleafTemplateName;
     protected final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
-    public ThymeleafView(RequestContext requestContext, String templateName) {
+    public ThymeleafView(RequestContext requestContext, String templateName, RegisterData registerData, RegisterDomainConfiguration registerDomainConfiguration) {
         super(templateName, StandardCharsets.UTF_8);
         this.requestContext = requestContext;
+        this.registerData = registerData;
+        this.registerDomain = registerDomainConfiguration.getRegisterDomain();
     }
 
     @Override
@@ -46,11 +52,11 @@ public class ThymeleafView extends View {
     }
 
     public String getRegisterId() {
-        return requestContext.getRegisterPrimaryKey();
+        return registerData.getRegister().getRegisterName();
     }
 
     public Register getRegister() {
-        return requestContext.getRegister();
+        return registerData.getRegister();
     }
 
     public Optional<String> getRenderedCopyrightText() {
@@ -60,7 +66,7 @@ public class ThymeleafView extends View {
     }
 
     public String getRegisterDomain() {
-        return requestContext.getRegisterDomain();
+        return registerDomain;
     }
 
     public ServletContext getServletContext() {

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
@@ -5,7 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.markdownj.MarkdownProcessor;
 import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.config.Register;
-import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import javax.servlet.ServletContext;

--- a/src/test/java/uk/gov/register/presentation/representations/CsvWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/CsvWriterTest.java
@@ -32,7 +32,7 @@ public class CsvWriterTest {
     public void writes_EntryListView_to_output_stream() throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         csvWriter.writeTo(new EntryListView(null,null,null, Optional.empty(),
-                ImmutableList.of(new Entry("1","1234abcd", Instant.ofEpochSecond(1400000000L)))),
+                ImmutableList.of(new Entry("1","1234abcd", Instant.ofEpochSecond(1400000000L))), () -> "test.register.gov.uk", null),
                 EntryListView.class,
                 null,
                 null,

--- a/src/test/java/uk/gov/register/presentation/resource/RequestContextTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/RequestContextTest.java
@@ -1,18 +1,14 @@
 package uk.gov.register.presentation.resource;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.register.presentation.RegisterData;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,11 +28,6 @@ public class RequestContextTest {
     }
 
     @Test
-    public void takesRegisterNameFromRegisterData() throws IOException {
-        assertThat(requestContext.getRegisterPrimaryKey(), equalTo("foobar"));
-    }
-
-    @Test
     public void resourceExtension_returnsTheResourceExtensionIfExists() {
         when(httpServletRequest.getRequestURI()).thenReturn("/foo/bar.json");
 
@@ -51,8 +42,7 @@ public class RequestContextTest {
     }
 
     private RequestContext createRequestContext() throws IOException {
-        HashMap<String, JsonNode> configData = new ObjectMapper().readValue("{\"register\":\"foobar\"}", HashMap.class);
-        RequestContext resultRequestContext = new RequestContext(new RegisterData(configData), () -> "");
+        RequestContext resultRequestContext = new RequestContext();
 
         httpServletRequest = Mockito.mock(HttpServletRequest.class);
         resultRequestContext.httpServletRequest = httpServletRequest;

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -5,17 +5,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.register.presentation.RegisterData;
-import uk.gov.register.presentation.config.RegistersConfiguration;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,18 +27,13 @@ public class SearchResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        requestContext = new RequestContext(new RegisterData(Collections.emptyMap()), () -> ""){
+        requestContext = new RequestContext(){
             @Override
             public HttpServletResponse getHttpServletResponse() {
                 return servletResponse;
             }
-
-            @Override
-            public String getRegisterPrimaryKey() {
-                return "school";
-            }
         };
-        resource = new SearchResource(requestContext);
+        resource = new SearchResource(requestContext, () -> "school");
     }
 
     @Test

--- a/src/test/java/uk/gov/register/presentation/view/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/presentation/view/HomePageViewTest.java
@@ -1,16 +1,17 @@
 package uk.gov.register.presentation.view;
 
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.register.presentation.config.Register;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -24,10 +25,13 @@ public class HomePageViewTest {
 
     @Test
     public void getRegisterText_rendersRegisterTextAsMarkdown() throws Exception {
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, "openregister.org");
-
         String registerText = "foo *bar* [baz](/quux)";
-        when(mockRequestContext.getRegister()).thenReturn(new Register("", Collections.emptyList(), "", "", registerText, "alpha"));
+        RegisterData registerData = new RegisterData(ImmutableMap.of(
+                "register", new TextNode("widget"),
+                "phase", new TextNode("alpha"),
+                "text", new TextNode(registerText)
+        ));
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, () -> "test.register.gov.uk", registerData);
 
         String result = homePageView.getRegisterText();
 
@@ -38,7 +42,7 @@ public class HomePageViewTest {
     public void getLastUpdatedTime_formatsTheLocalDateTimeToUKDateTimeFormat() {
         Instant instant = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543).toInstant(ZoneOffset.UTC);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, instant, "openregister.org");
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, instant, () -> "test.register.gov.uk", null);
 
         assertThat(homePageView.getLastUpdatedTime(), equalTo("11 September 2015"));
     }
@@ -47,12 +51,14 @@ public class HomePageViewTest {
     public void getLinkToRegisterRegister_returnsTheLinkOfRegisterRegister(){
         Instant instant = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543).toInstant(ZoneOffset.UTC);
 
-        when(mockRequestContext.getRegisterPrimaryKey()).thenReturn("school");
         when(mockRequestContext.getScheme()).thenReturn("https");
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, instant, "openregister.org");
+        RegisterData registerData = new RegisterData(ImmutableMap.of(
+                "register", new TextNode("school")
+        ));
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, instant, () -> "test.register.gov.uk", registerData);
 
-        assertThat(homePageView.getLinkToRegisterRegister(), equalTo("https://register.openregister.org/record/school"));
+        assertThat(homePageView.getLinkToRegisterRegister(), equalTo("https://register.test.register.gov.uk/record/school"));
     }
 
 }

--- a/src/test/java/uk/gov/register/presentation/view/RecordListViewTest.java
+++ b/src/test/java/uk/gov/register/presentation/view/RecordListViewTest.java
@@ -1,5 +1,7 @@
 package uk.gov.register.presentation.view;
 
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.dropwizard.jackson.Jackson;
 import org.json.JSONException;
@@ -10,6 +12,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.skyscreamer.jsonassert.JSONAssert;
 import uk.gov.register.FieldsConfiguration;
 import uk.gov.register.presentation.ItemConverter;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.dao.Entry;
 import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.dao.Record;
@@ -23,7 +26,6 @@ import java.util.Optional;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RecordListViewTest {
@@ -44,8 +46,8 @@ public class RecordListViewTest {
                         new Item("cd", Jackson.newObjectMapper().readTree("{\"address\":\"456\", \"street\":\"bar\"}"))
                 )
         );
-        when(requestContext.getRegisterPrimaryKey()).thenReturn("address");
-        RecordListView recordListView = new RecordListView(requestContext, null, null, null, new ItemConverter(new FieldsConfiguration(Optional.empty()), requestContext), records);
+        RegisterData registerData = new RegisterData(ImmutableMap.of("register", new TextNode("address")));
+        RecordListView recordListView = new RecordListView(requestContext, null, null, null, new ItemConverter(new FieldsConfiguration(Optional.empty()), requestContext, () -> "test.register.gov.uk"), records, () -> "test.register.gov.uk", registerData);
 
         Map<String, RecordView> result = recordListView.recordsJson();
         assertThat(result.size(), equalTo(2));

--- a/src/test/java/uk/gov/register/presentation/view/RecordViewTest.java
+++ b/src/test/java/uk/gov/register/presentation/view/RecordViewTest.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import org.json.JSONException;
 import org.junit.Test;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.dao.Entry;
 import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.dao.Record;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -20,7 +22,7 @@ public class RecordViewTest {
         ObjectMapper objectMapper = Jackson.newObjectMapper();
 
         Record record = new Record(new Entry("1", "ab", Instant.ofEpochMilli(1459241964336L)), new Item("ab", objectMapper.readTree("{\"a\":\"b\"}")));
-        RecordView recordView = new RecordView(null, null, null, null, record);
+        RecordView recordView = new RecordView(null, null, null, null, record, () -> "test.register.gov.uk", new RegisterData(Collections.emptyMap()));
 
         String result = objectMapper.writeValueAsString(recordView);
 

--- a/src/test/java/uk/gov/register/thymeleaf/ThymeleafViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/ThymeleafViewTest.java
@@ -1,20 +1,18 @@
 package uk.gov.register.thymeleaf;
 
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.register.presentation.config.Register;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.resource.RequestContext;
-
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ThymeleafViewTest {
@@ -24,12 +22,14 @@ public class ThymeleafViewTest {
 
     @Before
     public void setUp() throws Exception {
-        thymeleafView = new ThymeleafView(requestContext, "don't care");
+        RegisterData register = new RegisterData(ImmutableMap.of(
+                "register", new TextNode("company-limited-by-guarantee"),
+                "copyright", new TextNode("Copyright text [with link](http://www.example.com/copyright)")));
+        thymeleafView = new ThymeleafView(requestContext, "don't care", register, () -> "test.register.gov.uk");
     }
 
     @Test
     public void friendlyRegisterName_convertsHyphensToUnderscores() throws Exception {
-        when(requestContext.getRegisterPrimaryKey()).thenReturn("company-limited-by-guarantee");
 
         assertThat(thymeleafView.getFriendlyRegisterName(), equalTo("Company limited by guarantee register"));
     }
@@ -37,10 +37,6 @@ public class ThymeleafViewTest {
     @Test
     @SuppressWarnings("OptionalGetWithoutIsPresent, should always be present for this test")
     public void getRenderedCopyrightText_returnsCopyrightRenderedAsMarkdown() throws Exception {
-        Register theRegister = mock(Register.class);
-        when(theRegister.getCopyright()).thenReturn(Optional.of("Copyright text [with link](http://www.example.com/copyright)"));
-        when(requestContext.getRegister()).thenReturn(theRegister);
-
         String renderedCopyrightText = thymeleafView.getRenderedCopyrightText().get();
 
         assertThat(renderedCopyrightText, containsString("<p>Copyright text <a href=\"http://www.example.com/copyright\">with link</a></p>"));


### PR DESCRIPTION
This removes the register configuration methods from RequestContext.

When we configured the register by sniffing the Host: header, it made
some kind of sense for this code to live here.  But now we get it from
yaml configuration instead, let's rip it all out.