### PR TITLE
Checking field exists in SearchResource

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -22,6 +22,7 @@ import uk.gov.organisation.client.GovukOrganisationClient;
 import uk.gov.register.auth.AuthBundle;
 import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.PublicBodiesConfiguration;
+import uk.gov.register.configuration.RegisterFieldsConfiguration;
 import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.core.*;
 import uk.gov.register.db.SchemaCreator;
@@ -82,6 +83,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         RegistersConfiguration registersConfiguration = new RegistersConfiguration(Optional.ofNullable(System.getProperty("registersYaml")));
         FieldsConfiguration mintFieldsConfiguration = new FieldsConfiguration(Optional.ofNullable(System.getProperty("fieldsYaml")));
         RegisterData registerData = registersConfiguration.getRegisterData(configuration.getRegisterName());
+        RegisterFieldsConfiguration registerFieldsConfiguration = new RegisterFieldsConfiguration(registerData);
 
         JerseyEnvironment jersey = environment.jersey();
         DropwizardResourceConfig resourceConfig = jersey.getResourceConfig();
@@ -95,6 +97,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(mintFieldsConfiguration).to(FieldsConfiguration.class);
                 bind(registersConfiguration).to(RegistersConfiguration.class);
                 bind(registerData).to(RegisterData.class);
+                bind(registerFieldsConfiguration).to(RegisterFieldsConfiguration.class);
                 bind(jdbi);
                 bind(new PublicBodiesConfiguration(Optional.ofNullable(System.getProperty("publicBodiesYaml")))).to(PublicBodiesConfiguration.class);
 

--- a/src/main/java/uk/gov/register/configuration/RegisterFieldsConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/RegisterFieldsConfiguration.java
@@ -1,0 +1,18 @@
+package uk.gov.register.configuration;
+
+import com.google.common.collect.Lists;
+import uk.gov.register.core.RegisterData;
+
+import java.util.ArrayList;
+
+public class RegisterFieldsConfiguration {
+    private final ArrayList<String> registerFields;
+
+    public RegisterFieldsConfiguration(RegisterData registerData) {
+        this.registerFields = Lists.newArrayList(registerData.getRegister().getFields());
+    }
+
+    public boolean containsField(String fieldName) {
+        return registerFields.contains(fieldName);
+    }
+}

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -1,6 +1,6 @@
 package uk.gov.register.core;
 
-import com.google.common.collect.Lists;
+import uk.gov.register.configuration.RegisterFieldsConfiguration;
 import uk.gov.register.db.RecordIndex;
 import uk.gov.register.exceptions.NoSuchFieldException;
 import uk.gov.register.exceptions.NoSuchItemForEntryException;
