### PR TITLE
remove dynamic register proof from home page

### DIFF
--- a/src/main/java/uk/gov/register/resources/HomePageResource.java
+++ b/src/main/java/uk/gov/register/resources/HomePageResource.java
@@ -3,7 +3,6 @@ package uk.gov.register.resources;
 import io.dropwizard.views.View;
 import uk.gov.register.db.EntryQueryDAO;
 import uk.gov.register.db.RecordQueryDAO;
-import uk.gov.register.service.VerifiableLogService;
 import uk.gov.register.views.ViewFactory;
 import uk.gov.register.views.representations.ExtraMediaType;
 
@@ -19,15 +18,12 @@ public class HomePageResource {
     private final ViewFactory viewFactory;
     private final RecordQueryDAO recordDAO;
     private final EntryQueryDAO entryDAO;
-    private final VerifiableLogService verifiableLogService;
-
 
     @Inject
-    public HomePageResource(ViewFactory viewFactory, RecordQueryDAO recordDAO, EntryQueryDAO entryDAO, VerifiableLogService verifiableLogService) {
+    public HomePageResource(ViewFactory viewFactory, RecordQueryDAO recordDAO, EntryQueryDAO entryDAO) {
         this.viewFactory = viewFactory;
         this.recordDAO = recordDAO;
         this.entryDAO = entryDAO;
-        this.verifiableLogService = verifiableLogService;
     }
 
     @GET
@@ -36,8 +32,8 @@ public class HomePageResource {
         return viewFactory.homePageView(
                 recordDAO.getTotalRecords(),
                 entryDAO.getTotalEntries(),
-                entryDAO.getLastUpdatedTime(),
-                verifiableLogService.getRegisterProof());
+                entryDAO.getLastUpdatedTime()
+        );
     }
 
     @GET

--- a/src/main/java/uk/gov/register/views/HomePageView.java
+++ b/src/main/java/uk/gov/register/views/HomePageView.java
@@ -1,8 +1,5 @@
 package uk.gov.register.views;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.configuration.RegisterDomainConfiguration;
 import uk.gov.register.core.PublicBody;
@@ -21,7 +18,6 @@ public class HomePageView extends AttributionView {
     private final static DateTimeFormatter FRIENDLY_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMMM uuuu").withZone(ZoneId.of("UTC"));
 
     private final Optional<Instant> lastUpdated;
-    private final RegisterProof registerProof;
     private final int totalRecords;
     private final int totalEntries;
     private final String registerDomain;
@@ -34,13 +30,11 @@ public class HomePageView extends AttributionView {
             int totalEntries,
             Optional<Instant> lastUpdated,
             RegisterDomainConfiguration registerDomainConfiguration,
-            RegisterData registerData,
-            RegisterProof registerProof) {
+            RegisterData registerData) {
         super(requestContext, custodian, custodianBranding, "home.html", registerDomainConfiguration, registerData);
         this.totalRecords = totalRecords;
         this.totalEntries = totalEntries;
         this.lastUpdated = lastUpdated;
-        this.registerProof = registerProof;
         this.registerDomain = registerDomainConfiguration.getRegisterDomain();
     }
 
@@ -72,13 +66,4 @@ public class HomePageView extends AttributionView {
                 getRegisterId()
         );
     }
-
-    public String getRegisterJson() throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-        return objectMapper.writeValueAsString(registerProof);
-
-    }
-
-
 }

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -53,8 +53,8 @@ public class ViewFactory {
         return new BadRequestExceptionView(requestContext, e, registerDomainConfiguration, registerData);
     }
 
-    public HomePageView homePageView(int totalRecords, int totalEntries, Optional<Instant> lastUpdated, RegisterProof registerProof) {
-        return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, totalEntries, lastUpdated, registerDomainConfiguration, registerData, registerProof);
+    public HomePageView homePageView(int totalRecords, int totalEntries, Optional<Instant> lastUpdated) {
+        return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, totalEntries, lastUpdated, registerDomainConfiguration, registerData);
     }
 
     public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, int totalItems, Optional<Instant> lastUpdated) {

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -45,7 +45,13 @@
         <summary>Check the register fingerprint</summary>
         <div class="fingerprint-container">
             <span class="fingerprint-explanation"><a href="https://gdstechnology.blog.gov.uk/2015/10/13/guaranteeing-the-integrity-of-a-register/">See how the fingerprint works</a></span>
-            <pre class="fingerprint"><code th:text="${registerJson}">}</code></pre>
+            <pre class="fingerprint"><code>{
+  "tree_size": 9803348,
+  "timestamp": 1447421303202,
+  "sha256_root_hash": "JATHxRF5gczvNPP1S1WuhD8jSx2bl+WoTt8bIE3YKvU=",
+  "tree_head_signature":
+  "BAMARzBFAiEAkKM3aRUBKhShdCyrGLdd8lYBV52FLrwqjHa5/YuzK7ECIFTlRmNuKLqbVQv0QS8nq0pAUwgbilKOR5piBAIC8LpS"
+}</code></pre>
         </div>
     </details>
 

--- a/src/test/java/uk/gov/register/resources/HomePageResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/HomePageResourceTest.java
@@ -3,9 +3,7 @@ package uk.gov.register.resources;
 import org.junit.Test;
 import uk.gov.register.db.EntryQueryDAO;
 import uk.gov.register.db.RecordQueryDAO;
