### PR TITLE
fix AssetsBundle 404s, remove RegisterNameExtractor

### DIFF
--- a/src/main/java/uk/gov/register/AssetsBundleCustomErrorHandler.java
+++ b/src/main/java/uk/gov/register/AssetsBundleCustomErrorHandler.java
@@ -10,10 +10,10 @@ import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.WebContext;
 import org.thymeleaf.resourceresolver.FileResourceResolver;
 import org.thymeleaf.templateresolver.TemplateResolver;
+import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.core.RegisterData;
 import uk.gov.register.thymeleaf.ThymeleafResourceResolver;
-import uk.gov.register.util.RegisterNameExtractor;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -55,7 +55,8 @@ public class AssetsBundleCustomErrorHandler extends ErrorHandler {
         ServletContext sc = baseRequest.getContext();
         ServiceLocator sl = ((ServletContainer) environment.getJerseyServletContainer()).getApplicationHandler().getServiceLocator();
         RegistersConfiguration rc = sl.getService(RegistersConfiguration.class);
-        String registerId = RegisterNameExtractor.extractRegisterName(request.getHeader("Host"));
+        RegisterNameConfiguration rnc = sl.getService(RegisterNameConfiguration.class);
+        String registerId = rnc.getRegister();
         RegisterData rd = rc.getRegisterData(registerId);
         String registerName = registerId.replace('-', ' ');
 
@@ -63,6 +64,7 @@ public class AssetsBundleCustomErrorHandler extends ErrorHandler {
                 request.getLocale());
         wc.setVariable("register", rd.getRegister());
         wc.setVariable("friendlyRegisterName", StringUtils.capitalize(registerName) + " register");
+        wc.setVariable("renderedCopyrightText", rd.getRegister().getCopyright());
 
         response.setHeader("Content-Type", "text/html; charset=UTF-8");
         engine.process("404.html", wc, response.getWriter());

--- a/src/main/java/uk/gov/register/util/RegisterNameExtractor.java
+++ b/src/main/java/uk/gov/register/util/RegisterNameExtractor.java
@@ -1,7 +1,0 @@
-package uk.gov.register.util;
-
-public class RegisterNameExtractor {
-    public static String extractRegisterName(String host) {
-        return host.split(":")[0].split("\\.")[0];
-    }
-}

--- a/src/test/java/uk/gov/register/functional/AssetsBundleCustomErrorHandlerTest.java
+++ b/src/test/java/uk/gov/register/functional/AssetsBundleCustomErrorHandlerTest.java
@@ -1,0 +1,26 @@
+package uk.gov.register.functional;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.junit.Assert;
+import org.junit.Test;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AssetsBundleCustomErrorHandlerTest extends FunctionalTestBase {
+    @Test
+    public void displays404pageForNonexistentAssets() {
+        Response response = getRequest("/assets/not-an-assets");
+
+        assertThat(response.getStatus(), equalTo(404));
+        assertThat(response.getMediaType().isCompatible(MediaType.TEXT_HTML_TYPE), equalTo(true));
+
+        Document doc = Jsoup.parse(response.readEntity(String.class));
+        Elements notFoundHeader = doc.select("main h1");
+        Assert.assertThat(notFoundHeader.first().text(), equalTo("Page not found"));
+    }
+}


### PR DESCRIPTION
Any 404 within the AssetsBundle path (eg /assets/not-found ) will
currently break.  This is because the `renderedCopyrightText` variable
is not set, causing the template engine to break.

Also, the error handler was the last place still getting the register
name from the Host header rather than from the register configuration.
I took the opportunity to replace that.