### PR TITLE
Separate database transactions from register

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -30,6 +30,8 @@ import uk.gov.register.monitoring.CloudWatchHeartbeater;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.service.ItemConverter;
 import uk.gov.register.service.ItemValidator;
+import uk.gov.register.store.BackingStoreDriver;
+import uk.gov.register.store.postgres.PostgresDriverNonTransactional;
 import uk.gov.register.thymeleaf.ThymeleafViewRenderer;
 import uk.gov.register.util.ObjectReconstructor;
 import uk.gov.register.views.ViewFactory;
@@ -101,6 +103,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(EntryLog.class).to(EntryLog.class);
                 bind(ItemStore.class).to(ItemStore.class);
                 bind(RecordIndex.class).to(RecordIndex.class);
+                bind(PostgresDriverNonTransactional.class).to(BackingStoreDriver.class);
 
                 bind(RequestContext.class).to(RequestContext.class);
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -24,12 +24,12 @@ import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.PublicBodiesConfiguration;
 import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.core.*;
-import uk.gov.register.db.RecordIndex;
 import uk.gov.register.db.SchemaCreator;
 import uk.gov.register.monitoring.CloudWatchHeartbeater;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.service.ItemConverter;
 import uk.gov.register.service.ItemValidator;
+import uk.gov.register.service.RegisterService;
 import uk.gov.register.store.BackingStoreDriver;
 import uk.gov.register.store.postgres.PostgresDriverNonTransactional;
 import uk.gov.register.thymeleaf.ThymeleafViewRenderer;
@@ -100,10 +100,8 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
 
                 bind(ItemValidator.class).to(ItemValidator.class);
                 bind(ObjectReconstructor.class).to(ObjectReconstructor.class);
-                bind(EntryLog.class).to(EntryLog.class);
-                bind(ItemStore.class).to(ItemStore.class);
-                bind(RecordIndex.class).to(RecordIndex.class);
                 bind(PostgresDriverNonTransactional.class).to(BackingStoreDriver.class);
+                bind(RegisterService.class).to(RegisterService.class);
 
                 bind(RequestContext.class).to(RequestContext.class);
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);

--- a/src/main/java/uk/gov/register/core/EntryLog.java
+++ b/src/main/java/uk/gov/register/core/EntryLog.java
@@ -1,34 +1,28 @@
 package uk.gov.register.core;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.skife.jdbi.v2.Handle;
 import uk.gov.register.db.EntryDAO;
-import uk.gov.register.db.EntryMerkleLeafStore;
-import uk.gov.register.db.EntryQueryDAO;
+import uk.gov.register.store.BackingStoreDriver;
 import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
