### PR TITLE
Remove dead code

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -9,7 +9,6 @@ import io.dropwizard.auth.basic.BasicCredentialAuthFilter;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
-import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
@@ -73,7 +72,6 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                         new EnvironmentVariableSubstitutor(false)
                 ));
         bootstrap.addBundle(new AssetsBundle("/assets"));
-        bootstrap.setObjectMapper(Jackson.newObjectMapper());
     }
 
     @Override

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -1,8 +1,5 @@
 package uk.gov.register;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.Application;
@@ -63,12 +60,6 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         }
     }
 
-    public static ObjectMapper customObjectMapper() {
-        ObjectMapper objectMapper = Jackson.newObjectMapper();
-        objectMapper.registerModules(new Jdk8Module(), new JavaTimeModule());
-        return objectMapper;
-    }
-
     @Override
     public String getName() {
         return "openregister";
@@ -82,7 +73,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                         new EnvironmentVariableSubstitutor(false)
                 ));
         bootstrap.addBundle(new AssetsBundle("/assets"));
-        bootstrap.setObjectMapper(customObjectMapper());
+        bootstrap.setObjectMapper(Jackson.newObjectMapper());
     }
 
     @Override

--- a/src/test/java/uk/gov/organisation/client/TestJerseyClientBuilder.java
+++ b/src/test/java/uk/gov/organisation/client/TestJerseyClientBuilder.java
@@ -3,9 +3,9 @@ package uk.gov.organisation.client;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.jackson.Jackson;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
-import uk.gov.register.RegisterApplication;
 
 import javax.ws.rs.client.Client;
 
@@ -17,7 +17,7 @@ public abstract class TestJerseyClientBuilder {
     }
 
     public static Client createTestJerseyClient(Duration timeout) {
-        Environment environment = new Environment("test-dropwizard-apache-connector", RegisterApplication.customObjectMapper(),
+        Environment environment = new Environment("test-dropwizard-apache-connector", Jackson.newObjectMapper(),
                 buildDefaultValidatorFactory().getValidator(), new MetricRegistry(),
                 TestJerseyClientBuilder.class.getClassLoader());
 


### PR DESCRIPTION
Since we moved to Dropwizard 1.0, Java 8 is supported by default.  This
means that the Jdk8Module and the JavaTimeModule are automatically
supported by Jackson.newObjectMapper(), and we don't need to add them
separately.