### PR TITLE
don't show PASSED tests in build output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ check {
 test {
     dependsOn << compileTestJava
     testLogging {
-        events "passed", "skipped", "failed", "standardError"
+        events "skipped", "failed", "standardError"
         showCauses true
         showExceptions true
         showStackTraces true


### PR DESCRIPTION
When a test fails, it's hard to see which one failed because it's lost
in the noise of all the PASSED tests in the output.

We originally added this output to give us confidence that the tests
were actually being run.  I don't think we need that any more.