### PR TITLE
Fix useless header tag + unimplemented exception

### DIFF
--- a/src/main/resources/templates/400.html
+++ b/src/main/resources/templates/400.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
@@ -15,3 +15,4 @@
 <footer th:replace="main.html::footer"></footer>
 </body>
 </html>
+xw

--- a/src/main/resources/templates/400.html
+++ b/src/main/resources/templates/400.html
@@ -15,4 +15,3 @@
 <footer th:replace="main.html::footer"></footer>
 </body>
 </html>
-xw

--- a/src/main/resources/templates/404.html
+++ b/src/main/resources/templates/404.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>

--- a/src/main/resources/templates/500.html
+++ b/src/main/resources/templates/500.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>

--- a/src/main/resources/templates/download.html
+++ b/src/main/resources/templates/download.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 
 <div class="content-grid-row">
     <main id="content" role="main">

--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
     <div class="grid-row">

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
     <div class="grid-row">

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
     <div class="grid-row">

--- a/src/main/resources/templates/item.html
+++ b/src/main/resources/templates/item.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
     <div class="grid-row">

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/css/main.css"/>
 </head>
 
-<header th:fragment="header" id="global-header" role="banner">
+<header th:fragment="global-header" id="global-header" role="banner">
     <div class="header-wrapper">
         <div class="header-global">
             <div class="header-logo">

--- a/src/main/resources/templates/not-implemented.html
+++ b/src/main/resources/templates/not-implemented.html
@@ -3,11 +3,12 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
-    <h1>This page has not been implemented</h1>
+    <a href="/">&lt; back</a>
+    <header th:replace="main.html::page-header(title='This page has not been implemented yet')"></header>
     <p>We haven’t prioritised this work yet. If you are interested in this feature, please let us know so we can
                 adjust our priorities.</p>
 </main>

--- a/src/main/resources/templates/record.html
+++ b/src/main/resources/templates/record.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
     <div class="grid-row">

--- a/src/main/resources/templates/records.html
+++ b/src/main/resources/templates/records.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:replace="main.html::global-header"></header>
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
     <div class="grid-row">


### PR DESCRIPTION
https://trello.com/c/sUnoWz2L/490-bug-empty-h1-on-every-page

When only `header` was used both TAGs header were pulled on the page regardless of their fragment names, hence the second one page-header was rendered empty where it should not

This also adds a mapper to catch our not implemented/unsupported operation exception and renders dedicated page for it.