### PR TITLE
Check canonicalization of items in itemstore

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -33,6 +33,8 @@ import uk.gov.register.service.RegisterService;
 import uk.gov.register.store.BackingStoreDriver;
 import uk.gov.register.store.postgres.PostgresDriverNonTransactional;
 import uk.gov.register.thymeleaf.ThymeleafViewRenderer;
+import uk.gov.register.util.CanonicalJsonMapper;
+import uk.gov.register.util.JsonMapper;
 import uk.gov.register.util.ObjectReconstructor;
 import uk.gov.register.views.ViewFactory;
 import uk.gov.verifiablelog.store.memoization.InMemoryPowOfTwoNoLeaves;
@@ -102,6 +104,8 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(ObjectReconstructor.class).to(ObjectReconstructor.class);
                 bind(PostgresDriverNonTransactional.class).to(BackingStoreDriver.class);
                 bind(RegisterService.class).to(RegisterService.class);
+                bind(CanonicalJsonMapper.class).to(CanonicalJsonMapper.class);
+                bind(JsonMapper.class).to(JsonMapper.class);
 
                 bind(RequestContext.class).to(RequestContext.class);
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);

--- a/src/main/java/uk/gov/register/core/Item.java
+++ b/src/main/java/uk/gov/register/core/Item.java
@@ -16,14 +16,16 @@ public class Item {
 
     private final String sha256hex;
     private final JsonNode content;
+    private final String rawContent;
 
-    public Item(JsonNode content) {
-        this(itemHash(content), content);
+    public Item(JsonNode content, String rawContent) {
+        this(itemHash(content), content, rawContent);
     }
 
-    public Item(String sha256hex, JsonNode content) {
+    public Item(String sha256hex, JsonNode content, String rawContent) {
         this.sha256hex = sha256hex;
         this.content = content;
+        this.rawContent = rawContent;
     }
 
     public static String itemHash(JsonNode content) {
@@ -41,6 +43,8 @@ public class Item {
     public JsonNode getContent() {
         return content;
     }
+
+    public String getRawContent() { return rawContent; }
 
     @SuppressWarnings("unused, used by DAO")
     public PGobject getContentAsJsonb() throws SQLException {

--- a/src/main/java/uk/gov/register/core/ItemStore.java
+++ b/src/main/java/uk/gov/register/core/ItemStore.java
@@ -18,7 +18,7 @@ public class ItemStore {
     }
 
     public void putItem(Item item) {
-        itemValidator.validateItem(registerName, item.getContent());
+        itemValidator.validateItem(registerName, item);
         backingStoreDriver.insertItem(item);
     }
 

--- a/src/main/java/uk/gov/register/db/mappers/ItemMapper.java
+++ b/src/main/java/uk/gov/register/db/mappers/ItemMapper.java
@@ -22,7 +22,7 @@ public class ItemMapper implements ResultSetMapper<Item> {
     public Item map(int index, ResultSet r, StatementContext ctx) throws SQLException {
         try {
             String rawContent = r.getString("content");
-            return new Item(r.getString("sha256hex"), objectMapper.readValue(rawContent, JsonNode.class));
+            return new Item(r.getString("sha256hex"), objectMapper.readValue(rawContent, JsonNode.class), rawContent);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/uk/gov/register/db/mappers/ItemMapper.java
+++ b/src/main/java/uk/gov/register/db/mappers/ItemMapper.java
@@ -5,14 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
-import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Calendar;
-import java.util.TimeZone;
 
 public class ItemMapper implements ResultSetMapper<Item> {
     private final ObjectMapper objectMapper;
@@ -24,7 +21,8 @@ public class ItemMapper implements ResultSetMapper<Item> {
     @Override
     public Item map(int index, ResultSet r, StatementContext ctx) throws SQLException {
         try {
-            return new Item(r.getString("sha256hex"), objectMapper.readValue(r.getString("content"), JsonNode.class));
+            String rawContent = r.getString("content");
+            return new Item(r.getString("sha256hex"), objectMapper.readValue(rawContent, JsonNode.class));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/uk/gov/register/util/CanonicalJsonMapper.java
+++ b/src/main/java/uk/gov/register/util/CanonicalJsonMapper.java
@@ -1,12 +1,28 @@
 package uk.gov.register.util;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializationFeature;
+
+import java.io.IOException;
 
 public class CanonicalJsonMapper extends JsonMapper {
     public CanonicalJsonMapper() {
         super();
         objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
         objectMapper.getFactory().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
+    }
+
+    @Override
+    public byte[] writeToBytes(JsonNode jsonNode) {
+        try {
+            // Method from http://stackoverflow.com/questions/18952571/jackson-jsonnode-to-string-with-sorted-keys
+            Object obj = objectMapper.treeToValue(jsonNode, Object.class);
+            // for some reason, writeValueAsString(obj).getBytes() doesn't re-escape unicode, but writeValueAsBytes does
+            // our canonical form requires raw unescaped unicode, so we need this version
+            return objectMapper.writeValueAsString(obj).getBytes();
+        } catch (IOException e) {
+            return ExceptionUtils.rethrow(e);
+        }
     }
 }

--- a/src/main/java/uk/gov/register/util/CanonicalJsonMapper.java
+++ b/src/main/java/uk/gov/register/util/CanonicalJsonMapper.java
@@ -1,38 +1,12 @@
 package uk.gov.register.util;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
-import java.io.IOException;
-
-public class CanonicalJsonMapper {
-    private final ObjectMapper objectMapper;
-
+public class CanonicalJsonMapper extends JsonMapper {
     public CanonicalJsonMapper() {
-        objectMapper = new ObjectMapper();
+        super();
         objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
         objectMapper.getFactory().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
-    }
-
-    public JsonNode readFromBytes(byte[] body) {
-        try {
-            return objectMapper.readValue(body, JsonNode.class);
-        } catch (IOException e) {
-            return ExceptionUtils.rethrow(e);
-        }
-    }
-
-    public byte[] writeToBytes(JsonNode jsonNode) {
-        try {
-            // Method from http://stackoverflow.com/questions/18952571/jackson-jsonnode-to-string-with-sorted-keys
-            Object obj = objectMapper.treeToValue(jsonNode, Object.class);
-            // for some reason, writeValueAsString(obj).getBytes() doesn't re-escape unicode, but writeValueAsBytes does
-            // our canonical form requires raw unescaped unicode, so we need this version
-            return objectMapper.writeValueAsString(obj).getBytes();
-        } catch (IOException e) {
-            return ExceptionUtils.rethrow(e);
-        }
     }
 }

--- a/src/main/java/uk/gov/register/util/JsonMapper.java
+++ b/src/main/java/uk/gov/register/util/JsonMapper.java
@@ -1,0 +1,34 @@
+package uk.gov.register.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public class JsonMapper {
+    protected final ObjectMapper objectMapper;
+
+    public JsonMapper() {
+        objectMapper = new ObjectMapper();
+    }
+
+    public JsonNode readFromBytes(byte[] body) {
+        try {
+            return objectMapper.readValue(body, JsonNode.class);
+        } catch (IOException e) {
+            return ExceptionUtils.rethrow(e);
+        }
+    }
+
+    public byte[] writeToBytes(JsonNode jsonNode) {
+        try {
+            // Method from http://stackoverflow.com/questions/18952571/jackson-jsonnode-to-string-with-sorted-keys
+            Object obj = objectMapper.treeToValue(jsonNode, Object.class);
+            // for some reason, writeValueAsString(obj).getBytes() doesn't re-escape unicode, but writeValueAsBytes does
+            // our canonical form requires raw unescaped unicode, so we need this version
+            return objectMapper.writeValueAsString(obj).getBytes();
+        } catch (IOException e) {
+            return ExceptionUtils.rethrow(e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/register/util/JsonMapper.java
+++ b/src/main/java/uk/gov/register/util/JsonMapper.java
@@ -25,8 +25,7 @@ public class JsonMapper {
             // Method from http://stackoverflow.com/questions/18952571/jackson-jsonnode-to-string-with-sorted-keys
             Object obj = objectMapper.treeToValue(jsonNode, Object.class);
             // for some reason, writeValueAsString(obj).getBytes() doesn't re-escape unicode, but writeValueAsBytes does
-            // our canonical form requires raw unescaped unicode, so we need this version
-            return objectMapper.writeValueAsString(obj).getBytes();
+            return objectMapper.writeValueAsBytes(obj);
         } catch (IOException e) {
             return ExceptionUtils.rethrow(e);
         }

--- a/src/main/java/uk/gov/register/util/ObjectReconstructor.java
+++ b/src/main/java/uk/gov/register/util/ObjectReconstructor.java
@@ -7,13 +7,24 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public class ObjectReconstructor {
+    private JsonMapper jsonMapper;
     private CanonicalJsonMapper canonicalJsonMapper;
 
     public ObjectReconstructor() {
+        this.jsonMapper = new JsonMapper();
         this.canonicalJsonMapper = new CanonicalJsonMapper();
     }
 
     public Iterable<JsonNode> reconstruct(String[] jsonObjectsAsStrings) {
         return Iterables.transform(Arrays.asList(jsonObjectsAsStrings), e -> canonicalJsonMapper.readFromBytes(e.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public Iterable<JsonNode> reconstructWithoutCanonicalization(String[] jsonObjectsAsStrings) {
+        return Iterables.transform(Arrays.asList(jsonObjectsAsStrings), e -> jsonMapper.readFromBytes(e.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public boolean verifyCanonicalization(String jsonObject) {
+        byte[] objBytes = jsonObject.getBytes();
+        return canonicalJsonMapper.readFromBytes(objBytes) == jsonMapper.readFromBytes(objBytes);
     }
 }

--- a/src/main/java/uk/gov/register/util/ObjectReconstructor.java
+++ b/src/main/java/uk/gov/register/util/ObjectReconstructor.java
@@ -15,8 +15,16 @@ public class ObjectReconstructor {
         this.canonicalJsonMapper = new CanonicalJsonMapper();
     }
 
+    public JsonNode reconstruct(String jsonObjectAsString) {
+        return canonicalJsonMapper.readFromBytes(jsonObjectAsString.getBytes(StandardCharsets.UTF_8));
+    }
+
     public Iterable<JsonNode> reconstruct(String[] jsonObjectsAsStrings) {
         return Iterables.transform(Arrays.asList(jsonObjectsAsStrings), e -> canonicalJsonMapper.readFromBytes(e.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public JsonNode reconstructWithoutCanonicalization(String jsonObjectAsString) {
+        return jsonMapper.readFromBytes(jsonObjectAsString.getBytes(StandardCharsets.UTF_8));
     }
 
     public Iterable<JsonNode> reconstructWithoutCanonicalization(String[] jsonObjectsAsStrings) {

--- a/src/test/java/uk/gov/register/core/ItemTest.java
+++ b/src/test/java/uk/gov/register/core/ItemTest.java
@@ -13,8 +13,8 @@ public class ItemTest {
     @Test
     public void twoItemsAreSameIfHashIsSame() throws IOException {
         JsonNode json = new ObjectMapper().readTree("{\"key\":\"value\"}");
-        Item item1 = new Item(json);
-        Item item2 = new Item(json);
+        Item item1 = new Item(json, "{\"key\":\"value\"}");
+        Item item2 = new Item(json, "{\"key\":\"value\"}");
         Assert.assertThat(item1, equalTo(item2));
     }
 }

--- a/src/test/java/uk/gov/register/functional/AnalyticsFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/AnalyticsFunctionalTest.java
@@ -8,12 +8,10 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import uk.gov.register.RegisterApplication;
 import uk.gov.register.RegisterConfiguration;
-import uk.gov.register.functional.app.WipeDatabaseRule;
 import uk.gov.register.functional.db.DBSupport;
 import uk.gov.register.functional.db.TestDAO;
 import uk.gov.register.functional.db.TestEntry;
@@ -49,8 +47,8 @@ public class AnalyticsFunctionalTest {
         dbSupport = new DBSupport(testDAO);
 
         dbSupport.cleanDb();
-        testEntry1 = TestEntry.anEntry(1, "{\"street\":\"" + testEntry1Key + "\",\"address\":\"12345\"}");
-        testEntry2 = TestEntry.anEntry(2, "{\"street\":\"" + testEntry2Key + "\",\"address\":\"12346\"}");
+        testEntry1 = TestEntry.anEntry(1, "{\"address\":\"12345\",\"street\":\"" + testEntry1Key + "\"}");
+        testEntry2 = TestEntry.anEntry(2, "{\"address\":\"12346\",\"street\":\"" + testEntry2Key + "\"}");
         dbSupport.publishEntries("address", Arrays.asList(testEntry1, testEntry2));
     }
 

--- a/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
@@ -87,8 +87,8 @@ public class DataUploadFunctionalTest {
 
     @Test
     public void loadTwoDistinctItems_addsTwoRowsInEntryAndItemTable() {
-        String item1 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
-        String item2 = "{\"register\":\"register2\",\"text\":\"Register2 Text\", \"phase\":\"alpha\"}";
+        String item1 = "{\"phase\":\"alpha\",\"register\":\"register1\",\"text\":\"Register1 Text\"}";
+        String item2 = "{\"phase\":\"alpha\",\"register\":\"register2\",\"text\":\"Register2 Text\"}";
 
         Response r = send(item1 + "\n" + item2);
 
@@ -124,8 +124,8 @@ public class DataUploadFunctionalTest {
 
     @Test
     public void loadTwoSameItems_addsTwoRowsInEntryAndOnlyOneRowInItemTable() {
-        String item1 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
-        String item2 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
+        String item1 = "{\"phase\":\"alpha\",\"register\":\"register1\",\"text\":\"Register1 Text\"}";
+        String item2 = "{\"phase\":\"alpha\",\"register\":\"register1\",\"text\":\"Register1 Text\"}";
 
         Response r = send(item1 + "\n" + item2);
 
@@ -156,11 +156,11 @@ public class DataUploadFunctionalTest {
 
     @Test
     public void loadTwoNewItems_withOneItemPreexistsInDatabase_addsTwoRowsInEntryAndOnlyOneRowInItemTable() {
-        String item1 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
+        String item1 = "{\"phase\":\"alpha\",\"register\":\"register1\",\"text\":\"Register1 Text\"}";
         Response r = send(item1);
         assertThat(r.getStatus(), equalTo(204));
 
-        String item2 = "{\"register\":\"register2\",\"text\":\"Register2 Text\", \"phase\":\"alpha\"}";
+        String item2 = "{\"phase\":\"alpha\",\"register\":\"register2\",\"text\":\"Register2 Text\"}";
 
         r = send(item1 + "\n" + item2);
 

--- a/src/test/java/uk/gov/register/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/functional/FindEntityTest.java
@@ -16,9 +16,9 @@ public class FindEntityTest extends FunctionalTestBase {
     @Before
     public void publishTestMessages() {
         mintItems(
-                "{\"street\":\"ellis\",\"address\":\"12345\"}",
-                "{\"street\":\"presley\",\"address\":\"6789\"}",
-                "{\"street\":\"ellis\",\"address\":\"145678\"}"
+                "{\"address\":\"12345\",\"street\":\"ellis\"}",
+                "{\"address\":\"6789\",\"street\":\"presley\"}",
+                "{\"address\":\"145678\",\"street\":\"ellis\"}"
         );
     }
 

--- a/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
@@ -21,11 +21,11 @@ public class RecordListResourceFunctionalTest extends FunctionalTestBase {
     @Before
     public void publishTestMessages() {
         mintItems(
-                "{\"street\":\"ellis\",\"address\":\"12345\"}",
-                "{\"street\":\"presley\",\"address\":\"6789\"}",
-                "{\"street\":\"ellis\",\"address\":\"145678\"}",
-                "{\"street\":\"updatedEllisName\",\"address\":\"145678\"}",
-                "{\"street\":\"ellis\",\"address\":\"6789\"}"
+                "{\"address\":\"12345\",\"street\":\"ellis\"}",
+                "{\"address\":\"6789\",\"street\":\"presley\"}",
+                "{\"address\":\"145678\",\"street\":\"ellis\"}",
+                "{\"address\":\"145678\",\"street\":\"updatedEllisName\"}",
+                "{\"address\":\"6789\",\"street\":\"ellis\"}"
         );
     }
 
@@ -38,9 +38,9 @@ public class RecordListResourceFunctionalTest extends FunctionalTestBase {
 
         assertThat(responseMap.size(), equalTo(3));
 
-        assertThat(responseMap.get("6789"), equalTo(ImmutableMap.of("entry-number", "5", "item-hash", "sha-256:" + DigestUtils.sha256Hex("{\"address\":\"6789\",\"street\":\"ellis\"}"), "entry-timestamp", responseMap.get("6789").get("entry-timestamp"), "street", "ellis", "address", "6789")));
-        assertThat(responseMap.get("145678"), equalTo(ImmutableMap.of("entry-number", "4", "item-hash", "sha-256:" + DigestUtils.sha256Hex("{\"address\":\"145678\",\"street\":\"updatedEllisName\"}"), "entry-timestamp", responseMap.get("145678").get("entry-timestamp"), "street", "updatedEllisName", "address", "145678")));
-        assertThat(responseMap.get("12345"), equalTo(ImmutableMap.of("entry-number", "1", "item-hash", "sha-256:" + DigestUtils.sha256Hex("{\"address\":\"12345\",\"street\":\"ellis\"}"), "entry-timestamp", responseMap.get("12345").get("entry-timestamp"), "street", "ellis", "address", "12345")));
+        assertThat(responseMap.get("6789"), equalTo(ImmutableMap.of("entry-number", "5", "item-hash", "sha-256:" + DigestUtils.sha256Hex("{\"address\":\"6789\",\"street\":\"ellis\"}"), "entry-timestamp", responseMap.get("6789").get("entry-timestamp"), "address", "6789", "street", "ellis")));
+        assertThat(responseMap.get("145678"), equalTo(ImmutableMap.of("entry-number", "4", "item-hash", "sha-256:" + DigestUtils.sha256Hex("{\"address\":\"145678\",\"street\":\"updatedEllisName\"}"), "entry-timestamp", responseMap.get("145678").get("entry-timestamp"), "address", "145678", "street", "updatedEllisName")));
+        assertThat(responseMap.get("12345"), equalTo(ImmutableMap.of("entry-number", "1", "item-hash", "sha-256:" + DigestUtils.sha256Hex("{\"address\":\"12345\",\"street\":\"ellis\"}"), "entry-timestamp", responseMap.get("12345").get("entry-timestamp"), "address", "12345", "street", "ellis")));
     }
 
     @Test
@@ -81,8 +81,8 @@ public class RecordListResourceFunctionalTest extends FunctionalTestBase {
 
         assertThat(responseMap.size(), equalTo(2));
 
-        assertThat(responseMap.get("6789"), equalTo(ImmutableMap.of("entry-number", "5", "item-hash", "sha-256:" + DigestUtils.sha256Hex("{\"address\":\"6789\",\"street\":\"ellis\"}"), "entry-timestamp", responseMap.get("6789").get("entry-timestamp"), "street", "ellis", "address", "6789")));
-        assertThat(responseMap.get("12345"), equalTo(ImmutableMap.of("entry-number", "1", "item-hash", "sha-256:" + DigestUtils.sha256Hex("{\"address\":\"12345\",\"street\":\"ellis\"}"), "entry-timestamp", responseMap.get("12345").get("entry-timestamp"), "street", "ellis", "address", "12345")));
+        assertThat(responseMap.get("6789"), equalTo(ImmutableMap.of("entry-number", "5", "item-hash", "sha-256:" + DigestUtils.sha256Hex("{\"address\":\"6789\",\"street\":\"ellis\"}"), "entry-timestamp", responseMap.get("6789").get("entry-timestamp"), "address", "6789", "street", "ellis")));
+        assertThat(responseMap.get("12345"), equalTo(ImmutableMap.of("entry-number", "1", "item-hash", "sha-256:" + DigestUtils.sha256Hex("{\"address\":\"12345\",\"street\":\"ellis\"}"), "entry-timestamp", responseMap.get("12345").get("entry-timestamp"), "address", "12345", "street", "ellis")));
     }
 
 

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresDriverTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresDriverTransactionalFunctionalTest.java
@@ -27,9 +27,9 @@ public class PostgresDriverTransactionalFunctionalTest extends TestDBSupport {
     public void useTransactionShouldApplyChangesAtomicallyToDatabase() {
         DBI dbi = new DBI(postgresConnectionString);
 
-        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode());
-        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode());
-        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode());
+        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode(), "");
+        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode(), "");
+        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode(), "");
         Entry entry1 = new Entry(1, "itemhash1", Instant.now());
         Entry entry2 = new Entry(2, "itemhash2", Instant.now());
         Entry entry3 = new Entry(3, "itemhash3", Instant.now());
@@ -68,9 +68,9 @@ public class PostgresDriverTransactionalFunctionalTest extends TestDBSupport {
     public void useTransactionShouldRollbackIfExceptionThrown() {
         DBI dbi = new DBI(postgresConnectionString);
 
-        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode());
-        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode());
-        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode());
+        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode(), "");
+        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode(), "");
+        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode(), "");
         Entry entry1 = new Entry(1, "itemhash1", Instant.now());
         Entry entry2 = new Entry(2, "itemhash2", Instant.now());
         Entry entry3 = new Entry(3, "itemhash3", Instant.now());
@@ -111,4 +111,3 @@ public class PostgresDriverTransactionalFunctionalTest extends TestDBSupport {
         assertThat(testItemDAO.getItems().size(), is(0));
     }
 }
-

--- a/src/test/java/uk/gov/register/service/ItemValidatorTest.java
+++ b/src/test/java/uk/gov/register/service/ItemValidatorTest.java
@@ -7,6 +7,7 @@ import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.exceptions.ItemValidationException;
 import uk.gov.register.service.ItemValidator;
+import uk.gov.register.util.CanonicalJsonMapper;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -17,11 +18,12 @@ import static org.junit.Assert.fail;
 
 public class ItemValidatorTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CanonicalJsonMapper canonicalJsonMapper = new CanonicalJsonMapper();
 
     private FieldsConfiguration fieldsConfiguration = new FieldsConfiguration(Optional.empty());
     private RegistersConfiguration registerConfiguration = new RegistersConfiguration(Optional.empty());
 
-    private ItemValidator itemValidator = new ItemValidator(registerConfiguration, fieldsConfiguration);
+    private ItemValidator itemValidator = new ItemValidator(registerConfiguration, fieldsConfiguration, canonicalJsonMapper);
 
     @Test
     public void validateItem_throwsValidationException_givenPrimaryKeyOfRegisterNotExists() throws IOException {

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDriverNonTransactionalTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDriverNonTransactionalTest.java
@@ -18,10 +18,10 @@ public class PostgresDriverNonTransactionalTest extends PostgresDriverTestBase {
         PostgresDriverNonTransactional postgresDriver = new PostgresDriverNonTransactional(
                 dbi, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
 
-        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode());
-        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode());
-        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode());
-        Item item4 = new Item("itemhash4", new ObjectMapper().createObjectNode());
+        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode(), "");
+        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode(), "");
+        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode(), "");
+        Item item4 = new Item("itemhash4", new ObjectMapper().createObjectNode(), "");
 
         postgresDriver.insertItem(item1);
         postgresDriver.insertItem(item2);

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
@@ -123,7 +123,7 @@ public class PostgresDriverTransactionalTest extends PostgresDriverTestBase {
         PostgresDriverTransactional postgresDriver = new PostgresDriverTransactional(
                 handle, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
 
-        items.add(new Item("itemhash1", new ObjectMapper().createObjectNode()));
+        items.add(new Item("itemhash1", new ObjectMapper().createObjectNode(), ""));
         entries.add(mock(Entry.class));
         currentKeys.add(new CurrentKey("DE", 1));
 
@@ -131,7 +131,7 @@ public class PostgresDriverTransactionalTest extends PostgresDriverTestBase {
         assertThat(entries.size(), is(1));
         assertThat(currentKeys.size(), is(1));
 
-        postgresDriver.insertItem(new Item("itemhash2", new ObjectMapper().createObjectNode()));
+        postgresDriver.insertItem(new Item("itemhash2", new ObjectMapper().createObjectNode(), ""));
         postgresDriver.insertEntry(mock(Entry.class));
         postgresDriver.insertRecord(mockRecord("country", "VA", 2), "country");
 
@@ -180,9 +180,9 @@ public class PostgresDriverTransactionalTest extends PostgresDriverTestBase {
         PostgresDriverTransactional postgresDriver = new PostgresDriverTransactional(
                 handle, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
 
-        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode());
-        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode());
-        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode());
+        Item item1 = new Item("itemhash1", new ObjectMapper().createObjectNode(), "");
+        Item item2 = new Item("itemhash2", new ObjectMapper().createObjectNode(), "");
+        Item item3 = new Item("itemhash3", new ObjectMapper().createObjectNode(), "");
         Entry entry1 = new Entry(1, "itemhash1", Instant.now());
         Entry entry2 = new Entry(2, "itemhash2", Instant.now());
         Entry entry3 = new Entry(3, "itemhash3", Instant.now());

--- a/src/test/java/uk/gov/register/util/ArchiveCreatorTest.java
+++ b/src/test/java/uk/gov/register/util/ArchiveCreatorTest.java
@@ -35,11 +35,11 @@ public class ArchiveCreatorTest {
 
     private final Item entry1Item = new Item("entry1sha", jsonFactory.objectNode()
         .put("field-1", "entry1-field-1-value")
-        .put("field-2", "entry1-field-2-value"));
+        .put("field-2", "entry1-field-2-value"), "{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}");
 
     private final Item entry2Item = new Item("entry2sha", jsonFactory.objectNode()
         .put("field-1", "entry2-field-1-value")
-        .put("field-2", "entry2-field-2-value"));
+        .put("field-2", "entry2-field-2-value"), "{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}");
 
     @Test
     public void create_shouldCreateAnArchiveWithRegisterInfoEntriesAndItems() throws IOException {

--- a/src/test/java/uk/gov/register/views/RecordListViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordListViewTest.java
@@ -39,11 +39,11 @@ public class RecordListViewTest {
         List<Record> records = Lists.newArrayList(
                 new Record(
                         new Entry(1, "ab", t1),
-                        new Item("ab", Jackson.newObjectMapper().readTree("{\"address\":\"123\", \"street\":\"foo\"}"))
+                        new Item("ab", Jackson.newObjectMapper().readTree("{\"address\":\"123\", \"street\":\"foo\"}"), "")
                 ),
                 new Record(
                         new Entry(2, "cd", t2),
-                        new Item("cd", Jackson.newObjectMapper().readTree("{\"address\":\"456\", \"street\":\"bar\"}"))
+                        new Item("cd", Jackson.newObjectMapper().readTree("{\"address\":\"456\", \"street\":\"bar\"}"), "")
                 )
         );
         RegisterData registerData = new RegisterData(ImmutableMap.of("register", new TextNode("address")));

--- a/src/test/java/uk/gov/register/views/RecordViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordViewTest.java
@@ -22,7 +22,7 @@ public class RecordViewTest {
     public void recordJsonRepresentation_isFlatJsonOfEntryAndItemContent() throws IOException, JSONException {
         ObjectMapper objectMapper = Jackson.newObjectMapper();
 
-        Record record = new Record(new Entry(1, "ab", Instant.ofEpochSecond(1470403440)), new Item("ab", objectMapper.readTree("{\"a\":\"b\"}")));
+        Record record = new Record(new Entry(1, "ab", Instant.ofEpochSecond(1470403440)), new Item("ab", objectMapper.readTree("{\"a\":\"b\"}"), ""));
         RecordView recordView = new RecordView(null, null, null, null, record, () -> "test.register.gov.uk", new RegisterData(Collections.emptyMap()), () -> Optional.empty());
 
         String result = objectMapper.writeValueAsString(recordView);

--- a/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
@@ -11,8 +11,6 @@ import uk.gov.register.resources.RequestContext;
 import uk.gov.register.service.ItemConverter;
 import uk.gov.register.views.EntryView;
 import uk.gov.register.views.ItemView;
-import uk.gov.register.views.representations.turtle.EntryTurtleWriter;
-import uk.gov.register.views.representations.turtle.ItemTurtleWriter;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -65,7 +63,7 @@ public class TurtleRepresentationWriterTest {
                 "key3", new StringValue("val\"ue3"),
                 "key4", new StringValue("value4")
         );
-        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item("hash", objectMapper.valueToTree(map)), () -> "test.register.gov.uk", null, () -> Optional.empty());
+        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item("hash", objectMapper.valueToTree(map), ""), () -> "test.register.gov.uk", null, () -> Optional.empty());
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
@@ -98,7 +96,7 @@ public class TurtleRepresentationWriterTest {
                         "name", new StringValue("foo")
                 );
 
-        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item("itemhash", objectMapper.valueToTree(map)), () -> "test.register.gov.uk", null, () -> Optional.empty());
+        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item("itemhash", objectMapper.valueToTree(map), ""), () -> "test.register.gov.uk", null, () -> Optional.empty());
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
@@ -121,7 +119,7 @@ public class TurtleRepresentationWriterTest {
                         "name", new StringValue("foo")
                 );
 
-        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item("hash", objectMapper.valueToTree(map)), () -> "test.register.gov.uk", null, () -> Optional.empty());
+        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item("hash", objectMapper.valueToTree(map), ""), () -> "test.register.gov.uk", null, () -> Optional.empty());
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 


### PR DESCRIPTION
This is an implementation of validating items that are being added to a register to ensure that they are canonicalized. It is based on the following assumptions:

- We will be storing the raw item JSON as part of the `Item`, enabling us to use the output from the  `JsonMapper` and `CanonicalJsonMapper` to determine if an item is in canonical form.
- `Item` should keep the property `content` of type `JsonNode`, as this node is determined when the `Item` is created based on whether the input is in canonical form or not.
- `DataUpload` has been extended to include a new endpoint for loading data without applying canonicalization to `Item`s. Whilst not technically part of this story, it shows how `Item`s will be constructed.
- All `Item`s added to the `ItemStore` will need to be in canonical form, as the `ItemValidator` will throw an exception otherwise. This is the intended behaviour: items added to the register via the 'legacy' endpoint will be canonicalized on their way in, whereas items added via the new endpoint have the requirement to be in canonical form to begin with.
- Downloading data from the register in ZIP format will canonicalize items.