-import uk.gov.verifiablelog.VerifiableLog;
-import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import javax.inject.Inject;
-import javax.xml.bind.DatatypeConverter;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * An append-only log of Entries, together with proofs
  */
 public class EntryLog {
-    private final MemoizationStore memoizationStore;
+    private final BackingStoreDriver backingStoreDriver;
 
     @Inject
-    public EntryLog(MemoizationStore memoizationStore) {
-        this.memoizationStore = memoizationStore;
+    public EntryLog(BackingStoreDriver backingStoreDriver) {
+        this.backingStoreDriver = backingStoreDriver;
     }
 
     public void appendEntries(Handle handle, List<Entry> entries) {
@@ -37,55 +31,35 @@ public class EntryLog {
         entryDAO.setEntryNumber(entryDAO.currentEntryNumber() + entries.size());
     }
 
-    public Optional<Entry> getEntry(Handle handle, int entryNumber) {
-        return handle.attach(EntryQueryDAO.class).findByEntryNumber(entryNumber);
+    public Optional<Entry> getEntry(int entryNumber) {
+        return backingStoreDriver.getEntry(entryNumber);
     }
 
-    public Collection<Entry> getEntries(Handle h, int start, int limit) {
-        return h.attach(EntryQueryDAO.class).getEntries(start, limit);
+    public Collection<Entry> getEntries(int start, int limit) {
+        return backingStoreDriver.getEntries(start, limit);
     }
 
-    public Collection<Entry> getAllEntries(Handle handle) {
-        return handle.attach(EntryQueryDAO.class).getAllEntriesNoPagination();
+    public Collection<Entry> getAllEntries() {
+        return backingStoreDriver.getAllEntries();
     }
 
-    public int getTotalEntries(Handle h) {
-        return h.attach(EntryQueryDAO.class).getTotalEntries();
+    public int getTotalEntries() {
+        return backingStoreDriver.getTotalEntries();
     }
 
-    public Optional<Instant> getLastUpdatedTime(Handle h) {
-        return h.attach(EntryQueryDAO.class).getLastUpdatedTime();
+    public Optional<Instant> getLastUpdatedTime() {
+        return backingStoreDriver.getLastUpdatedTime();
     }
 
-    public RegisterProof getRegisterProof(Handle handle) throws NoSuchAlgorithmException {
-        VerifiableLog verifiableLog = getVerifiableLog(handle);
-        String rootHash = bytesToString(verifiableLog.currentRoot());
-        return new RegisterProof(rootHash);
+    public RegisterProof getRegisterProof() throws NoSuchAlgorithmException {
+        return backingStoreDriver.getRegisterProof();
     }
 
-    public EntryProof getEntryProof(Handle handle, int entryNumber, int totalEntries) {
-        VerifiableLog verifiableLog = getVerifiableLog(handle);
-
-        List<String> auditProof = verifiableLog.auditProof(entryNumber, totalEntries).stream()
-                .map(this::bytesToString).collect(Collectors.toList());
-
-        return new EntryProof(Integer.toString(entryNumber), auditProof);
+    public EntryProof getEntryProof(int entryNumber, int totalEntries) {
+        return backingStoreDriver.getEntryProof(entryNumber, totalEntries);
     }
 
-    public ConsistencyProof getConsistencyProof(Handle handle, int totalEntries1, int totalEntries2){
-        VerifiableLog verifiableLog = getVerifiableLog(handle);
-        List<String> consistencyProof = verifiableLog.consistencyProof(totalEntries1, totalEntries2).stream()
-                .map(this::bytesToString).collect(Collectors.toList());
-
-        return new ConsistencyProof(consistencyProof);
-    }
-
-    private VerifiableLog getVerifiableLog(Handle handle) {
-        EntryMerkleLeafStore merkleLeafStore = new EntryMerkleLeafStore(handle.attach(EntryQueryDAO.class));
-        return new VerifiableLog(DigestUtils.getSha256Digest(), merkleLeafStore, memoizationStore);
-    }
-
-    private String bytesToString(byte[] bytes) {
-        return DatatypeConverter.printHexBinary(bytes).toLowerCase();
+    public ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2){
+        return backingStoreDriver.getConsistencyProof(totalEntries1, totalEntries2);
     }
 }

--- a/src/main/java/uk/gov/register/core/EntryLog.java
+++ b/src/main/java/uk/gov/register/core/EntryLog.java
@@ -1,7 +1,5 @@
 package uk.gov.register.core;
 
-import org.skife.jdbi.v2.Handle;
-import uk.gov.register.db.EntryDAO;
 import uk.gov.register.store.BackingStoreDriver;
 import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
@@ -10,7 +8,6 @@ import uk.gov.register.views.RegisterProof;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -23,10 +20,8 @@ public class EntryLog {
         this.backingStoreDriver = backingStoreDriver;
     }
 
-    public void appendEntries(Handle handle, List<Entry> entries) {
-        EntryDAO entryDAO = handle.attach(EntryDAO.class);
-        entryDAO.insertInBatch(entries);
-        entryDAO.setEntryNumber(entryDAO.currentEntryNumber() + entries.size());
+    public void appendEntry(Entry entry) {
+        backingStoreDriver.insertEntry(entry);
     }
 
     public Optional<Entry> getEntry(int entryNumber) {

--- a/src/main/java/uk/gov/register/core/EntryLog.java
+++ b/src/main/java/uk/gov/register/core/EntryLog.java
@@ -7,7 +7,6 @@ import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
 
-import javax.inject.Inject;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Collection;
@@ -20,7 +19,6 @@ import java.util.Optional;
 public class EntryLog {
     private final BackingStoreDriver backingStoreDriver;
 
-    @Inject
     public EntryLog(BackingStoreDriver backingStoreDriver) {
         this.backingStoreDriver = backingStoreDriver;
     }

--- a/src/main/java/uk/gov/register/core/ItemStore.java
+++ b/src/main/java/uk/gov/register/core/ItemStore.java
@@ -2,21 +2,27 @@ package uk.gov.register.core;
 
 import org.skife.jdbi.v2.Handle;
 import uk.gov.register.db.ItemDAO;
-import uk.gov.register.db.ItemQueryDAO;
+import uk.gov.register.store.BackingStoreDriver;
 
 import java.util.Collection;
 import java.util.Optional;
 
 public class ItemStore {
+    private final BackingStoreDriver backingStoreDriver;
+
+    public ItemStore(BackingStoreDriver backingStoreDriver) {
+        this.backingStoreDriver = backingStoreDriver;
+    }
+
     public void putItems(Handle handle, Iterable<Item> items) {
         handle.attach(ItemDAO.class).insertInBatch(items);
     }
 
-    public Optional<Item> getItemBySha256(Handle h, String sha256hex) {
-        return h.attach(ItemQueryDAO.class).getItemBySHA256(sha256hex);
+    public Optional<Item> getItemBySha256(String sha256hex) {
+        return backingStoreDriver.getItemBySha256(sha256hex);
     }
 
-    public Collection<Item> getAllItems(Handle h) {
-        return h.attach(ItemQueryDAO.class).getAllItemsNoPagination();
+    public Collection<Item> getAllItems() {
+        return backingStoreDriver.getAllItems();
     }
 }

--- a/src/main/java/uk/gov/register/core/ItemStore.java
+++ b/src/main/java/uk/gov/register/core/ItemStore.java
@@ -1,7 +1,5 @@
 package uk.gov.register.core;
 
-import org.skife.jdbi.v2.Handle;
-import uk.gov.register.db.ItemDAO;
 import uk.gov.register.store.BackingStoreDriver;
 
 import java.util.Collection;
@@ -14,8 +12,8 @@ public class ItemStore {
         this.backingStoreDriver = backingStoreDriver;
     }
 
-    public void putItems(Handle handle, Iterable<Item> items) {
-        handle.attach(ItemDAO.class).insertInBatch(items);
+    public void putItem(Item item) {
+        backingStoreDriver.insertItem(item);
     }
 
     public Optional<Item> getItemBySha256(String sha256hex) {

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -30,13 +30,12 @@ public class PostgresRegister implements Register {
 
     @Inject
     public PostgresRegister(RegisterNameConfiguration registerNameConfig,
-                            RecordIndex recordIndex,
                             DBI dbi,
                             BackingStoreDriver backingStoreDriver) {
         registerName = registerNameConfig.getRegister();
         this.entryLog = new EntryLog(backingStoreDriver);
         this.itemStore = new ItemStore(backingStoreDriver);
-        this.recordIndex = recordIndex;
+        this.recordIndex = new RecordIndex(backingStoreDriver);
         this.dbi = dbi;
     }
 
@@ -75,17 +74,17 @@ public class PostgresRegister implements Register {
 
     @Override
     public Optional<Record> getRecord(String key) {
-        return dbi.withHandle(h -> recordIndex.getRecord(h, key));
+        return recordIndex.getRecord(key);
     }
 
     @Override
     public Collection<Entry> allEntriesOfRecord(String key) {
-        return dbi.withHandle(h -> recordIndex.findAllEntriesOfRecordBy(h, registerName, key));
+        return recordIndex.findAllEntriesOfRecordBy(registerName, key);
     }
 
     @Override
     public List<Record> getRecords(int limit, int offset) {
-        return dbi.withHandle(h -> recordIndex.getRecords(h, limit, offset));
+        return recordIndex.getRecords(limit, offset);
     }
 
     @Override
@@ -100,7 +99,7 @@ public class PostgresRegister implements Register {
 
     @Override
     public int getTotalRecords() {
-        return dbi.withHandle(recordIndex::getTotalRecords);
+        return recordIndex.getTotalRecords();
     }
 
     @Override
@@ -110,7 +109,7 @@ public class PostgresRegister implements Register {
 
     @Override
     public List<Record> max100RecordsFacetedByKeyValue(String key, String value) {
-        return dbi.withHandle(h -> recordIndex.findMax100RecordsByKeyValue(h, key, value));
+        return recordIndex.findMax100RecordsByKeyValue(key, value);
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -2,6 +2,7 @@ package uk.gov.register.core;
 
 import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.db.RecordIndex;
+import uk.gov.register.exceptions.NoSuchItemException;
 import uk.gov.register.store.BackingStoreDriver;
 import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
@@ -38,7 +39,8 @@ public class PostgresRegister implements Register {
     @Override
     public void appendEntry(Entry entry) {
         entryLog.appendEntry(entry);
-        recordIndex.updateRecordIndex(registerName, new Record(entry, itemStore.getItemBySha256(entry.getSha256hex()).get()));
+        recordIndex.updateRecordIndex(registerName, new Record(entry, itemStore.getItemBySha256(entry.getSha256hex())
+                .orElseThrow(() -> new NoSuchItemException(entry.getSha256hex()))));
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -31,12 +31,11 @@ public class PostgresRegister implements Register {
     @Inject
     public PostgresRegister(RegisterNameConfiguration registerNameConfig,
                             RecordIndex recordIndex,
-                            ItemStore itemStore,
                             DBI dbi,
                             BackingStoreDriver backingStoreDriver) {
         registerName = registerNameConfig.getRegister();
         this.entryLog = new EntryLog(backingStoreDriver);
-        this.itemStore = itemStore;
+        this.itemStore = new ItemStore(backingStoreDriver);
         this.recordIndex = recordIndex;
         this.dbi = dbi;
     }
@@ -61,7 +60,7 @@ public class PostgresRegister implements Register {
 
     @Override
     public Optional<Item> getItemBySha256(String sha256hex) {
-        return dbi.withHandle(h -> itemStore.getItemBySha256(h, sha256hex));
+        return itemStore.getItemBySha256(sha256hex);
     }
 
     @Override
@@ -96,7 +95,7 @@ public class PostgresRegister implements Register {
 
     @Override
     public Collection<Item> getAllItems() {
-        return dbi.withHandle(itemStore::getAllItems);
+        return itemStore.getAllItems();
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/Register.java
+++ b/src/main/java/uk/gov/register/core/Register.java
@@ -4,5 +4,6 @@ import org.jvnet.hk2.annotations.Contract;
 
 @Contract
 public interface Register extends RegisterReadOnly {
-    void mintItems(Iterable<Item> items);
+    void putItem(Item item);
+    void appendEntry(Entry entry);
 }

--- a/src/main/java/uk/gov/register/db/EntryQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryQueryDAO.java
@@ -6,7 +6,6 @@ import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.customizers.FetchSize;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
-import org.skife.jdbi.v2.sqlobject.mixins.Transactional;
 import uk.gov.register.core.Entry;
 import uk.gov.register.db.mappers.EntryMapper;
 import uk.gov.register.db.mappers.LongTimestampToInstantMapper;
@@ -15,7 +14,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
 
-public interface EntryQueryDAO extends Transactional<EntryQueryDAO> {
+public interface EntryQueryDAO {
     @RegisterMapper(EntryMapper.class)
     @SingleValueResult(Entry.class)
     @SqlQuery("select * from entry where entry_number=:entryNumber")

--- a/src/main/java/uk/gov/register/db/RecordIndex.java
+++ b/src/main/java/uk/gov/register/db/RecordIndex.java
@@ -5,7 +5,6 @@ import uk.gov.register.core.Record;
 import uk.gov.register.store.BackingStoreDriver;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class RecordIndex {
     private final BackingStoreDriver backingStoreDriver;
@@ -36,15 +35,5 @@ public class RecordIndex {
 
     public Collection<Entry> findAllEntriesOfRecordBy(String registerName, String key) {
         return backingStoreDriver.findAllEntriesOfRecordBy(registerName, key);
-    }
-
-    private List<CurrentKey> extractCurrentKeys(String registerName, List<Record> records) {
-        Map<String, Integer> currentKeys = new HashMap<>();
-        records.forEach(r -> currentKeys.put(r.item.getKey(registerName), r.entry.getEntryNumber()));
-        return currentKeys
-                .entrySet()
-                .stream()
-                .map(e -> new CurrentKey(e.getKey(), e.getValue()))
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/register/db/RecordIndex.java
+++ b/src/main/java/uk/gov/register/db/RecordIndex.java
@@ -1,7 +1,5 @@
 package uk.gov.register.db;
 
-import com.google.common.collect.Lists;
-import org.skife.jdbi.v2.Handle;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Record;
 import uk.gov.register.store.BackingStoreDriver;
@@ -16,13 +14,8 @@ public class RecordIndex {
         this.backingStoreDriver = backingStoreDriver;
     }
 
-    public void updateRecordIndex(Handle handle, String registerName, List<Record> records) {
-        CurrentKeysUpdateDAO currentKeysUpdateDAO = handle.attach(CurrentKeysUpdateDAO.class);
-        List<CurrentKey> currentKeys = extractCurrentKeys(registerName, records);
-        int noOfRecordsDeleted = currentKeysUpdateDAO.removeRecordWithKeys(Lists.transform(currentKeys, r -> r.key));
-
-        currentKeysUpdateDAO.writeCurrentKeys(currentKeys);
-        currentKeysUpdateDAO.updateTotalRecords(currentKeys.size() - noOfRecordsDeleted);
+    public void updateRecordIndex(String registerName, Record record) {
+        backingStoreDriver.insertRecord(record, registerName);
     }
 
     public Optional<Record> getRecord(String key) {

--- a/src/main/java/uk/gov/register/db/RecordIndex.java
+++ b/src/main/java/uk/gov/register/db/RecordIndex.java
@@ -4,11 +4,18 @@ import com.google.common.collect.Lists;
 import org.skife.jdbi.v2.Handle;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Record;
+import uk.gov.register.store.BackingStoreDriver;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class RecordIndex {
+    private final BackingStoreDriver backingStoreDriver;
+
+    public RecordIndex(BackingStoreDriver backingStoreDriver) {
+        this.backingStoreDriver = backingStoreDriver;
+    }
+
     public void updateRecordIndex(Handle handle, String registerName, List<Record> records) {
         CurrentKeysUpdateDAO currentKeysUpdateDAO = handle.attach(CurrentKeysUpdateDAO.class);
         List<CurrentKey> currentKeys = extractCurrentKeys(registerName, records);
@@ -18,24 +25,24 @@ public class RecordIndex {
         currentKeysUpdateDAO.updateTotalRecords(currentKeys.size() - noOfRecordsDeleted);
     }
 
-    public Optional<Record> getRecord(Handle h, String key) {
-        return h.attach(RecordQueryDAO.class).findByPrimaryKey(key);
+    public Optional<Record> getRecord(String key) {
+        return backingStoreDriver.getRecord(key);
     }
 
-    public int getTotalRecords(Handle h) {
-        return h.attach(RecordQueryDAO.class).getTotalRecords();
+    public int getTotalRecords() {
+        return backingStoreDriver.getTotalRecords();
     }
 
-    public List<Record> getRecords(Handle h, int limit, int offset) {
-        return h.attach(RecordQueryDAO.class).getRecords(limit, offset);
+    public List<Record> getRecords(int limit, int offset) {
+        return backingStoreDriver.getRecords(limit, offset);
     }
 
-    public List<Record> findMax100RecordsByKeyValue(Handle h, String key, String value) {
-        return h.attach(RecordQueryDAO.class).findMax100RecordsByKeyValue(key, value);
+    public List<Record> findMax100RecordsByKeyValue(String key, String value) {
+        return backingStoreDriver.findMax100RecordsByKeyValue(key, value);
     }
 
-    public Collection<Entry> findAllEntriesOfRecordBy(Handle h, String registerName, String key) {
-        return h.attach(RecordQueryDAO.class).findAllEntriesOfRecordBy(registerName, key);
+    public Collection<Entry> findAllEntriesOfRecordBy(String registerName, String key) {
+        return backingStoreDriver.findAllEntriesOfRecordBy(registerName, key);
     }
 
     private List<CurrentKey> extractCurrentKeys(String registerName, List<Record> records) {

--- a/src/main/java/uk/gov/register/exceptions/NoSuchItemException.java
+++ b/src/main/java/uk/gov/register/exceptions/NoSuchItemException.java
@@ -1,0 +1,14 @@
+package uk.gov.register.exceptions;
+
+public class NoSuchItemException extends RuntimeException {
+    private final String sha256hex;
+
+    public NoSuchItemException(String sha256hex) {
+        super("No item found with sha256hex " + sha256hex);
+        this.sha256hex = sha256hex;
+    }
+
+    public String getSha256Hex() {
+        return sha256hex;
+    }
+}

--- a/src/main/java/uk/gov/register/service/RegisterService.java
+++ b/src/main/java/uk/gov/register/service/RegisterService.java
@@ -1,0 +1,31 @@
+package uk.gov.register.service;
+
+import org.skife.jdbi.v2.DBI;
+import uk.gov.register.configuration.RegisterNameConfiguration;
+import uk.gov.register.core.PostgresRegister;
+import uk.gov.register.core.Register;
+import uk.gov.register.store.postgres.PostgresDriverTransactional;
+import uk.gov.verifiablelog.store.memoization.MemoizationStore;
+
+import javax.inject.Inject;
+import java.util.function.Consumer;
+
+public class RegisterService {
+    private final RegisterNameConfiguration registerNameConfig;
+    private final DBI dbi;
+    private final MemoizationStore memoizationStore;
+
+    @Inject
+    public RegisterService(RegisterNameConfiguration registerNameConfig, DBI dbi, MemoizationStore memoizationStore) {
+        this.registerNameConfig = registerNameConfig;
+        this.dbi = dbi;
+        this.memoizationStore = memoizationStore;
+    }
+
+    public void asAtomicRegisterOperation(Consumer<Register> callback) {
+        PostgresDriverTransactional.useTransaction(dbi, memoizationStore, postgresDriver -> {
+            Register register = new PostgresRegister(registerNameConfig, postgresDriver);
+            callback.accept(register);
+        });
+    }
+}

--- a/src/main/java/uk/gov/register/store/BackingStoreDriver.java
+++ b/src/main/java/uk/gov/register/store/BackingStoreDriver.java
@@ -1,13 +1,11 @@
 package uk.gov.register.store;
 
+import com.google.common.base.Function;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
-import uk.gov.register.views.ConsistencyProof;
-import uk.gov.register.views.EntryProof;
-import uk.gov.register.views.RegisterProof;
+import uk.gov.verifiablelog.VerifiableLog;
 
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -34,7 +32,5 @@ public interface BackingStoreDriver {
     List<Record> findMax100RecordsByKeyValue(String key, String value);
     Collection<Entry> findAllEntriesOfRecordBy(String registerName, String key);
 
-    RegisterProof getRegisterProof() throws NoSuchAlgorithmException;
-    EntryProof getEntryProof(int entryNumber, int totalEntries);
-    ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2);
+    <ReturnType> ReturnType withVerifiableLog(Function<VerifiableLog, ReturnType> callback);
 }

--- a/src/main/java/uk/gov/register/store/BackingStoreDriver.java
+++ b/src/main/java/uk/gov/register/store/BackingStoreDriver.java
@@ -1,0 +1,40 @@
+package uk.gov.register.store;
+
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.Item;
+import uk.gov.register.core.Record;
+import uk.gov.register.views.ConsistencyProof;
+import uk.gov.register.views.EntryProof;
+import uk.gov.register.views.RegisterProof;
+
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface BackingStoreDriver {
+
+    void insertEntry(Entry entry);
+    void insertItem(Item item);
+    void insertRecord(Record record, String registerName);
+
+    Optional<Entry> getEntry(int entryNumber);
+    Collection<Entry> getEntries(int start, int limit);
+    Collection<Entry> getAllEntries();
+    int getTotalEntries();
+    Optional<Instant> getLastUpdatedTime();
+
+    Optional<Item> getItemBySha256(String sha256hex);
+    Collection<Item> getAllItems();
+
+    Optional<Record> getRecord(String key);
+    int getTotalRecords();
+    List<Record> getRecords(int limit, int offset);
+    List<Record> findMax100RecordsByKeyValue(String key, String value);
+    Collection<Entry> findAllEntriesOfRecordBy(String registerName, String key);
+
+    RegisterProof getRegisterProof() throws NoSuchAlgorithmException;
+    EntryProof getEntryProof(int entryNumber, int totalEntries);
+    ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2);
+}

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
@@ -105,7 +105,7 @@ public abstract class PostgresDriver implements BackingStoreDriver {
 
     @Override
     public RegisterProof getRegisterProof() throws NoSuchAlgorithmException {
-        return inTransaction((handle, status) -> {
+        return inTransaction(handle -> {
             VerifiableLog verifiableLog = getVerifiableLog(handle);
             String rootHash = bytesToString(verifiableLog.currentRoot());
             return new RegisterProof(rootHash);
@@ -114,7 +114,7 @@ public abstract class PostgresDriver implements BackingStoreDriver {
 
     @Override
     public EntryProof getEntryProof(int entryNumber, int totalEntries) {
-        return inTransaction((handle, status) -> {
+        return inTransaction(handle -> {
             VerifiableLog verifiableLog = getVerifiableLog(handle);
 
             List<String> auditProof = verifiableLog.auditProof(entryNumber, totalEntries).stream()
@@ -126,7 +126,7 @@ public abstract class PostgresDriver implements BackingStoreDriver {
 
     @Override
     public ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2) {
-        return inTransaction((handle, status) -> {
+        return inTransaction(handle -> {
             VerifiableLog verifiableLog = getVerifiableLog(handle);
             List<String> consistencyProof = verifiableLog.consistencyProof(totalEntries1, totalEntries2).stream()
                     .map(this::bytesToString).collect(Collectors.toList());
@@ -170,5 +170,5 @@ public abstract class PostgresDriver implements BackingStoreDriver {
 
     protected abstract <ReturnType> ReturnType withHandle(HandleCallback<ReturnType> callback);
 
-    protected abstract <ReturnType> ReturnType inTransaction(TransactionCallback<ReturnType> callback);
+    protected abstract <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback);
 }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.TransactionCallback;
 import org.skife.jdbi.v2.tweak.HandleCallback;
 import org.skife.jdbi.v2.tweak.HandleConsumer;
 import uk.gov.register.core.Entry;

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
@@ -1,0 +1,174 @@
+package uk.gov.register.store.postgres;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.TransactionCallback;
+import org.skife.jdbi.v2.tweak.HandleCallback;
+import org.skife.jdbi.v2.tweak.HandleConsumer;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.Item;
+import uk.gov.register.core.Record;
+import uk.gov.register.db.*;
+import uk.gov.register.store.BackingStoreDriver;
+import uk.gov.register.views.ConsistencyProof;
+import uk.gov.register.views.EntryProof;
+import uk.gov.register.views.RegisterProof;
+import uk.gov.verifiablelog.VerifiableLog;
+import uk.gov.verifiablelog.store.memoization.MemoizationStore;
+
+import javax.xml.bind.DatatypeConverter;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public abstract class PostgresDriver implements BackingStoreDriver {
+
+    protected final MemoizationStore memoizationStore;
+
+    public PostgresDriver(MemoizationStore memoizationStore) {
+        this.memoizationStore = memoizationStore;
+    }
+
+    @Override
+    public abstract void insertEntry(Entry entry);
+
+    @Override
+    public abstract void insertItem(Item item);
+
+    @Override
+    public abstract void insertRecord(Record record, String registerName);
+
+    @Override
+    public Optional<Entry> getEntry(int entryNumber) {
+        return withHandle(handle -> handle.attach(EntryQueryDAO.class).findByEntryNumber(entryNumber));
+    }
+
+    @Override
+    public Collection<Entry> getEntries(int start, int limit) {
+        return withHandle(handle -> handle.attach(EntryQueryDAO.class).getEntries(start, limit));
+    }
+
+    @Override
+    public Collection<Entry> getAllEntries() {
+        return withHandle(handle -> handle.attach(EntryQueryDAO.class).getAllEntriesNoPagination());
+    }
+
+    @Override
+    public int getTotalEntries() {
+        return withHandle(handle -> handle.attach(EntryQueryDAO.class).getTotalEntries());
+    }
+
+    @Override
+    public Optional<Instant> getLastUpdatedTime() {
+        return withHandle(handle -> handle.attach(EntryQueryDAO.class).getLastUpdatedTime());
+    }
+
+    @Override
+    public Optional<Item> getItemBySha256(String sha256hex) {
+        return withHandle(handle -> handle.attach(ItemQueryDAO.class).getItemBySHA256(sha256hex));
+    }
+
+    @Override
+    public Collection<Item> getAllItems() {
+        return withHandle(handle -> handle.attach(ItemQueryDAO.class).getAllItemsNoPagination());
+    }
+
+    @Override
+    public Optional<Record> getRecord(String key) {
+        return withHandle(handle -> handle.attach(RecordQueryDAO.class).findByPrimaryKey(key));
+    }
+
+    @Override
+    public int getTotalRecords() {
+        return withHandle(handle -> handle.attach(RecordQueryDAO.class).getTotalRecords());
+    }
+
+    @Override
+    public List<Record> getRecords(int limit, int offset) {
+        return withHandle(handle -> handle.attach(RecordQueryDAO.class).getRecords(limit, offset));
+    }
+
+    @Override
+    public List<Record> findMax100RecordsByKeyValue(String key, String value) {
+        return withHandle(handle -> handle.attach(RecordQueryDAO.class).findMax100RecordsByKeyValue(key, value));
+    }
+
+    @Override
+    public Collection<Entry> findAllEntriesOfRecordBy(String registerName, String key) {
+        return withHandle(handle -> handle.attach(RecordQueryDAO.class).findAllEntriesOfRecordBy(registerName, key));
+    }
+
+    @Override
+    public RegisterProof getRegisterProof() throws NoSuchAlgorithmException {
+        return inTransaction((handle, status) -> {
+            VerifiableLog verifiableLog = getVerifiableLog(handle);
+            String rootHash = bytesToString(verifiableLog.currentRoot());
+            return new RegisterProof(rootHash);
+        });
+    }
+
+    @Override
+    public EntryProof getEntryProof(int entryNumber, int totalEntries) {
+        return inTransaction((handle, status) -> {
+            VerifiableLog verifiableLog = getVerifiableLog(handle);
+
+            List<String> auditProof = verifiableLog.auditProof(entryNumber, totalEntries).stream()
+                    .map(this::bytesToString).collect(Collectors.toList());
+
+            return new EntryProof(Integer.toString(entryNumber), auditProof);
+        });
+    }
+
+    @Override
+    public ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2) {
+        return inTransaction((handle, status) -> {
+            VerifiableLog verifiableLog = getVerifiableLog(handle);
+            List<String> consistencyProof = verifiableLog.consistencyProof(totalEntries1, totalEntries2).stream()
+                    .map(this::bytesToString).collect(Collectors.toList());
+
+            return new ConsistencyProof(consistencyProof);
+        });
+    }
+
+    protected void insertEntries(Iterable<Entry> entries) {
+        useHandle(handle -> {
+            EntryDAO entryDAO = handle.attach(EntryDAO.class);
+            entryDAO.insertInBatch(entries);
+            entryDAO.setEntryNumber(entryDAO.currentEntryNumber() + Iterables.size(entries));
+        });
+    }
+
+    protected void insertItems(Iterable<Item> items) {
+        useHandle(handle -> handle.attach(ItemDAO.class).insertInBatch(items));
+    }
+
+    protected void insertCurrentKeys(List<CurrentKey> currentKeys) {
+        useHandle(handle -> {
+            CurrentKeysUpdateDAO currentKeysUpdateDAO = handle.attach(CurrentKeysUpdateDAO.class);
+
+            int noOfRecordsDeleted = currentKeysUpdateDAO.removeRecordWithKeys(Lists.transform(currentKeys, r -> r.getKey()));
+            currentKeysUpdateDAO.writeCurrentKeys(currentKeys);
+            currentKeysUpdateDAO.updateTotalRecords(currentKeys.size() - noOfRecordsDeleted);
+        });
+    }
+
+    private VerifiableLog getVerifiableLog(Handle handle) {
+        EntryMerkleLeafStore merkleLeafStore = new EntryMerkleLeafStore(handle.attach(EntryQueryDAO.class));
+        return new VerifiableLog(DigestUtils.getSha256Digest(), merkleLeafStore, memoizationStore);
+    }
+
+    private String bytesToString(byte[] bytes) {
+        return DatatypeConverter.printHexBinary(bytes).toLowerCase();
+    }
+
+    protected abstract void useHandle(HandleConsumer callback);
+
+    protected abstract <ReturnType> ReturnType withHandle(HandleCallback<ReturnType> callback);
+
+    protected abstract <ReturnType> ReturnType inTransaction(TransactionCallback<ReturnType> callback);
+}

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
@@ -49,7 +49,7 @@ public class PostgresDriverNonTransactional extends PostgresDriver {
     }
 
     @Override
-    protected <ReturnType> ReturnType inTransaction(TransactionCallback<ReturnType> callback) {
-        return dbi.inTransaction(callback);
+    protected <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback) {
+        return dbi.inTransaction((handle, status) -> callback.withHandle(handle));
     }
 }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
@@ -14,7 +14,6 @@ import javax.inject.Inject;
 import java.util.Arrays;
 
 public class PostgresDriverNonTransactional extends PostgresDriver {
-
     private DBI dbi;
 
     @Inject

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
@@ -1,0 +1,55 @@
+package uk.gov.register.store.postgres;
+
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.TransactionCallback;
+import org.skife.jdbi.v2.tweak.HandleCallback;
+import org.skife.jdbi.v2.tweak.HandleConsumer;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.Item;
+import uk.gov.register.core.Record;
+import uk.gov.register.db.CurrentKey;
+import uk.gov.verifiablelog.store.memoization.MemoizationStore;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+
+public class PostgresDriverNonTransactional extends PostgresDriver {
+
+    private DBI dbi;
+
+    @Inject
+    public PostgresDriverNonTransactional(DBI dbi, MemoizationStore memoizationStore) {
+        super(memoizationStore);
+        this.dbi = dbi;
+    }
+
+    @Override
+    public void insertEntry(Entry entry) {
+        super.insertEntries(Arrays.asList(entry));
+    }
+
+    @Override
+    public void insertItem(Item item) {
+        super.insertItems(Arrays.asList(item));
+    }
+
+    @Override
+    public void insertRecord(Record record, String registerName) {
+        super.insertCurrentKeys(Arrays.asList(new CurrentKey(record.item.getKey(registerName), record.entry.getEntryNumber())));
+    }
+
+    @Override
+    protected void useHandle(HandleConsumer callback) {
+        dbi.useHandle(callback);
+    }
+
+    @Override
+    protected <ReturnType> ReturnType withHandle(HandleCallback<ReturnType> callback) {
+        return dbi.withHandle(callback);
+    }
+
+    @Override
+    protected <ReturnType> ReturnType inTransaction(TransactionCallback<ReturnType> callback) {
+        return dbi.inTransaction(callback);
+    }
+}

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
@@ -1,13 +1,14 @@
 package uk.gov.register.store.postgres;
 
+import com.google.common.base.Function;
 import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.TransactionCallback;
+import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.tweak.HandleCallback;
 import org.skife.jdbi.v2.tweak.HandleConsumer;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
-import uk.gov.register.db.CurrentKey;
+import uk.gov.register.db.*;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import javax.inject.Inject;
@@ -19,6 +20,14 @@ public class PostgresDriverNonTransactional extends PostgresDriver {
     @Inject
     public PostgresDriverNonTransactional(DBI dbi, MemoizationStore memoizationStore) {
         super(memoizationStore);
+        this.dbi = dbi;
+    }
+
+    protected PostgresDriverNonTransactional(DBI dbi, MemoizationStore memoizationStore,
+                                             Function<Handle, EntryQueryDAO> entryQueryDAO, Function<Handle, EntryDAO> entryDAO,
+                                             Function<Handle, ItemQueryDAO> itemQueryDAO, Function<Handle, ItemDAO> itemDAO,
+                                             Function<Handle, RecordQueryDAO> recordQueryDAO, Function<Handle, CurrentKeysUpdateDAO> currentKeysUpdateDAO) {
+        super(entryQueryDAO, entryDAO, itemQueryDAO, itemDAO,  recordQueryDAO, currentKeysUpdateDAO, memoizationStore);
         this.dbi = dbi;
     }
 

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
@@ -28,7 +28,7 @@ public class PostgresDriverTransactional extends PostgresDriver {
 
         this.handle = handle;
         this.stagedEntries = new ArrayList<>();
-        this.stagedItems = new HashSet<>();
+        this.stagedItems = new LinkedHashSet<>();
         this.stagedCurrentKeys = new HashMap<>();
     }
 

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
@@ -1,0 +1,124 @@
+package uk.gov.register.store.postgres;
+
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.TransactionIsolationLevel;
+import org.skife.jdbi.v2.exceptions.CallbackFailedException;
+import org.skife.jdbi.v2.tweak.HandleCallback;
+import org.skife.jdbi.v2.tweak.HandleConsumer;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.Item;
+import uk.gov.register.core.Record;
+import uk.gov.register.db.CurrentKey;
+import uk.gov.verifiablelog.store.memoization.MemoizationStore;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class PostgresDriverTransactional extends PostgresDriver {
+    private final Handle handle;
+
+    private final List<Entry> stagedEntries;
+    private final Set<Item> stagedItems;
+    private final HashMap<String, Integer> stagedCurrentKeys;
+
+    private PostgresDriverTransactional(Handle handle, MemoizationStore memoizationStore) {
+        super(memoizationStore);
+
+        this.handle = handle;
+        this.stagedEntries = new ArrayList<>();
+        this.stagedItems = new HashSet<>();
+        this.stagedCurrentKeys = new HashMap<>();
+    }
+
+    public static void useTransaction(DBI dbi, MemoizationStore memoizationStore, Consumer<PostgresDriverTransactional> callback) {
+        dbi.useTransaction(TransactionIsolationLevel.SERIALIZABLE, (handle, status) -> {
+            callback.accept(new PostgresDriverTransactional(handle, memoizationStore));
+            callback.andThen(pd -> pd.writeStagedData());
+        });
+    }
+
+    @Override
+    public void insertEntry(Entry entry) {
+        stagedEntries.add(entry);
+    }
+
+    @Override
+    public void insertItem(Item item) {
+        stagedItems.add(item);
+    }
+
+    @Override
+    public void insertRecord(Record record, String registerName) {
+        stagedCurrentKeys.put(record.item.getKey(registerName), record.entry.getEntryNumber());
+    }
+
+    @Override
+    protected void useHandle(HandleConsumer callback) {
+        useExistingHandle(callback);
+    }
+
+    @Override
+    protected <ReturnType> ReturnType withHandle(HandleCallback<ReturnType> callback) {
+        return useExistingHandle(callback);
+    }
+
+    @Override
+    protected <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback) {
+        return useExistingHandle(callback);
+    }
+
+    private void useExistingHandle(HandleConsumer callback) {
+        try {
+            writeStagedData();
+            callback.useHandle(handle);
+        } catch (Exception ex) {
+            throw new CallbackFailedException(ex);
+        }
+    }
+
+    private <ReturnType> ReturnType useExistingHandle(HandleCallback<ReturnType> callback) {
+        try {
+            writeStagedData();
+            return callback.withHandle(handle);
+        } catch (Exception ex) {
+            throw new CallbackFailedException(ex);
+        }
+    }
+
+    private void writeStagedData() {
+        writeEntries();
+        writeItems();
+        writeCurrentKeys();
+    }
+
+    private void writeEntries() {
+        if (stagedEntries.isEmpty()) {
+            return;
+        }
+        super.insertEntries(stagedEntries);
+        stagedEntries.clear();
+    }
+
+    private void writeItems() {
+        if (stagedItems.isEmpty()) {
+            return;
+        }
+        super.insertItems(stagedItems);
+        stagedItems.clear();
+    }
+
+    private void writeCurrentKeys() {
+        if (stagedCurrentKeys.isEmpty()) {
+            return;
+        }
+
+        List<CurrentKey> currentKeysToWrite = stagedCurrentKeys.entrySet().stream()
+                .map(ck -> new CurrentKey(ck.getKey(), ck.getValue()))
+                .collect(Collectors.toList());
+
+        super.insertCurrentKeys(currentKeysToWrite);
+        stagedCurrentKeys.clear();
+    }
+}

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
@@ -56,6 +56,12 @@ public class PostgresDriverTransactional extends PostgresDriver {
     }
 
     @Override
+    public Optional<Item> getItemBySha256(String sha256hex) {
+        Optional<Item> stagedItem = searchStagingForItem(sha256hex);
+        return stagedItem.isPresent() ? stagedItem : super.getItemBySha256(sha256hex);
+    }
+
+    @Override
     protected void useHandle(HandleConsumer callback) {
         useExistingHandle(callback);
     }
@@ -120,5 +126,9 @@ public class PostgresDriverTransactional extends PostgresDriver {
 
         super.insertCurrentKeys(currentKeysToWrite);
         stagedCurrentKeys.clear();
+    }
+
+    private Optional<Item> searchStagingForItem(String sha256hex) {
+        return stagedItems.stream().filter(item -> item.getSha256hex().equals(sha256hex)).findFirst();
     }
 }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
@@ -1,5 +1,6 @@
 package uk.gov.register.store.postgres;
 
+import com.google.common.base.Function;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.TransactionIsolationLevel;
@@ -9,7 +10,7 @@ import org.skife.jdbi.v2.tweak.HandleConsumer;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
-import uk.gov.register.db.CurrentKey;
+import uk.gov.register.db.*;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import java.util.*;
@@ -25,6 +26,18 @@ public class PostgresDriverTransactional extends PostgresDriver {
 
     private PostgresDriverTransactional(Handle handle, MemoizationStore memoizationStore) {
         super(memoizationStore);
+
+        this.handle = handle;
+        this.stagedEntries = new ArrayList<>();
+        this.stagedItems = new LinkedHashSet<>();
+        this.stagedCurrentKeys = new HashMap<>();
+    }
+
+    protected PostgresDriverTransactional(Handle handle, MemoizationStore memoizationStore,
+                                          Function<Handle, EntryQueryDAO> entryQueryDAO, Function<Handle, EntryDAO> entryDAO,
+                                          Function<Handle, ItemQueryDAO> itemQueryDAO, Function<Handle, ItemDAO> itemDAO,
+                                          Function<Handle, RecordQueryDAO> recordQueryDAO, Function<Handle, CurrentKeysUpdateDAO> currentKeysUpdateDAO) {
+        super(entryQueryDAO, entryDAO, itemQueryDAO, itemDAO,  recordQueryDAO, currentKeysUpdateDAO, memoizationStore);
 
         this.handle = handle;
         this.stagedEntries = new ArrayList<>();

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresDriverTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresDriverTransactionalFunctionalTest.java
@@ -1,0 +1,114 @@
+package uk.gov.register.functional.store.postgres;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.Item;
+import uk.gov.register.functional.app.WipeDatabaseRule;
+import uk.gov.register.functional.db.TestDBSupport;
+import uk.gov.register.store.postgres.PostgresDriverTransactional;
+import uk.gov.verifiablelog.store.memoization.DoNothing;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+
+public class PostgresDriverTransactionalFunctionalTest extends TestDBSupport {
+
+    @Rule
+    public TestRule wipe = new WipeDatabaseRule();
+
+    @Test
+    public void useTransactionShouldApplyChangesAtomicallyToDatabase() {
+        DBI dbi = new DBI(postgresConnectionString);
+
+        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode());
+        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode());
+        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode());
+        Entry entry1 = new Entry(1, "itemhash1", Instant.now());
+        Entry entry2 = new Entry(2, "itemhash2", Instant.now());
+        Entry entry3 = new Entry(3, "itemhash3", Instant.now());
+
+        PostgresDriverTransactional.useTransaction(dbi, new DoNothing(), postgresDriver -> {
+            postgresDriver.insertItem(item1);
+            postgresDriver.insertEntry(entry1);
+
+            assertThat(postgresDriver.getAllEntries().size(), is(1));
+            assertThat(postgresDriver.getAllItems().size(), is(1));
+            assertThat(testEntryDAO.getAllEntries(), is(empty()));
+            assertThat(testItemDAO.getItems(), is(empty()));
+
+            postgresDriver.insertItem(item2);
+            postgresDriver.insertEntry(entry2);
+
+            assertThat(postgresDriver.getAllEntries().size(), is(2));
+            assertThat(postgresDriver.getAllItems().size(), is(2));
+            assertThat(testEntryDAO.getAllEntries(), is(empty()));
+            assertThat(testItemDAO.getItems(), is(empty()));
+
+            postgresDriver.insertItem(item3);
+            postgresDriver.insertEntry(entry3);
+
+            assertThat(postgresDriver.getAllEntries().size(), is(3));
+            assertThat(postgresDriver.getAllItems().size(), is(3));
+            assertThat(testEntryDAO.getAllEntries(), is(empty()));
+            assertThat(testItemDAO.getItems(), is(empty()));
+        });
+
+        assertThat(testEntryDAO.getAllEntries().size(), is(3));
+        assertThat(testItemDAO.getItems().size(), is(3));
+    }
+
+    @Test
+    public void useTransactionShouldRollbackIfExceptionThrown() {
+        DBI dbi = new DBI(postgresConnectionString);
+
+        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode());
+        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode());
+        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode());
+        Entry entry1 = new Entry(1, "itemhash1", Instant.now());
+        Entry entry2 = new Entry(2, "itemhash2", Instant.now());
+        Entry entry3 = new Entry(3, "itemhash3", Instant.now());
+
+        try {
+            PostgresDriverTransactional.useTransaction(dbi, new DoNothing(), postgresDriver -> {
+                postgresDriver.insertItem(item1);
+                postgresDriver.insertEntry(entry1);
+
+                assertThat(postgresDriver.getAllEntries().size(), is(1));
+                assertThat(postgresDriver.getAllItems().size(), is(1));
+                assertThat(testEntryDAO.getAllEntries(), is(empty()));
+                assertThat(testItemDAO.getItems(), is(empty()));
+
+                postgresDriver.insertItem(item2);
+                postgresDriver.insertEntry(entry2);
+
+                assertThat(postgresDriver.getAllEntries().size(), is(2));
+                assertThat(postgresDriver.getAllItems().size(), is(2));
+                assertThat(testEntryDAO.getAllEntries(), is(empty()));
+                assertThat(testItemDAO.getItems(), is(empty()));
+
+                postgresDriver.insertItem(item3);
+                postgresDriver.insertEntry(entry3);
+
+                assertThat(postgresDriver.getAllEntries().size(), is(3));
+                assertThat(postgresDriver.getAllItems().size(), is(3));
+                assertThat(testEntryDAO.getAllEntries(), is(empty()));
+                assertThat(testItemDAO.getItems(), is(empty()));
+
+                throw new RuntimeException();
+            });
+        } catch (RuntimeException ex) {
+            // intentionally thrown
+        }
+
+        assertThat(testEntryDAO.getAllEntries().size(), is(0));
+        assertThat(testItemDAO.getItems().size(), is(0));
+    }
+}
+

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDriverNonTransactionalTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDriverNonTransactionalTest.java
@@ -1,0 +1,74 @@
+package uk.gov.register.store.postgres;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.Item;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.Is.is;
+
+public class PostgresDriverNonTransactionalTest extends PostgresDriverTestBase {
+
+    @Test
+    public void insertItemShouldCommitItemImmediatelyInOrder() throws Exception {
+        PostgresDriverNonTransactional postgresDriver = new PostgresDriverNonTransactional(
+                dbi, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
+
+        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode());
+        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode());
+        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode());
+        Item item4 = new Item("itemhash4", new ObjectMapper().createObjectNode());
+
+        postgresDriver.insertItem(item1);
+        postgresDriver.insertItem(item2);
+        assertThat(items.size(), is(2));
+        assertThat(items, contains(item1, item2));
+
+        postgresDriver.insertItem(item3);
+        postgresDriver.insertItem(item4);
+        assertThat(items.size(), is(4));
+        assertThat(items, contains(item1, item2, item3, item4));
+    }
+
+    @Test
+    public void insertEntryShouldCommitEntryImmediatelyInOrder() throws Exception {
+        PostgresDriverNonTransactional postgresDriver = new PostgresDriverNonTransactional(
+                dbi, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
+
+        Entry entry1 = new Entry(1, "itemhash1", Instant.now());
+        Entry entry2 = new Entry(2, "itemhash2", Instant.now());
+        Entry entry3 = new Entry(3, "itemhash3", Instant.now());
+
+        postgresDriver.insertEntry(entry1);
+        assertThat(entries.size(), is(1));
+        assertThat(entries, contains(entry1));
+
+        postgresDriver.insertEntry(entry2);
+        postgresDriver.insertEntry(entry3);
+        assertThat(entries.size(), is(3));
+        assertThat(entries, contains(entry1, entry2, entry3));
+    }
+
+    @Test
+    public void insertRecordShouldCommitRecordImmediatelyInOrder() throws Exception {
+        PostgresDriverNonTransactional postgresDriver = new PostgresDriverNonTransactional(
+                dbi, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
+
+        postgresDriver.insertRecord(mockRecord("country", "DE", 1), "country");
+        assertThat(currentKeys.size(), is(1));
+        assertThat(currentKeys.get(0).getKey(), is("DE"));
+        assertThat(currentKeys.get(0).getEntry_number(), is(1));
+
+        postgresDriver.insertRecord(mockRecord("country", "VA", 2), "country");
+        postgresDriver.insertRecord(mockRecord("country", "DE", 3), "country");
+        assertThat(currentKeys.size(), is(2));
+        assertThat(currentKeys.get(0).getKey(), is("VA"));
+        assertThat(currentKeys.get(0).getEntry_number(), is(2));
+        assertThat(currentKeys.get(1).getKey(), is("DE"));
+        assertThat(currentKeys.get(1).getEntry_number(), is(3));
+    }
+}

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDriverTestBase.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDriverTestBase.java
@@ -1,0 +1,112 @@
+package uk.gov.register.store.postgres;
+
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.tweak.HandleConsumer;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.Item;
+import uk.gov.register.core.Record;
+import uk.gov.register.db.*;
+import uk.gov.verifiablelog.store.memoization.MemoizationStore;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+
+public class PostgresDriverTestBase {
+
+    protected List<Entry> entries;
+    protected List<Item> items;
+    protected List<CurrentKey> currentKeys;
+
+    protected EntryQueryDAO entryQueryDAO;
+    protected EntryDAO entryDAO;
+    protected ItemQueryDAO itemQueryDAO;
+    protected ItemDAO itemDAO;
+    protected RecordQueryDAO recordQueryDAO;
+    protected CurrentKeysUpdateDAO currentKeysUpdateDAO;
+
+    protected DBI dbi;
+    protected Handle handle;
+    protected MemoizationStore memoizationStore;
+
+    @Before
+    public void setup() {
+        entries = new ArrayList<>();
+        items = new ArrayList<>();
+        currentKeys = new ArrayList<>();
+
+        entryQueryDAO = mock(EntryQueryDAO.class);
+        entryDAO = mock(EntryDAO.class);
+        itemQueryDAO = mock(ItemQueryDAO.class);
+        itemDAO = mock(ItemDAO.class);
+        recordQueryDAO = mock(RecordQueryDAO.class);
+        currentKeysUpdateDAO = mock(CurrentKeysUpdateDAO.class);
+
+        dbi = mock(DBI.class);
+        handle = mock(Handle.class);
+        memoizationStore = mock(MemoizationStore.class);
+
+        mockDBI();
+        mockEntryDAOInsert();
+        mockItemDAOInsert();
+        mockCurrentKeysUpdateDAOInsert();
+    }
+
+    protected Record mockRecord(String registerName, String key, Integer entryNumber) {
+        Entry entry = mock(Entry.class);
+        Item item = mock(Item.class);
+        when(entry.getEntryNumber()).thenReturn(entryNumber);
+        when(item.getKey(registerName)).thenReturn(key);
+        return new Record(entry, item);
+    }
+
+    private void mockDBI() {
+        ArgumentCaptor<HandleConsumer> argumentCaptor = ArgumentCaptor.forClass(HandleConsumer.class);
+        doAnswer(invocation -> {
+            argumentCaptor.getValue().useHandle(handle);
+            return null;
+        }).when(dbi).useHandle(argumentCaptor.capture());
+    }
+
+    private void mockEntryDAOInsert() {
+        ArgumentCaptor<Collection> argumentCaptor = ArgumentCaptor.forClass(Collection.class);
+        doAnswer(invocation -> {
+            entries.addAll(argumentCaptor.getValue());
+            return null;
+        }).when(entryDAO).insertInBatch(argumentCaptor.capture());
+    }
+
+    private void mockItemDAOInsert() {
+        ArgumentCaptor<Collection> argumentCaptor = ArgumentCaptor.forClass(Collection.class);
+        doAnswer(invocation -> {
+            items.addAll(argumentCaptor.getValue());
+            return null;
+        }).when(itemDAO).insertInBatch(argumentCaptor.capture());
+    }
+
+    private void mockCurrentKeysUpdateDAOInsert() {
+        ArgumentCaptor<Collection> argumentCaptor = ArgumentCaptor.forClass(Collection.class);
+
+        doAnswer(invocation -> {
+            currentKeys.addAll(argumentCaptor.getValue());
+            return null;
+        }).when(currentKeysUpdateDAO).writeCurrentKeys(argumentCaptor.capture());
+
+        doAnswer(invocation -> {
+            argumentCaptor.getValue().forEach(keyToRemove -> {
+                Optional<CurrentKey> currentKeyToRemove = currentKeys.stream().filter(ck -> ck.getKey().equals(keyToRemove)).findFirst();
+                if (currentKeyToRemove.isPresent()){
+                    currentKeys.remove(currentKeyToRemove.get());
+                }
+            });
+            return null;
+        }).when(currentKeysUpdateDAO).removeRecordWithKeys(argumentCaptor.capture());
+    }
+}

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
@@ -11,10 +11,13 @@ import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
 import uk.gov.register.db.*;
+import uk.gov.register.views.RegisterProof;
+import uk.gov.verifiablelog.VerifiableLog;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -140,6 +143,13 @@ public class PostgresDriverTransactionalTest {
     public void findAllEntriesOfRecordByShouldAlwaysCommitStagedData() {
         when(recordQueryDAO.findAllEntriesOfRecordBy("country", "DE")).thenReturn(asList());
         assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.findAllEntriesOfRecordBy("country", "DE"));
+    }
+
+    @Test
+    public void withVerifiableLogShouldAlwaysCommitStagedData() {
+        Function<VerifiableLog, RegisterProof> func = mock(Function.class);
+        when(func.apply(mock(VerifiableLog.class))).thenReturn(mock(RegisterProof.class));
+        assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.withVerifiableLog(verifiableLog -> func));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
@@ -1,0 +1,228 @@
+package uk.gov.register.store.postgres;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.Handle;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.Item;
+import uk.gov.register.core.Record;
+import uk.gov.register.db.*;
+import uk.gov.verifiablelog.store.memoization.MemoizationStore;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PostgresDriverTransactionalTest {
+
+    List<Entry> entries;
+    List<Item> items;
+    List<CurrentKey> currentKeys;
+
+    EntryQueryDAO entryQueryDAO;
+    EntryDAO entryDAO;
+    ItemQueryDAO itemQueryDAO;
+    ItemDAO itemDAO;
+    RecordQueryDAO recordQueryDAO;
+    CurrentKeysUpdateDAO currentKeysUpdateDAO;
+
+    @Mock
+    Handle handle;
+    @Mock
+    MemoizationStore memoizationStore;
+
+    ArgumentCaptor<Collection> argumentCaptor = ArgumentCaptor.forClass(Collection.class);
+
+    @Before
+    public void setup() {
+        entries = new ArrayList<>();
+        items = new ArrayList<>();
+        currentKeys = new ArrayList<>();
+
+        entryQueryDAO = mock(EntryQueryDAO.class);
+        entryDAO = mock(EntryDAO.class);
+        itemQueryDAO = mock(ItemQueryDAO.class);
+        itemDAO = mock(ItemDAO.class);
+        recordQueryDAO = mock(RecordQueryDAO.class);
+        currentKeysUpdateDAO = mock(CurrentKeysUpdateDAO.class);
+
+        mockEntryDAOInsert();
+        mockItemDAOInsert();
+        mockCurrentKeysUpdateDAOInsert();
+    }
+
+    @Test
+    public void insertItemEntryRecordShouldNotCommitData() {
+        PostgresDriverTransactional postgresDriver = new PostgresDriverTransactional(
+                handle, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
+
+        postgresDriver.insertItem(mock(Item.class));
+        postgresDriver.insertEntry(mock(Entry.class));
+        postgresDriver.insertEntry(mock(Entry.class));
+        postgresDriver.insertRecord(mockRecord("country", "DE", 1), "country");
+
+        assertThat(items, is(empty()));
+        assertThat(entries, is(empty()));
+        assertThat(currentKeys, is(empty()));
+    }
+
+    @Test
+    public void getEntryShouldAlwaysCommitStagedData() {
+        when(entryQueryDAO.findByEntryNumber(1)).thenReturn(Optional.empty());
+        assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.getEntry(1));
+    }
+
+    @Test
+    public void getEntriesShouldAlwaysCommitStagedData() {
+        when(entryQueryDAO.getEntries(1, 10)).thenReturn(asList());
+        assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.getEntries(1, 10));
+    }
+
+    @Test
+    public void getAllEntriesShouldAlwaysCommitStagedData() {
+        when(entryQueryDAO.getAllEntriesNoPagination()).thenReturn(asList());
+        assertStagedDataIsCommittedOnAction(PostgresDriverTransactional::getAllEntries);
+    }
+
+    @Test
+    public void getTotalEntriesShouldAlwaysCommitStagedData() {
+        when(entryQueryDAO.getTotalEntries()).thenReturn(10);
+        assertStagedDataIsCommittedOnAction(PostgresDriverTransactional::getTotalEntries);
+    }
+
+    @Test
+    public void getLastUpdatedTimeShouldAlwaysCommitStagedData() {
+        when(entryQueryDAO.getLastUpdatedTime()).thenReturn(Optional.empty());
+        assertStagedDataIsCommittedOnAction(PostgresDriverTransactional::getLastUpdatedTime);
+    }
+
+    @Test
+    public void getAllItemsShouldAlwaysCommitStagedData() {
+        when(itemQueryDAO.getAllItemsNoPagination()).thenReturn(asList());
+        assertStagedDataIsCommittedOnAction(PostgresDriverTransactional::getAllItems);
+    }
+
+    @Test
+    public void getRecordShouldAlwaysCommitStagedData() {
+        when(recordQueryDAO.findByPrimaryKey("DE")).thenReturn(Optional.empty());
+        assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.getRecord("DE"));
+    }
+
+    @Test
+    public void getTotalRecordsShouldAlwaysCommitStagedData() {
+        when(recordQueryDAO.getTotalRecords()).thenReturn(10);
+        assertStagedDataIsCommittedOnAction(PostgresDriverTransactional::getTotalRecords);
+    }
+
+    @Test
+    public void getRecordsShouldAlwaysCommitStagedData() {
+        when(recordQueryDAO.getRecords(10, 0)).thenReturn(asList());
+        assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.getRecords(10, 0));
+    }
+
+    @Test
+    public void findMax100RecordsByKeyValueShouldAlwaysCommitStagedData() {
+        when(recordQueryDAO.findMax100RecordsByKeyValue("name", "Germany")).thenReturn(asList());
+        assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.findMax100RecordsByKeyValue("name", "Germany"));
+    }
+
+    @Test
+    public void findAllEntriesOfRecordByShouldAlwaysCommitStagedData() {
+        when(recordQueryDAO.findAllEntriesOfRecordBy("country", "DE")).thenReturn(asList());
+        assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.findAllEntriesOfRecordBy("country", "DE"));
+    }
+
+    @Test
+    public void getItemBySha256ShouldCommitStagedDataOnlyIfItemNotStaged() {
+        ArgumentCaptor<String> hashArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        when(itemQueryDAO.getItemBySHA256(hashArgumentCaptor.capture()))
+                .thenReturn(items.stream().filter(item -> item.getSha256hex().equals(hashArgumentCaptor.getValue())).findFirst());
+
+        PostgresDriverTransactional postgresDriver = new PostgresDriverTransactional(
+                handle, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
+
+        items.add(new Item("itemhash1", new ObjectMapper().createObjectNode()));
+        entries.add(mock(Entry.class));
+        currentKeys.add(new CurrentKey("DE", 1));
+
+        assertThat(items.size(), is(1));
+        assertThat(entries.size(), is(1));
+        assertThat(currentKeys.size(), is(1));
+
+        postgresDriver.insertItem(new Item("itemhash2", new ObjectMapper().createObjectNode()));
+        postgresDriver.insertEntry(mock(Entry.class));
+        postgresDriver.insertRecord(mockRecord("country", "DE", 2), "country");
+
+        postgresDriver.getItemBySha256("itemhash2");
+
+        assertThat(items.size(), is(1));
+        assertThat(entries.size(), is(1));
+        assertThat(currentKeys.size(), is(1));
+
+        postgresDriver.getItemBySha256("itemhash1");
+
+        assertThat(items.size(), is(2));
+        assertThat(entries.size(), is(2));
+        assertThat(currentKeys.size(), is(2));
+
+    }
+
+    private void assertStagedDataIsCommittedOnAction(Consumer<PostgresDriverTransactional> actionToTest) {
+        PostgresDriverTransactional postgresDriver = new PostgresDriverTransactional(
+                handle, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
+
+        postgresDriver.insertItem(mock(Item.class));
+        postgresDriver.insertItem(mock(Item.class));
+        postgresDriver.insertEntry(mock(Entry.class));
+        postgresDriver.insertRecord(mockRecord("country", "DE", 1), "country");
+
+        assertThat(items, is(empty()));
+        assertThat(entries, is(empty()));
+        assertThat(currentKeys, is(empty()));
+
+        actionToTest.accept(postgresDriver);
+
+        assertThat(items.size(), is(2));
+        assertThat(entries.size(), is(1));
+        assertThat(currentKeys.size(), is(1));
+    }
+
+    private Record mockRecord(String registerName, String key, Integer entryNumber) {
+        Entry entry = mock(Entry.class);
+        Item item = mock(Item.class);
+        when(entry.getEntryNumber()).thenReturn(entryNumber);
+        when(item.getKey(registerName)).thenReturn(key);
+        return new Record(entry, item);
+    }
+
+    private void mockEntryDAOInsert() {
+        Mockito.doAnswer(invocation -> {
+            entries.addAll(argumentCaptor.getValue());
+            return null;
+        }).when(entryDAO).insertInBatch(argumentCaptor.capture());
+    }
+
+    private void mockItemDAOInsert() {
+        Mockito.doAnswer(invocation -> {
+            items.addAll(argumentCaptor.getValue());
+            return null;
+        }).when(itemDAO).insertInBatch(argumentCaptor.capture());
+    }
+
+    private void mockCurrentKeysUpdateDAOInsert() {
+        Mockito.doAnswer(invocation -> {
+            currentKeys.addAll(argumentCaptor.getValue());
+            return null;
+        }).when(currentKeysUpdateDAO).writeCurrentKeys(argumentCaptor.capture());
+    }
+}

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
@@ -1,19 +1,14 @@
 package uk.gov.register.store.postgres;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.skife.jdbi.v2.Handle;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
 import uk.gov.register.db.*;
 import uk.gov.register.views.RegisterProof;
 import uk.gov.verifiablelog.VerifiableLog;
-import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import java.time.Instant;
 import java.util.*;
@@ -27,43 +22,7 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PostgresDriverTransactionalTest {
-
-    List<Entry> entries;
-    List<Item> items;
-    List<CurrentKey> currentKeys;
-
-    EntryQueryDAO entryQueryDAO;
-    EntryDAO entryDAO;
-    ItemQueryDAO itemQueryDAO;
-    ItemDAO itemDAO;
-    RecordQueryDAO recordQueryDAO;
-    CurrentKeysUpdateDAO currentKeysUpdateDAO;
-
-    @Mock
-    Handle handle;
-    @Mock
-    MemoizationStore memoizationStore;
-
-    ArgumentCaptor<Collection> argumentCaptor = ArgumentCaptor.forClass(Collection.class);
-
-    @Before
-    public void setup() {
-        entries = new ArrayList<>();
-        items = new ArrayList<>();
-        currentKeys = new ArrayList<>();
-
-        entryQueryDAO = mock(EntryQueryDAO.class);
-        entryDAO = mock(EntryDAO.class);
-        itemQueryDAO = mock(ItemQueryDAO.class);
-        itemDAO = mock(ItemDAO.class);
-        recordQueryDAO = mock(RecordQueryDAO.class);
-        currentKeysUpdateDAO = mock(CurrentKeysUpdateDAO.class);
-
-        mockEntryDAOInsert();
-        mockItemDAOInsert();
-        mockCurrentKeysUpdateDAOInsert();
-    }
+public class PostgresDriverTransactionalTest extends PostgresDriverTestBase {
 
     @Test
     public void insertItemEntryRecordShouldNotCommitData() {
@@ -257,34 +216,5 @@ public class PostgresDriverTransactionalTest {
         assertThat(items.size(), is(2));
         assertThat(entries.size(), is(1));
         assertThat(currentKeys.size(), is(1));
-    }
-
-    private Record mockRecord(String registerName, String key, Integer entryNumber) {
-        Entry entry = mock(Entry.class);
-        Item item = mock(Item.class);
-        when(entry.getEntryNumber()).thenReturn(entryNumber);
-        when(item.getKey(registerName)).thenReturn(key);
-        return new Record(entry, item);
-    }
-
-    private void mockEntryDAOInsert() {
-        Mockito.doAnswer(invocation -> {
-            entries.addAll(argumentCaptor.getValue());
-            return null;
-        }).when(entryDAO).insertInBatch(argumentCaptor.capture());
-    }
-
-    private void mockItemDAOInsert() {
-        Mockito.doAnswer(invocation -> {
-            items.addAll(argumentCaptor.getValue());
-            return null;
-        }).when(itemDAO).insertInBatch(argumentCaptor.capture());
-    }
-
-    private void mockCurrentKeysUpdateDAOInsert() {
-        Mockito.doAnswer(invocation -> {
-            currentKeys.addAll(argumentCaptor.getValue());
-            return null;
-        }).when(currentKeysUpdateDAO).writeCurrentKeys(argumentCaptor.capture());
     }
 }

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
@@ -1,8 +1,6 @@
 package uk.gov.register.store.postgres;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.assertj.core.error.ShouldBeInSameYear;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;


### PR DESCRIPTION
I have not added any new functionality, only refactored what already exists. 

I've separated database transactions and batching from atomic operations on a register, but created a mapping between the two (in `RegisterService`). 

The `PostgresDriverTransactional` manages a list of staged items, entries and current keys. These are batched up and inserted into the database at certain points. This is managed using a read/write barrier. Whenever there is a read across the whole register, the staged data is written to the database.

I have also changed the Register interface to only implement append-entry and put-item write operations. This will help make sure that all loading code will use the same operations on the Register object instead of duplicating code.