### PR TITLE
Fix Content-Security-Policy

### DIFF
--- a/src/main/java/uk/gov/register/filters/ContentSecurityPolicyFilter.java
+++ b/src/main/java/uk/gov/register/filters/ContentSecurityPolicyFilter.java
@@ -12,6 +12,6 @@ import java.io.IOException;
 public class ContentSecurityPolicyFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
-        responseContext.getHeaders().add(HttpHeaders.CONTENT_SECURITY_POLICY, "default-src 'self' www.google-analytics.com 'nonce-321analytics123'");
+        responseContext.getHeaders().add(HttpHeaders.CONTENT_SECURITY_POLICY, "default-src 'self' www.google-analytics.com");
     }
 }

--- a/src/main/java/uk/gov/register/resources/HomePageResource.java
+++ b/src/main/java/uk/gov/register/resources/HomePageResource.java
@@ -1,6 +1,7 @@
 package uk.gov.register.resources;
 
 import io.dropwizard.views.View;
+import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.views.ViewFactory;
 import uk.gov.register.views.representations.ExtraMediaType;
@@ -16,11 +17,13 @@ import java.security.NoSuchAlgorithmException;
 public class HomePageResource {
     private final RegisterReadOnly register;
     private final ViewFactory viewFactory;
+    private final RegisterTrackingConfiguration config;
 
     @Inject
-    public HomePageResource(RegisterReadOnly register, ViewFactory viewFactory) {
+    public HomePageResource(RegisterReadOnly register, ViewFactory viewFactory, RegisterTrackingConfiguration config) {
         this.register = register;
         this.viewFactory = viewFactory;
+        this.config = config;
     }
 
     @GET
@@ -39,6 +42,12 @@ public class HomePageResource {
     public String robots() {
         return "User-agent: *\n" +
                 "Disallow: /\n";
+    }
+    @GET
+    @Path("/analytics-code.js")
+    @Produces("application/javascript")
+    public String analyticsTrackingId() {
+        return "var gaTrackingId = \"" + config.getRegisterTrackingId().get() + "\";\n";
     }
 
 }

--- a/src/main/java/uk/gov/register/resources/HomePageResource.java
+++ b/src/main/java/uk/gov/register/resources/HomePageResource.java
@@ -47,7 +47,8 @@ public class HomePageResource {
     @Path("/analytics-code.js")
     @Produces("application/javascript")
     public String analyticsTrackingId() {
-        return "var gaTrackingId = \"" + config.getRegisterTrackingId().get() + "\";\n";
+        return config.getRegisterTrackingId().map(
+                trackingId -> "var gaTrackingId = \"" + trackingId + "\";\n"
+        ).orElse("");
     }
-
 }

--- a/src/main/java/uk/gov/register/resources/HomePageResource.java
+++ b/src/main/java/uk/gov/register/resources/HomePageResource.java
@@ -45,7 +45,7 @@ public class HomePageResource {
     }
     @GET
     @Path("/analytics-code.js")
-    @Produces("application/javascript")
+    @Produces(ExtraMediaType.APPLICATION_JAVASCRIPT)
     public String analyticsTrackingId() {
         return config.getRegisterTrackingId().map(
                 trackingId -> "var gaTrackingId = \"" + trackingId + "\";\n"

--- a/src/main/java/uk/gov/register/views/representations/ExtraMediaType.java
+++ b/src/main/java/uk/gov/register/views/representations/ExtraMediaType.java
@@ -4,6 +4,7 @@ import javax.ws.rs.core.MediaType;
 
 public class ExtraMediaType {
     public static final String TEXT_HTML = "text/html; charset=UTF-8";
+    public static final String APPLICATION_JAVASCRIPT = "application/javascript";
 
     public static final String TEXT_CSV = "text/csv; charset=UTF-8";
     public static final MediaType TEXT_CSV_TYPE = new MediaType("text", "csv", "UTF-8");

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -85,11 +85,7 @@
     <script type="text/javascript" src="/assets/js/details.polyfill.js"></script>
 
     <th:block th:if="${registerTrackingId != null and registerTrackingId.present and !#strings.isEmpty(registerTrackingId.get())}">
-        <script id="analytics-tracking-id" nonce="321analytics123" th:inline="javascript">
-            /*<![CDATA[*/
-                var gaTrackingId = /*[[${registerTrackingId.get()}]]*/ '';
-            /*]]>*/
-        </script>
+        <script id="analytics-tracking-id" src="/analytics-code.js"></script>
         <script id="analytics-main" type="text/javascript" src="/assets/js/analytics.js"></script>
         <script id="analytics-external-links" type="text/javascript" src="/assets/js/analytics-external-links.js"></script>
     </th:block>

--- a/src/test/java/uk/gov/register/functional/AnalyticsFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/AnalyticsFunctionalTest.java
@@ -105,18 +105,13 @@ public class AnalyticsFunctionalTest {
         Document doc = Jsoup.parse(response.readEntity(String.class));
         assertThat(response.getStatus(), lessThan(500));
 
-        Element trackingIdElem = doc.getElementById("analytics-tracking-id");
-        Boolean docIncludesAnalyticsId = trackingIdElem != null;
+        Boolean docIncludesAnalyticsId = doc.getElementById("analytics-tracking-id") != null;
         Boolean docIncludesMainAnalytics = doc.getElementById("analytics-main") != null;
         Boolean docIncludesExtLinksAnalytics = doc.getElementById("analytics-external-links") != null;
 
         assertThat(docIncludesAnalyticsId, equalTo(shouldIncludeAnalytics));
         assertThat(docIncludesMainAnalytics, equalTo(shouldIncludeAnalytics));
         assertThat(docIncludesExtLinksAnalytics, equalTo(shouldIncludeAnalytics));
-
-        if (shouldIncludeAnalytics) {
-            assertThat(trackingIdElem.html(), containsString("var gaTrackingId = '" + trackingId + "';"));
-        }
     }
 
     private Client getTestClient(DropwizardAppRule<RegisterConfiguration> appRule) {

--- a/src/test/java/uk/gov/register/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/functional/ApplicationTest.java
@@ -41,7 +41,7 @@ public class ApplicationTest extends FunctionalTestBase {
                 .request()
                 .get();
 
-        assertThat(response.getHeaders().get(HttpHeaders.CONTENT_SECURITY_POLICY), equalTo(ImmutableList.of("default-src 'self' www.google-analytics.com 'nonce-321analytics123'")));
+        assertThat(response.getHeaders().get(HttpHeaders.CONTENT_SECURITY_POLICY), equalTo(ImmutableList.of("default-src 'self' www.google-analytics.com")));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/resources/HomePageResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/HomePageResourceTest.java
@@ -28,7 +28,7 @@ public class HomePageResourceTest {
         when(registerMock.getLastUpdatedTime()).thenReturn(lastUpdated);
         when(viewFactoryMock.homePageView(totalRecords, totalEntries, lastUpdated)).thenReturn(homePageView);
 
-        HomePageResource homePageResource = new HomePageResource(registerMock, viewFactoryMock);
+        HomePageResource homePageResource = new HomePageResource(registerMock, viewFactoryMock, () -> Optional.of("trackingId"));
         homePageResource.home();
 
         verify(registerMock, times(1)).getTotalRecords();

--- a/src/test/java/uk/gov/register/resources/HomePageResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/HomePageResourceTest.java
@@ -9,6 +9,8 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class HomePageResourceTest {
@@ -34,6 +36,30 @@ public class HomePageResourceTest {
         verify(registerMock, times(1)).getTotalRecords();
         verify(registerMock, times(1)).getTotalEntries();
         verify(viewFactoryMock, times(1)).homePageView(totalRecords, totalEntries, lastUpdated);
+    }
+
+    @Test
+    public void shouldRenderAnalyticsCodeIfPresent() throws Exception {
+        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        ViewFactory viewFactoryMock = mock(ViewFactory.class);
+
+        HomePageResource homePageResource = new HomePageResource(registerMock, viewFactoryMock, () -> Optional.of("codeForTest"));
+
+        String s = homePageResource.analyticsTrackingId();
+
+        assertThat(s, equalTo("var gaTrackingId = \"codeForTest\";\n"));
+    }
+
+    @Test
+    public void shouldRenderEmptyJsFileIfCodeIsAbsent() throws Exception {
+        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        ViewFactory viewFactoryMock = mock(ViewFactory.class);
+
+        HomePageResource homePageResource = new HomePageResource(registerMock, viewFactoryMock, () -> Optional.empty());
+
+        String s = homePageResource.analyticsTrackingId();
+
+        assertThat(s, equalTo(""));
     }
 }
 


### PR DESCRIPTION
This extracts the inline GA tracking id code into a new dynamic endpoint
so that we don't need to use a nonce or hash in the CSP.

The nonce was a problem because we hardcoded a single value that was
reused, which means that an XSS attacker could also reuse that nonce,
removing the security property of the CSP.

Tested locally using a throwaway GA tracking code.