### PR TITLE
Allow openregister-java to be deployed to heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -jar build/libs/openregister-java-all.jar server heroku.yaml

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,17 @@ apply from: 'idea-config.gradle'
 
 group 'openregister'
 
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+    }
+}
+
+apply plugin: 'com.github.johnrengelman.shadow'
+
 task wrapper(type: Wrapper) {
     gradleVersion = '2.6'
 }
@@ -54,6 +65,15 @@ jar {
                     "Class-Path": configurations.runtime.findAll { !it.directory }.collect { it.name }.join(' ')
             )
         }
+    }
+}
+
+shadowJar {
+    mergeServiceFiles()
+
+    baseName = "openregister-java"
+    manifest {
+        attributes 'Main-Class': 'uk.gov.register.RegisterApplication'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,27 +47,6 @@ dependencies {
 
 jar.baseName = "openregister-java"
 
-jar {
-    doFirst {
-        from {
-            configurations.compile.collect {
-                it.isDirectory() ? it : zipTree(it)
-            }
-        } {
-            exclude "META-INF/*.SF"
-            exclude "META-INF/*.DSA"
-            exclude "META-INF/*.RSA"
-        }
-
-        manifest {
-            attributes(
-                    "Main-Class": "uk.gov.register.RegisterApplication",
-                    "Class-Path": configurations.runtime.findAll { !it.directory }.collect { it.name }.join(' ')
-            )
-        }
-    }
-}
-
 shadowJar {
     mergeServiceFiles()
 
@@ -80,7 +59,7 @@ shadowJar {
 assemble {
     dependsOn << shadowJar
     doLast {
-        new File("deploy/openregister-java.jar").bytes = new File("build/libs/openregister-java.jar").bytes
+        new File("deploy/openregister-java.jar").bytes = shadowJar.archivePath.bytes
         createDeployableBundle.execute()
     }
 }
@@ -92,9 +71,8 @@ task startAppForConformance << {
 void startApp() {
     ProcessBuilder builder = new ProcessBuilder(
             "java",
-            "-cp",
-            sourceSets.test.runtimeClasspath.join(":"),
-            "uk.gov.register.RegisterApplication",
+            "-jar",
+            relativePath(shadowJar.archivePath),
             "server",
             "src/test/resources/conformance-app-config.yaml"
     ).directory(projectDir.absoluteFile)

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ shadowJar {
 }
 
 assemble {
+    dependsOn << shadowJar
     doLast {
         new File("deploy/openregister-java.jar").bytes = new File("build/libs/openregister-java.jar").bytes
         createDeployableBundle.execute()
@@ -215,3 +216,5 @@ task(loadSchoolData, type: JavaExec) {
     classpath = sourceSets.test.runtimeClasspath
     args = ["school", "school-data.jsonl", "openregister_java"]
 }
+
+task stage(dependsOn: ['assemble'])

--- a/heroku.yaml
+++ b/heroku.yaml
@@ -1,0 +1,34 @@
+database:
+  driverClass: org.postgresql.Driver
+  url: ${JDBC_DATABASE_URL}
+  user: ${JDBC_DATABASE_USER}
+  password: ${JDBC_DATABASE_PASSWORD}
+
+  #db connection properties
+  initialSize: 1
+  minSize: 1
+  maxSize: 4
+
+  properties:
+    charSet: UTF-8
+
+server:
+  registerDefaultExceptionMappers: false
+  connectors:
+    - type: http
+      port: ${PORT}
+  adminConnectors:
+    - type: http
+      port: ${PORT}
+
+registerDomain: ${APP_DOMAIN}
+
+register: school
+
+enableDownloadResource: true
+
+logging:
+  # The default level of all loggers. Can be OFF, ERROR, WARN, INFO, DEBUG, TRACE, or ALL.
+  level: INFO
+  appenders:
+  - type: console


### PR DESCRIPTION
I got this deployed to heroku. This was a wonderful yak shave:

 - heroku is based on logging to console rather than to file
 - trying to enable a logger by configuring it with `type: console` resulted in weird errors
 - these errors were caused by our fat jar not concatenating metadata properly
 - rather than fixing our home-grown fat jar code, I replaced it with the shadowJar plugin.

After this PR, there is a thin jar at `build/libs/openregister-java.jar` and a far jar at `build/libs/openregister-java-all.jar`.  The fat jar is used for everything -- in particular, starting the app for conformance test, and for copying into the .zip file which is uploaded to S3 for CodeDeploy.