### PR TITLE
Restart Docker app containers that haven't explicitly been stopped

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -11,6 +11,10 @@ aws s3 cp s3://${CONFIG_BUCKET}/${REGISTER_NAME}/openregister/config.yaml /srv/o
 aws s3 cp s3://${CONFIG_BUCKET}/registers.yaml /srv/openregister-java --region eu-west-1
 aws s3 cp s3://${CONFIG_BUCKET}/fields.yaml /srv/openregister-java --region eu-west-1
 
-docker run -d --name=openregister -p 80:8080 \
+docker run \
+    --detach \
+    --name=openregister \
+    --publish 80:8080 \
+    --restart "unless-stopped" \
     --volume /srv/openregister-java:/srv/openregister-java \
     jstepien/openjdk8 java -Xmx8g -Dfile.encoding=UTF-8 -DregistersYaml=/srv/openregister-java/registers.yaml -DfieldsYaml=/srv/openregister-java/fields.yaml -jar /srv/openregister-java/openregister-java.jar server /srv/openregister-java/config.yaml


### PR DESCRIPTION
If the container dies then we can have the Docker service automatically restart the container. We should see less downtime when apps die in environments where there is little or no redundancy.