### PR TITLE
Return Bad Request when a user sends a non-integer value

### DIFF
--- a/src/main/java/uk/gov/register/resources/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/EntryResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import io.dropwizard.jersey.params.IntParam;
 import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.RegisterReadOnly;
@@ -43,9 +44,9 @@ public class EntryResource {
     @GET
     @Path("/entries")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
-    public EntryListView entries(@QueryParam("start") Optional<Integer> optionalStart, @QueryParam("limit") Optional<Integer> optionalLimit) {
+    public EntryListView entries(@QueryParam("start") Optional<IntParam> optionalStart, @QueryParam("limit") Optional<IntParam> optionalLimit) {
         int totalEntries = register.getTotalEntries();
-        StartLimitPagination startLimitPagination = new StartLimitPagination(optionalStart, optionalLimit, totalEntries);
+        StartLimitPagination startLimitPagination = new StartLimitPagination(optionalStart.map(IntParam::get), optionalLimit.map(IntParam::get), totalEntries);
 
         Collection<Entry> entries = register.getEntries(startLimitPagination.start, startLimitPagination.limit);
 

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import io.dropwizard.jersey.params.IntParam;
 import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Record;
@@ -73,8 +74,8 @@ public class RecordResource {
     @GET
     @Path("/records")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
-    public RecordListView records(@QueryParam(IndexSizePagination.INDEX_PARAM) Optional<Integer> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<Integer> pageSize) {
-        IndexSizePagination pagination = new IndexSizePagination(pageIndex, pageSize, register.getTotalRecords());
+    public RecordListView records(@QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntParam> pageSize) {
+        IndexSizePagination pagination = new IndexSizePagination(pageIndex.map(IntParam::get), pageSize.map(IntParam::get), register.getTotalRecords());
 
         requestContext.resourceExtension().ifPresent(
                 ext -> httpServletResponseAdapter.addContentDispositionHeader(registerPrimaryKey + "-records." + ext)

--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -49,6 +49,16 @@ public class EntryResourceFunctionalTest extends FunctionalTestBase {
     }
 
     @Test
+    public void getEntries_return400ResponseWhenStartIsNotANumber() {
+        assertThat(getRequest("/entries?start=not-a-number").getStatus(), equalTo(400));
+    }
+
+    @Test
+    public void getEntries_return400ResponseWhenLimitIsNotANumber() {
+        assertThat(getRequest("/entries?limit=not-a-number").getStatus(), equalTo(400));
+    }
+
+    @Test
     public void getEntriesAsJson() throws JSONException, IOException {
         Response response = getRequest("/entries.json");
 

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -47,6 +47,16 @@ public class RecordResourceFunctionalTest extends FunctionalTestBase {
     }
 
     @Test
+    public void recordResource_return400ResponseWhenPageSizeIsNotANumber() {
+        assertThat(getRequest("/records?page-size=not-a-number").getStatus(), equalTo(400));
+    }
+
+    @Test
+    public void recordResource_return400ResponseWhenPageIndexIsNotANumber() {
+        assertThat(getRequest("/records?page-index=not-a-number").getStatus(), equalTo(400));
+    }
+
+    @Test
     public void historyResource_returnsHistoryOfARecord() throws IOException {
         Response response = getRequest("/record/6789/entries.json");
 


### PR DESCRIPTION
Previously we would return 500 if the query string contained values that could not be parsed into an Integer; this is not correct as the error lies with the client and should be in the 4xx range. Example: 

```
$ curl -I  "https://country.register.gov.uk/records?page-size=not-a-number"
HTTP/1.1 500 Internal Server Error
...
```

[`IntParam`](http://www.dropwizard.io/0.7.0/dropwizard-jersey/apidocs/io/dropwizard/jersey/params/IntParam.html) is the magic that makes this easy and we should probably use it for `PathParam`s that take integers too.