### PR TITLE
bump to dropwizard 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,6 @@ dependencies {
     compile dropwizard, stringTemplate, apacheCommonsCodec, awsCloudWatch
     compile jacksonCsv, jena, jerseyMedia, markdown, thymeleaf, verifiableLog
     compile jdbi, jersey_client
-    compile(dropwizard_module_java8) {
-        exclude group: 'io.dropwizard'
-    }
-    compile(dropwizard_module_java8_jdbi) {
-        exclude group: 'io.dropwizard'
-    }
     compile(postgresClient) {
         exclude group: 'org.slf4j'
     }

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -1,6 +1,5 @@
 ext {
-    dropwizard_version = '0.9.3'
-    dropwizard_java8_version = '0.9.0-1'
+    dropwizard_version = '1.0.0'
     jersey_version = '2.22.1'
     jackson_version = '2.6.7'
 
@@ -25,9 +24,6 @@ ext {
     awsCloudWatch = 'com.amazonaws:aws-java-sdk-cloudwatch:1.10.54'
     jdbi = 'org.jdbi:jdbi:2.63.1'
     jersey_client = 'org.glassfish.jersey.core:jersey-client:2.22.1'
-
-    dropwizard_module_java8      = "io.dropwizard.modules:dropwizard-java8:${dropwizard_java8_version}"
-    dropwizard_module_java8_jdbi = "io.dropwizard.modules:dropwizard-java8-jdbi:${dropwizard_java8_version}"
 
     jacksonCsv = "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:${jackson_version}"
 

--- a/src/main/java/uk/gov/mint/auth/MintAuthenticator.java
+++ b/src/main/java/uk/gov/mint/auth/MintAuthenticator.java
@@ -1,10 +1,11 @@
 package uk.gov.mint.auth;
 
-import com.google.common.base.Optional;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.basic.BasicCredentials;
 import uk.gov.mint.User;
+
+import java.util.Optional;
 
 public class MintAuthenticator implements Authenticator<BasicCredentials, User> {
     private final String expectedUsername;
@@ -20,6 +21,6 @@ public class MintAuthenticator implements Authenticator<BasicCredentials, User> 
         if (credentials.getUsername().equals(expectedUsername) && credentials.getPassword().equals(expectedPassword)) {
             return Optional.of(new User());
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 }

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -14,8 +14,7 @@ import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.java8.Java8Bundle;
-import io.dropwizard.java8.jdbi.DBIFactory;
+import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.jetty.MutableServletContextHandler;
@@ -30,11 +29,11 @@ import org.skife.jdbi.v2.DBI;
 import uk.gov.mint.*;
 import uk.gov.mint.monitoring.CloudWatchHeartbeater;
 import uk.gov.organisation.client.GovukOrganisationClient;
+import uk.gov.register.configuration.PublicBodiesConfiguration;
+import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.presentation.AssetsBundleCustomErrorHandler;
 import uk.gov.register.presentation.ItemConverter;
 import uk.gov.register.presentation.RegisterData;
-import uk.gov.register.configuration.PublicBodiesConfiguration;
-import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.presentation.dao.EntryQueryDAO;
 import uk.gov.register.presentation.dao.ItemQueryDAO;
 import uk.gov.register.presentation.dao.RecordQueryDAO;
@@ -83,7 +82,6 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                         new EnvironmentVariableSubstitutor(false)
                 ));
         bootstrap.addBundle(new AssetsBundle("/assets"));
-        bootstrap.addBundle(new Java8Bundle());
         bootstrap.setObjectMapper(customObjectMapper());
     }
 

--- a/src/main/java/uk/gov/register/presentation/dao/EntryQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/EntryQueryDAO.java
@@ -1,10 +1,11 @@
 package uk.gov.register.presentation.dao;
 
-import io.dropwizard.java8.jdbi.args.InstantMapper;
+import io.dropwizard.jdbi.args.InstantMapper;
 import org.skife.jdbi.v2.ResultIterator;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.customizers.FetchSize;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterColumnMapper;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 import org.skife.jdbi.v2.sqlobject.mixins.Transactional;
@@ -19,7 +20,7 @@ public interface EntryQueryDAO extends Transactional<EntryQueryDAO> {
     @SingleValueResult(Entry.class)
     Optional<Entry> findByEntryNumber(@Bind("entry_number") int entryNumber);
 
-    @RegisterMapper(InstantMapper.class)
+    @RegisterColumnMapper(InstantMapper.class)
     @SqlQuery("SELECT timestamp FROM entry ORDER BY entry_number DESC LIMIT 1")
     Instant getLastUpdatedTime();
 

--- a/src/test/java/uk/gov/register/presentation/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/ApplicationTest.java
@@ -52,7 +52,7 @@ public class ApplicationTest extends FunctionalTestBase {
 
         String contentType = (String) response.getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0);
         assertThat(contentType, containsString("text/html"));
-        assertThat(contentType, containsString("charset=UTF-8"));
+        assertThat(contentType, containsString("charset=utf-8"));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/presentation/functional/testSupport/TestDAO.java
+++ b/src/test/java/uk/gov/register/presentation/functional/testSupport/TestDAO.java
@@ -1,6 +1,6 @@
 package uk.gov.register.presentation.functional.testSupport;
 
-import io.dropwizard.java8.jdbi.args.InstantArgumentFactory;
+import io.dropwizard.jdbi.args.InstantArgumentFactory;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 


### PR DESCRIPTION
Relatively painless upgrade.  Release notes:
http://www.dropwizard.io/1.0.0/docs/about/release-notes.html#v1-0-0-jul-26-2016

The main difference that affected us is that the dropwizard-java8 stuff
has been merged into the main dropwizard code, so some packages were
renamed and some stuff went away (such as the Java8Bundle, which is
included by default).