### PR TITLE
X forwarded proto

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ task(run, type: JavaExec) {
 task(loadSchoolData, type: JavaExec) {
     main = 'uk.gov.register.presentation.functional.testSupport.DBSupport'
     classpath = sourceSets.test.runtimeClasspath
-    args = ["school", "school-data.jsonl", "school"]
+    args = ["school", "school-data.jsonl", "openregister_java"]
 }
 
 task(loadSchoolDataForConformance, type: JavaExec) {

--- a/src/main/java/uk/gov/register/presentation/resource/RequestContext.java
+++ b/src/main/java/uk/gov/register/presentation/resource/RequestContext.java
@@ -26,7 +26,8 @@ public class RequestContext {
     }
 
     public String getScheme() {
-        return httpServletRequest.getScheme();
+        Optional<String> header = Optional.ofNullable(httpServletRequest.getHeader("X-Forwarded-Proto"));
+        return header.orElse(httpServletRequest.getScheme());
     }
 
     public HttpServletRequest getHttpServletRequest() {


### PR DESCRIPTION
This supersedes openregister/presentation#255 by doing the Right Thing instead.

(warning: "scheme" and "protocol" are used interchangably here).

Currently, the app uses the scheme in the http request to the app server
to determine what scheme to use in URLs rendered as links (in html and
ttl formats, among others).

This is problematic because the scheme used to access an individual app
server might differ from the scheme used by a user to access the edge
server.

This can be resolved by use of the X-Forwarded-Proto header, which is
set by (among other things) Amazon Elastic Load Balancers (ELBs).  This
header is used to report what the edge request protocol was, rather than
using the individual app server protocol.