@@ -13,7 +13,6 @@ import uk.gov.register.views.RegisterProof;
 import javax.inject.Inject;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -24,18 +23,19 @@ public class PostgresRegister implements Register {
     private final String registerName;
     private final EntryLog entryLog;
     private final ItemStore itemStore;
-    private final ArrayList<String> fields;
+    private final RegisterFieldsConfiguration registerFieldsConfiguration;
 
     @Inject
     public PostgresRegister(RegisterData registerData,
                             BackingStoreDriver backingStoreDriver,
-                            ItemValidator itemValidator) {
+                            ItemValidator itemValidator,
+                            RegisterFieldsConfiguration registerFieldsConfiguration) {
         RegisterMetadata registerMetadata = registerData.getRegister();
         registerName = registerMetadata.getRegisterName();
-        fields = Lists.newArrayList(registerMetadata.getFields());
         this.entryLog = new EntryLog(backingStoreDriver);
         this.itemStore = new ItemStore(backingStoreDriver, itemValidator, registerName);
         this.recordIndex = new RecordIndex(backingStoreDriver);
+        this.registerFieldsConfiguration = registerFieldsConfiguration;
     }
 
     @Override
@@ -107,12 +107,12 @@ public class PostgresRegister implements Register {
 
     @Override
     public boolean containsField(String fieldName) {
-        return fields.contains(fieldName);
+        return registerFieldsConfiguration.containsField(fieldName);
     }
 
     @Override
     public List<Record> max100RecordsFacetedByKeyValue(String key, String value) {
-        if (!containsField(key)) {
+        if (!registerFieldsConfiguration.containsField(key)) {
             throw new NoSuchFieldException(registerName, key);
         }
 

--- a/src/main/java/uk/gov/register/resources/SearchResource.java
+++ b/src/main/java/uk/gov/register/resources/SearchResource.java
@@ -1,13 +1,11 @@
 package uk.gov.register.resources;
 
+import uk.gov.register.configuration.RegisterFieldsConfiguration;
 import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.UnsupportedEncodingException;
@@ -21,17 +19,23 @@ public class SearchResource {
 
     protected final RequestContext requestContext;
     private final String registerPrimaryKey;
+    private final RegisterFieldsConfiguration registerFieldsConfiguration;
 
     @Inject
-    public SearchResource(RequestContext requestContext, RegisterNameConfiguration registerNameConfiguration) {
+    public SearchResource(RequestContext requestContext, RegisterNameConfiguration registerNameConfiguration, RegisterFieldsConfiguration registerFieldsConfiguration) {
         this.requestContext = requestContext;
         registerPrimaryKey = registerNameConfiguration.getRegisterName();
+        this.registerFieldsConfiguration = registerFieldsConfiguration;
     }
 
     @GET
     @Path("/{key}/{value}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public Object find(@PathParam("key") String key, @PathParam("value") String value) throws Exception {
+        if (!key.equals(registerPrimaryKey) && !registerFieldsConfiguration.containsField(key)) {
+            throw new NotFoundException();
+        }
+
         String redirectUrl = key.equals(registerPrimaryKey) ?
                 String.format("/record/%s", encodeUrlValue(value)) :
                 String.format("/records/%s/%s", key, encodeUrlValue(value));

--- a/src/main/java/uk/gov/register/service/RegisterService.java
+++ b/src/main/java/uk/gov/register/service/RegisterService.java
@@ -1,6 +1,7 @@
 package uk.gov.register.service;
 
 import org.skife.jdbi.v2.DBI;
+import uk.gov.register.configuration.RegisterFieldsConfiguration;
 import uk.gov.register.core.PostgresRegister;
 import uk.gov.register.core.Register;
 import uk.gov.register.core.RegisterData;
@@ -15,18 +16,20 @@ public class RegisterService {
     private final DBI dbi;
     private final MemoizationStore memoizationStore;
     private final ItemValidator itemValidator;
+    private final RegisterFieldsConfiguration registerFieldsConfiguration;
 
     @Inject
-    public RegisterService(RegisterData registerData, DBI dbi, MemoizationStore memoizationStore, ItemValidator itemValidator) {
+    public RegisterService(RegisterData registerData, DBI dbi, MemoizationStore memoizationStore, ItemValidator itemValidator, RegisterFieldsConfiguration registerFieldsConfiguration) {
         this.registerData = registerData;
         this.dbi = dbi;
         this.memoizationStore = memoizationStore;
         this.itemValidator = itemValidator;
+        this.registerFieldsConfiguration = registerFieldsConfiguration;
     }
 
     public void asAtomicRegisterOperation(Consumer<Register> callback) {
         PostgresDriverTransactional.useTransaction(dbi, memoizationStore, postgresDriver -> {
-            Register register = new PostgresRegister(registerData, postgresDriver, itemValidator);
+            Register register = new PostgresRegister(registerData, postgresDriver, itemValidator, registerFieldsConfiguration);
             callback.accept(register);
         });
     }

--- a/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
+++ b/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import uk.gov.register.configuration.RegisterFieldsConfiguration;
 import uk.gov.register.exceptions.NoSuchFieldException;
 import uk.gov.register.exceptions.NoSuchItemForEntryException;
 import uk.gov.register.service.ItemValidator;
@@ -21,6 +22,7 @@ public class PostgresRegisterTest {
     private RegisterData registerData;
     private BackingStoreDriver backingStoreDriver;
     private ItemValidator itemValidator;
+    private RegisterFieldsConfiguration registerFieldsConfiguration;
 
     @Before
     public void setup() {
@@ -34,17 +36,19 @@ public class PostgresRegisterTest {
         when(registerData.getRegister()).thenReturn(registerMetadata);
         backingStoreDriver = mock(BackingStoreDriver.class);
         itemValidator = mock(ItemValidator.class);
+        registerFieldsConfiguration = mock(RegisterFieldsConfiguration.class);
     }
 
     @Test(expected = NoSuchFieldException.class)
     public void findMax100RecordsByKeyValueShouldFailWhenKeyDoesNotExist() {
-        PostgresRegister register = new PostgresRegister(registerData, backingStoreDriver, itemValidator);
+        PostgresRegister register = new PostgresRegister(registerData, backingStoreDriver, itemValidator, registerFieldsConfiguration);
         register.max100RecordsFacetedByKeyValue("citizen-name", "British");
     }
 
     @Test
     public void findMax100RecordsByKeyValueShouldReturnValueWhenKeyExists() {
-        PostgresRegister register = new PostgresRegister(registerData, backingStoreDriver, itemValidator);
+        when(registerFieldsConfiguration.containsField("name")).thenReturn(true);
+        PostgresRegister register = new PostgresRegister(registerData, backingStoreDriver, itemValidator, registerFieldsConfiguration);
         register.max100RecordsFacetedByKeyValue("name", "United Kingdom");
         verify(backingStoreDriver, times(1)).findMax100RecordsByKeyValue("name", "United Kingdom");
     }
@@ -55,7 +59,7 @@ public class PostgresRegisterTest {
 
         when(backingStoreDriver.getItemBySha256(anyString())).thenReturn(Optional.empty());
 
-        PostgresRegister register = new PostgresRegister(registerData, backingStoreDriver, itemValidator);
+        PostgresRegister register = new PostgresRegister(registerData, backingStoreDriver, itemValidator, registerFieldsConfiguration);
         register.appendEntry(entryDangling);
     }
 
@@ -69,7 +73,7 @@ public class PostgresRegisterTest {
                 .thenReturn(Optional.of(item))
                 .thenReturn(Optional.empty());
 
-        PostgresRegister register = new PostgresRegister(registerData, backingStoreDriver, itemValidator);
+        PostgresRegister register = new PostgresRegister(registerData, backingStoreDriver, itemValidator, registerFieldsConfiguration);
 
         try {
             register.appendEntry(entryNotDangling);
@@ -95,7 +99,7 @@ public class PostgresRegisterTest {
         when(registerMetadata.getRegisterName()).thenReturn("country");
         when(registerData.getRegister()).thenReturn(registerMetadata);
 
-        PostgresRegister register = new PostgresRegister(registerData, backingStoreDriver, itemValidator);
+        PostgresRegister register = new PostgresRegister(registerData, backingStoreDriver, itemValidator, registerFieldsConfiguration);
 
         try {
             register.appendEntry(entryNotDangling);

--- a/src/test/java/uk/gov/register/resources/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/SearchResourceTest.java
@@ -5,17 +5,25 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.register.configuration.RegisterFieldsConfiguration;
+import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterMetadata;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.lang.reflect.Method;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SearchResourceTest {
@@ -24,6 +32,8 @@ public class SearchResourceTest {
 
     RequestContext requestContext;
     SearchResource resource;
+    RegisterData registerData;
+    RegisterFieldsConfiguration registerFieldsConfiguration;
 
     @Before
     public void setUp() throws Exception {
@@ -33,11 +43,16 @@ public class SearchResourceTest {
                 return servletResponse;
             }
         };
-        resource = new SearchResource(requestContext, () -> "school");
+        RegisterMetadata registerMetadata = mock(RegisterMetadata.class);
+        registerData = mock(RegisterData.class);
+        when(registerData.getRegister()).thenReturn(registerMetadata);
+        registerFieldsConfiguration = mock(RegisterFieldsConfiguration.class);
     }
 
     @Test
     public void findSupportsTurtleHtmlAndJson() throws Exception {
+        resource = new SearchResource(requestContext, () -> "school", registerFieldsConfiguration);
+
         Method searchMethod = SearchResource.class.getDeclaredMethod("find", String.class, String.class);
         List<String> declaredMediaTypes = asList(searchMethod.getDeclaredAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes,
@@ -46,4 +61,18 @@ public class SearchResourceTest {
                         ExtraMediaType.TEXT_TTL));
     }
 
+    @Test(expected = NotFoundException.class)
+    public void find_doesNotRedirect_whenKeyDoesNotExistAsFieldInRegister() throws Exception {
+        resource = new SearchResource(requestContext, () -> "school", registerFieldsConfiguration);
+        resource.find("country-name", "United Kingdom");
+    }
+
+    @Test
+    public void find_returns301_whenKeyExistsAsFieldInRegister() throws Exception {
+        when(registerFieldsConfiguration.containsField("country-name")).thenReturn(true);
+        resource = new SearchResource(requestContext, () -> "school", registerFieldsConfiguration);
+
+        Response r = (Response) resource.find("country-name", "United Kingdom");
+        assertThat(r.getStatus(), equalTo(301));
+    }
 }

--- a/src/test/java/uk/gov/register/resources/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/SearchResourceTest.java
@@ -51,8 +51,6 @@ public class SearchResourceTest {
 
     @Test
     public void findSupportsTurtleHtmlAndJson() throws Exception {
-        resource = new SearchResource(requestContext, () -> "school", registerFieldsConfiguration);
-
         Method searchMethod = SearchResource.class.getDeclaredMethod("find", String.class, String.class);
         List<String> declaredMediaTypes = asList(searchMethod.getDeclaredAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes,


### PR DESCRIPTION
SearchResource shouldn't redirect to /records if the given field name doesn't exist in the current register, but should instead return a 404.

Refactored the checking of an existence of a field in a register into RegisterFieldsConfiguration, which is used in both SearchResource and PostgresRegister (although the latter may not technically need to be checking  this any longer if all requests first go through SearchResource).