### PR TITLE
Remove entry number from register command

### DIFF
--- a/src/main/java/uk/gov/register/serialization/AddItemCommand.java
+++ b/src/main/java/uk/gov/register/serialization/AddItemCommand.java
@@ -3,8 +3,6 @@ package uk.gov.register.serialization;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 public class AddItemCommand extends RegisterCommand {
 
     private Item item;
@@ -14,7 +12,7 @@ public class AddItemCommand extends RegisterCommand {
     }
 
     @Override
-    public void execute(Register register, AtomicInteger entryNumber) {
+    public void execute(Register register) {
         register.putItem(item);
     }
 

--- a/src/main/java/uk/gov/register/serialization/AppendEntryCommand.java
+++ b/src/main/java/uk/gov/register/serialization/AppendEntryCommand.java
@@ -3,8 +3,6 @@ package uk.gov.register.serialization;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Register;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 public class AppendEntryCommand extends RegisterCommand {
 
     private Entry entry;
@@ -14,8 +12,9 @@ public class AppendEntryCommand extends RegisterCommand {
     }
 
     @Override
-    public void execute(Register register, AtomicInteger entryNumber) {
-        Entry numberedEntry = new Entry(entryNumber.getAndIncrement(), entry.getSha256hex(), entry.getTimestamp());
+    public void execute(Register register) {
+        int nextEntryNumber = register.getTotalEntries() + 1;
+        Entry numberedEntry = new Entry(nextEntryNumber, entry.getSha256hex(), entry.getTimestamp());
         register.appendEntry(numberedEntry);
     }
 
@@ -37,6 +36,4 @@ public class AppendEntryCommand extends RegisterCommand {
     public int hashCode() {
         return 31 * entry.hashCode();
     }
-
-
 }

--- a/src/main/java/uk/gov/register/serialization/AssertRootHashCommand.java
+++ b/src/main/java/uk/gov/register/serialization/AssertRootHashCommand.java
@@ -5,7 +5,6 @@ import uk.gov.register.exceptions.RootHashAssertionException;
 import uk.gov.register.views.RegisterProof;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class AssertRootHashCommand extends RegisterCommand {
 
@@ -16,7 +15,7 @@ public class AssertRootHashCommand extends RegisterCommand {
     }
 
     @Override
-    public void execute(Register register, AtomicInteger entryNumber) throws Exception {
+    public void execute(Register register) throws Exception {
         RegisterProof actualProof = register.getRegisterProof();
         if (!actualProof.equals(this.registerProof)) {
             throw new RootHashAssertionException("Actual root hash: " + actualProof.getRootHash() + " does not match expected: " + this.registerProof.getRootHash());

--- a/src/main/java/uk/gov/register/serialization/RegisterCommand.java
+++ b/src/main/java/uk/gov/register/serialization/RegisterCommand.java
@@ -2,11 +2,9 @@ package uk.gov.register.serialization;
 
 import uk.gov.register.core.Register;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 public abstract class RegisterCommand {
 
-    public abstract void execute(Register register, AtomicInteger entryNumber) throws Exception;
+    public abstract void execute(Register register) throws Exception;
 
     public abstract String serialise(CommandParser commandParser);
 

--- a/src/main/java/uk/gov/register/service/RegisterSerialisationFormatService.java
+++ b/src/main/java/uk/gov/register/service/RegisterSerialisationFormatService.java
@@ -10,7 +10,6 @@ import uk.gov.register.views.RegisterProof;
 import javax.inject.Inject;
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class RegisterSerialisationFormatService {
 
@@ -61,11 +60,9 @@ public class RegisterSerialisationFormatService {
     }
 
     private void mintRegisterComponents(Iterator<RegisterCommand> commands, Register register) {
-        final int startEntryNum = register.getTotalEntries() + 1;
-        AtomicInteger entryNum = new AtomicInteger(startEntryNum);
         commands.forEachRemaining(c -> {
             try {
-                c.execute(register, entryNum);
+                c.execute(register);
             }catch(RootHashAssertionException e){
                 throw e;
             } catch (Exception e) {

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
@@ -16,10 +16,7 @@ import uk.gov.register.core.TransactionalMemoizationStore;
 import uk.gov.register.db.*;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -100,6 +97,12 @@ public class PostgresDriverTransactional extends PostgresDriver {
     }
 
     @Override
+    public int getTotalEntries() {
+        OptionalInt maxStagedEntryNumber = getMaxStagedEntryNumber();
+        return maxStagedEntryNumber.orElseGet(super::getTotalEntries);
+    }
+
+    @Override
     protected void useHandle(HandleConsumer callback) {
         useExistingHandle(callback);
     }
@@ -168,5 +171,9 @@ public class PostgresDriverTransactional extends PostgresDriver {
 
     private Optional<Item> searchStagingForItem(String sha256hex) {
         return Optional.ofNullable(stagedItems.get(sha256hex));
+    }
+
+    private OptionalInt getMaxStagedEntryNumber() {
+        return stagedEntries.stream().mapToInt(Entry::getEntryNumber).max();
     }
 }

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -73,7 +73,7 @@ public class RegisterSerialisationFormatServiceTest {
 
     @Test
     public void processRegisterComponents() throws Exception {
-        when(register.getTotalEntries()).thenReturn(0);
+        when(register.getTotalEntries()).thenReturn(0).thenReturn(1);
         when(register.getRegisterProof()).thenReturn(emptyRegisterProof);
 
         doAnswer(new Answer<Void>() {
@@ -98,8 +98,8 @@ public class RegisterSerialisationFormatServiceTest {
         verify(register, times(1)).putItem(item);
         verify(register, times(2)).appendEntry(any());
 
-        inOrder.verify(register, calls(1)).appendEntry(entry1);
-        inOrder.verify(register, calls(1)).appendEntry(entry2);
+        inOrder.verify(register, calls(1)).appendEntry(new Entry(1, entry1.getSha256hex(), entry1.getTimestamp()));
+        inOrder.verify(register, calls(1)).appendEntry(new Entry(2, entry2.getSha256hex(), entry2.getTimestamp()));
     }
 
     @Test


### PR DESCRIPTION
This removes entry-number from the `RegisterCommand.execute` interface as it is not required by all commands. Instead the next entry number is obtained from the `register` object.

To make sure this does not go the database for all commands actions, `PostgresDriverTransactional.getEntries()` has been changed to read the max entry number from the staged entries if there are any present. Otherwise, it goes to the database.