### PR TITLE
Use InMemoryPowOfTwoNoLeaves to memoize merkle tree hashes

### DIFF
--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -3,7 +3,7 @@ ext {
     jersey_version = '2.22.1'
     jackson_version = '2.6.7'
 
-    verifiableLog = 'verifiable-log:verifiable-log:0.1.64'
+    verifiableLog = 'verifiable-log:verifiable-log:0.1.67'
 
     dropwizard = [
             "io.dropwizard:dropwizard-core:${dropwizard_version}",

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -39,7 +39,7 @@ import uk.gov.register.service.VerifiableLogService;
 import uk.gov.register.thymeleaf.ThymeleafViewRenderer;
 import uk.gov.register.util.ObjectReconstructor;
 import uk.gov.register.views.ViewFactory;
-import uk.gov.verifiablelog.store.memoization.InMemoryPowOfTwo;
+import uk.gov.verifiablelog.store.memoization.InMemoryPowOfTwoNoLeaves;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import javax.inject.Singleton;
@@ -114,7 +114,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);
                 bind(ItemConverter.class).to(ItemConverter.class).in(Singleton.class);
                 bind(GovukOrganisationClient.class).to(GovukOrganisationClient.class).in(Singleton.class);
-                bind(InMemoryPowOfTwo.class).to(MemoizationStore.class).in(Singleton.class);
+                bind(InMemoryPowOfTwoNoLeaves.class).to(MemoizationStore.class).in(Singleton.class);
                 bind(configuration);
                 bind(client).to(Client.class);
             }


### PR DESCRIPTION
This means that the MemoizationStore doesn't get too large.

This was part of a commit to the Presentation repo which didn't get merged into the openregister-java repo https://github.com/openregister/presentation/commit/0dfd3c3d0c7505269d9c2656ebf6ad94b499eef5.