### PR TITLE
reinstate conformance tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,15 +70,73 @@ assemble {
     }
 }
 
+task startAppForConformance << {
+    startApp()
+}
+
+void startApp() {
+    ProcessBuilder builder = new ProcessBuilder(
+            "java",
+            "-cp",
+            sourceSets.test.runtimeClasspath.join(":"),
+            "uk.gov.register.RegisterApplication",
+            "server",
+            "src/test/resources/conformance-app-config.yaml"
+    ).directory(projectDir.absoluteFile)
+    builder.redirectError(ProcessBuilder.Redirect.to(new File(projectDir, 'stderr.txt')))
+    builder.redirectOutput(ProcessBuilder.Redirect.to(new File(projectDir, 'stdout.txt')))
+    project.ext.runningApp = builder.start()
+}
+
+task stopAppForConformance << {
+    stopApp()
+}
+
+void stopApp() {
+    runningApp?.destroy()?.waitFor()
+}
+
+task(loadSchoolDataForConformance, type: JavaExec) {
+    doFirst{
+        exec{
+            executable "$projectDir/drop_schema.sh" args 'ft_openregister_java'
+        }
+        exec{
+            executable "$projectDir/create_schema.sh" args 'ft_openregister_java'
+        }
+    }
+    main = 'uk.gov.register.presentation.functional.testSupport.DBSupport'
+    classpath = sourceSets.test.runtimeClasspath
+    args = ["school", "school-data.jsonl", "ft_openregister_java"]
+}
+
+task createConformanceTestVenv(type: Exec) {
+    commandLine 'pyvenv-3.5','.venv'
+}
+
+task installConformanceTestDeps(type: Exec) {
+    dependsOn << createConformanceTestVenv
+    commandLine '.venv/bin/pip', 'install', '-r', 'requirements.txt'
+}
+
+task runConformanceTests(type: Exec) {
+    dependsOn << startAppForConformance
+    dependsOn << loadSchoolDataForConformance
+    dependsOn << installConformanceTestDeps
+    finalizedBy stopAppForConformance
+    mustRunAfter test
+    doFirst {
+        waitForApplicationToStart()
+    }
+    commandLine '.venv/bin/openregister-conformance', '--no-https', 'http://school.openregister.dev:9090'
+}
+
+check {
+    dependsOn << runConformanceTests
+}
 
 test {
     dependsOn << compileTestJava
-    doLast {
-        // loadSchoolDataForConformance.execute()
-        // createConformanceTestVenv.execute()
-        // installConformanceTestDeps.execute()
-        // conformanceTest.execute()
-    }
     testLogging {
         events "passed", "skipped", "failed", "standardError"
         showCauses true
@@ -101,18 +159,6 @@ clean.doFirst {
     delete "${rootDir}/.venv/"
 }
 
-task createConformanceTestVenv(type: Exec) {
-    commandLine 'pyvenv-3.5','.venv'
-}
-
-task installConformanceTestDeps(type: Exec) {
-    commandLine '.venv/bin/pip', 'install', '-r', 'requirements.txt'
-}
-
-task conformanceTest(type: Exec) {
-    commandLine '.venv/bin/openregister-conformance', '--no-https', 'http://school.openregister.dev:9000'
-}
-
 task createDeployableBundle(type: Zip) {
     Map env = System.getenv()
     baseName("openregister-java-${env.'TRAVIS_BRANCH'}-${env.'TRAVIS_BUILD_NUMBER'}-${env.'TRAVIS_COMMIT'}")
@@ -129,22 +175,26 @@ task(run, type: JavaExec) {
     jvmArgs = ["-DbaseDirForTemplates=$projectDir/src/main/resources"]
 }
 
+def waitForApplicationToStart() {
+    URL target = new URL('http://localhost:9090/')
+
+    int counter = 0
+    boolean appRunning = false
+    while (!appRunning && counter++ < 10) {
+
+        try {
+            HttpURLConnection connection = (HttpURLConnection) target.openConnection()
+            appRunning = connection.getResponseCode() == 200
+        }
+        catch (IOException ignored) {
+            println "Waiting for application to start (10s max)..."
+            Thread.sleep(1000)
+        }
+    }
+}
+
 task(loadSchoolData, type: JavaExec) {
     main = 'uk.gov.register.presentation.functional.testSupport.DBSupport'
     classpath = sourceSets.test.runtimeClasspath
     args = ["school", "school-data.jsonl", "openregister_java"]
-}
-
-task(loadSchoolDataForConformance, type: JavaExec) {
-    doFirst{
-        exec{
-            executable "$projectDir/drop_schema.sh" args 'ft_openregister_java'
-        }
-        exec{
-            executable "$projectDir/create_schema.sh" args 'ft_openregister_java'
-        }
-    }
-    main = 'uk.gov.register.presentation.functional.testSupport.DBSupport'
-    classpath = sourceSets.test.runtimeClasspath
-    args = ["school", "school-data.jsonl", "ft_openregister_java"]
 }

--- a/create_schema.sh
+++ b/create_schema.sh
@@ -4,7 +4,7 @@ db_name=$1
 
 psql $db_name -U postgres -q -S -c "
 
-CREATE TABLE IF NOT EXISTS current_keys(key VARCHAR PRIMARY KEY, serial_number INTEGER UNIQUE);
+CREATE TABLE IF NOT EXISTS current_keys(key VARCHAR PRIMARY KEY, entry_number INTEGER UNIQUE);
 
 CREATE TABLE IF NOT EXISTS total_records(count INTEGER);
 

--- a/src/main/java/uk/gov/register/presentation/representations/RepresentationWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/RepresentationWriter.java
@@ -1,6 +1,5 @@
 package uk.gov.register.presentation.representations;
 
-import io.dropwizard.views.View;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import javax.ws.rs.core.Context;
@@ -9,7 +8,7 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-public abstract class RepresentationWriter<T extends View> implements MessageBodyWriter<T> {
+public abstract class RepresentationWriter<T> implements MessageBodyWriter<T> {
     @Context
     protected RequestContext requestContext;
 

--- a/src/main/java/uk/gov/register/presentation/representations/YamlWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/YamlWriter.java
@@ -3,7 +3,6 @@ package uk.gov.register.presentation.representations;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.views.View;
 
 import javax.inject.Inject;
 import javax.ws.rs.Produces;
@@ -18,7 +17,7 @@ import java.lang.reflect.Type;
 
 @Provider
 @Produces(ExtraMediaType.TEXT_YAML)
-public class YamlWriter extends RepresentationWriter<View> {
+public class YamlWriter extends RepresentationWriter<Object> {
     private final ObjectMapper objectMapper;
 
     @Inject
@@ -27,7 +26,7 @@ public class YamlWriter extends RepresentationWriter<View> {
     }
 
     @Override
-    public void writeTo(View view, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        objectMapper.writeValue(entityStream, view);
+    public void writeTo(Object object, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        objectMapper.writeValue(entityStream, object);
     }
 }

--- a/src/test/resources/conformance-app-config.yaml
+++ b/src/test/resources/conformance-app-config.yaml
@@ -1,0 +1,32 @@
+server:
+  registerDefaultExceptionMappers: false
+  applicationConnectors:
+    - type: http
+      port: 9090
+  adminConnectors:
+    - type: http
+      port: 9091
+
+register: school
+registerDomain: test.register.gov.uk
+
+credentials:
+  user: foo
+  password: bar
+
+database:
+  driverClass: org.postgresql.Driver
+  url: jdbc:postgresql://localhost:5432/ft_openregister_java
+  user: postgres
+  properties:
+    charSet: UTF-8
+
+  #db connection properties
+  initialSize: 1
+  minSize: 1
+  maxSize: 2
+
+  properties:
+    charSet: UTF-8
+
+enableDownloadResource: true


### PR DESCRIPTION
This commit re-enables the conformance tests that were removed during
the early stages of merging the apps.  In doing this, I've copied over
the previous strategy of starting up an app in the gradle file and
cloning/running the conformance tests.  However I've done some changes:

1) where possible, I define tasks and dependencies between tasks, rather
than as doFirst() or doLast() blocks.  In particular, the conformance
tests are run as part of the build by making the `check` task depend on
the conformance task. [1]

This has the advantage, among other things, that you are able to run the
conformance tests separately by running `./gradlew runConformanceTests`
now.

2) I have created a separate config file for running the app in
conformance test mode -- `conformance-app-config.yaml`.  This was
necessary because the conformance test data is based on schools and so
needs to set `register: school` in the config file.  I took the
opportunity to run it on a different port to avoid clashes with the app
servers run via DropwizardAppRules in the main tests.

3) The conformance tests actually found a bug!  The /registers.yaml
resource wasn't working, because the RegisterDetailView has changed to
no longer extend AttributionView as it used to.  It doesn't make sense
to make RegisterDetailView extend io.dropwizard.views.View because it
never gets rendered as HTML.  So instead I have changed YamlWriter to be
able to render any kind of object, not merely subclasses of View.

[1]: http://blog.proxerd.pl/article/gradle-s-check-task