### PR TITLE
use the Register tag, not the Name tag, for config

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -3,7 +3,7 @@
 set -eu
 
 INSTANCE_ID=$(curl 169.254.169.254/2014-11-05/meta-data/instance-id)
-REGISTER_NAME=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Name --region eu-west-1 --query 'Tags[0].Value' --output text)
+REGISTER_NAME=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Register --region eu-west-1 --query 'Tags[0].Value' --output text)
 ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Environment --region eu-west-1 --query 'Tags[0].Value' --output text)
 CONFIG_BUCKET=openregister.${ENV}.config
 


### PR DESCRIPTION
I noticed a comment in our terraform code:
https://github.com/openregister/deployment/blob/89c812d0660e01065d25327dd764360db139b57f/aws/modules/instance/main.tf#L15-L16

```
    // should be this once we've fixed the app startup script to use the Register tag:
    // Name = "${var.vpc_name}-${var.id}-${count.index +1}"
    Name = "${var.id}"
```

The comment is saying that the Name tag is set to the name of the
register, but it should instead be set to a meaningful name for the app
server.  Since there can be more than one app server per register, we
have lots of duplicate Names for our app servers.

The Register tag is available if you want to know what the register is.

The start-service.sh script needs to know the register name in order to
fetch the app configuration from S3.  Before this commit, it used the
Name tag, which prevents us from using a more meaningful Name.  This
commit changes the script to use the Register tag instead.

I manually checked on a single EC2 instance that this new command
returns the same expected value.