-import uk.gov.register.service.VerifiableLogService;
 import uk.gov.register.views.HomePageView;
-import uk.gov.register.views.RegisterProof;
 import uk.gov.register.views.ViewFactory;
 
 import java.security.NoSuchAlgorithmException;
@@ -21,27 +19,23 @@ public class HomePageResourceTest {
         int totalRecords = 5;
         int totalEntries = 6;
         Optional<Instant> lastUpdated = Optional.of(Instant.ofEpochMilli(1459241964336L));
-        RegisterProof registerProof = new RegisterProof("6b85b168f7c5f0587fc22ff4ba6937e61b33f6e89b70eed53d78d895d35dc9c3");
         HomePageView homePageView = mock(HomePageView.class);
 
         RecordQueryDAO recordDAOMock = mock(RecordQueryDAO.class);
         EntryQueryDAO entryDAOMock = mock(EntryQueryDAO.class);
-        VerifiableLogService verifiableLogServiceMock = mock(VerifiableLogService.class);
         ViewFactory viewFactoryMock = mock(ViewFactory.class);
 
         when(recordDAOMock.getTotalRecords()).thenReturn(totalRecords);
         when(entryDAOMock.getTotalEntries()).thenReturn(totalEntries);
         when(entryDAOMock.getLastUpdatedTime()).thenReturn(lastUpdated);
-        when(verifiableLogServiceMock.getRegisterProof()).thenReturn(registerProof);
-        when(viewFactoryMock.homePageView(totalRecords, totalEntries, lastUpdated, registerProof)).thenReturn(homePageView);
+        when(viewFactoryMock.homePageView(totalRecords, totalEntries, lastUpdated)).thenReturn(homePageView);
 
-        HomePageResource homePageResource = new HomePageResource(viewFactoryMock, recordDAOMock, entryDAOMock, verifiableLogServiceMock);
+        HomePageResource homePageResource = new HomePageResource(viewFactoryMock, recordDAOMock, entryDAOMock);
         homePageResource.home();
 
         verify(recordDAOMock, times(1)).getTotalRecords();
         verify(entryDAOMock, times(1)).getTotalEntries();
-        verify(verifiableLogServiceMock, times(1)).getRegisterProof();
-        verify(viewFactoryMock, times(1)).homePageView(totalRecords, totalEntries, lastUpdated, registerProof);
+        verify(viewFactoryMock, times(1)).homePageView(totalRecords, totalEntries, lastUpdated);
     }
 }
 

--- a/src/test/java/uk/gov/register/views/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/views/HomePageViewTest.java
@@ -33,7 +33,7 @@ public class HomePageViewTest {
                 "phase", new TextNode("alpha"),
                 "text", new TextNode(registerText)
         ));
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, () -> "test.register.gov.uk", registerData, createRegisterProof());
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, () -> "test.register.gov.uk", registerData);
 
         String result = homePageView.getRegisterText();
 
@@ -44,14 +44,14 @@ public class HomePageViewTest {
     public void getLastUpdatedTime_formatsTheLocalDateTimeToUKDateTimeFormat() {
         Instant instant = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543).toInstant(ZoneOffset.UTC);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), () -> "test.register.gov.uk", null, createRegisterProof());
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), () -> "test.register.gov.uk", null);
 
         assertThat(homePageView.getLastUpdatedTime(), equalTo("11 September 2015"));
     }
 
     @Test
     public void getLastUpdatedTime_returnsEmptyStringIfLastUpdatedTimeNotPresent() {
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), () -> "test.register.gov.uk", null, createRegisterProof());
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), () -> "test.register.gov.uk", null);
 
         assertThat(homePageView.getLastUpdatedTime(), isEmptyString());
     }
@@ -65,24 +65,8 @@ public class HomePageViewTest {
         RegisterData registerData = new RegisterData(ImmutableMap.of(
                 "register", new TextNode("school")
         ));
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), () -> "test.register.gov.uk", registerData, createRegisterProof());
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), () -> "test.register.gov.uk", registerData);
 
         assertThat(homePageView.getLinkToRegisterRegister(), equalTo("https://register.test.register.gov.uk/record/school"));
     }
-
-    @Test
-    public void getRegisterProof_returnsPrettyPrintedJson() throws Exception {
-        RegisterProof regProof = new RegisterProof("e869291e3017a7b1dd6b16af0b556d75378bef59486f1a7f53586b3ca86aed09");
-
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, () -> "test.register.gov.uk", null, regProof);
-
-        String result = homePageView.getRegisterJson();
-
-        assertThat(result, equalTo("{\n  \"proof-identifier\" : \"merkle:sha-256\",\n  \"root-hash\" : \"e869291e3017a7b1dd6b16af0b556d75378bef59486f1a7f53586b3ca86aed09\"\n}"));
-    }
-
-    private RegisterProof createRegisterProof(){
-        return new RegisterProof("e869291e3017a7b1dd6b16af0b556d75378bef59486f1a7f53586b3ca86aed09");
-    }
-
 }


### PR DESCRIPTION
For large registers, each time we redeploy we'll trash the in-memory
cache of merkle tree nodes.  If we have the root hash on the homepage,
then each time we redeploy, we won't be able to render the homepage
until the in-memory cache has been rebuilt.

Reverting back to the static mockup for the time being.