### PR TITLE
Introduce register rule

### DIFF
--- a/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
+++ b/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
@@ -1,11 +1,12 @@
 package uk.gov.register.db.mappers;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import uk.gov.register.core.Entry;
 import uk.gov.register.db.EntryQueryDAO;
-import uk.gov.register.functional.FunctionalTestBase;
+import uk.gov.register.functional.app.RegisterRule;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -13,7 +14,10 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-public class EntryMapperTest extends FunctionalTestBase {
+public class EntryMapperTest {
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
+
     @Test
     public void map_returnsSameDateAndTimeInUTC() throws Exception {
         String expected = "2016-07-15T10:00:00Z";

--- a/src/test/java/uk/gov/register/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/functional/ApplicationTest.java
@@ -5,7 +5,10 @@ import com.google.common.net.HttpHeaders;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.register.functional.app.RegisterRule;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -14,7 +17,15 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 
-public class ApplicationTest extends FunctionalTestBase {
+public class ApplicationTest {
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
+
+    @Before
+    public void setup() {
+        register.wipe();
+    }
+
     @Test
     public void appSupportsCORS() {
         String origin = "http://originfortest.com";

--- a/src/test/java/uk/gov/register/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/functional/ApplicationTest.java
@@ -18,7 +18,7 @@ public class ApplicationTest extends FunctionalTestBase {
     @Test
     public void appSupportsCORS() {
         String origin = "http://originfortest.com";
-        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/entries?cors-test")
+        Response response = register.target().path("/entries")
                 .request()
                 .header(HttpHeaders.ORIGIN, origin)
                 .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
@@ -37,18 +37,14 @@ public class ApplicationTest extends FunctionalTestBase {
 
     @Test
     public void appSupportsContentSecurityPolicy() throws Exception {
-        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/entries")
-                .request()
-                .get();
+        Response response = register.getRequest("/entries");
 
         assertThat(response.getHeaders().get(HttpHeaders.CONTENT_SECURITY_POLICY), equalTo(ImmutableList.of("default-src 'self' www.google-analytics.com")));
     }
 
     @Test
     public void appExplicitlySendsHtmlCharsetInHeader() throws Exception {
-        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/entries")
-                .request()
-                .get();
+        Response response = register.getRequest("/entries");
 
         String contentType = (String) response.getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0);
         assertThat(contentType, containsString("text/html"));
@@ -57,27 +53,21 @@ public class ApplicationTest extends FunctionalTestBase {
 
     @Test
     public void appSupportsContentTypeOptions() throws Exception {
-        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/entries")
-                .request()
-                .get();
+        Response response = register.getRequest("/entries");
 
         assertThat(response.getHeaders().get(HttpHeaders.X_CONTENT_TYPE_OPTIONS), equalTo(ImmutableList.of("nosniff")));
     }
 
     @Test
     public void appSupportsXssProtection() throws Exception {
-        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/entries")
-                .request()
-                .get();
+        Response response = register.getRequest("/entries");
 
         assertThat(response.getHeaders().get(HttpHeaders.X_XSS_PROTECTION), equalTo(ImmutableList.of("1; mode=block")));
     }
 
     @Test
     public void app404PageHasXhtmlLangAttributes() throws Exception {
-        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/missing_page_to_force_a_404")
-                .request()
-                .get();
+        Response response = register.getRequest("/missing_page_to_force_a_404");
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         Elements htmlElement = doc.select("html");

--- a/src/test/java/uk/gov/register/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/functional/ApplicationTest.java
@@ -18,7 +18,7 @@ public class ApplicationTest extends FunctionalTestBase {
     @Test
     public void appSupportsCORS() {
         String origin = "http://originfortest.com";
-        Response response = client.target("http://address.beta.openregister.org:" + APPLICATION_PORT + "/entries?cors-test")
+        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/entries?cors-test")
                 .request()
                 .header(HttpHeaders.ORIGIN, origin)
                 .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
@@ -37,7 +37,7 @@ public class ApplicationTest extends FunctionalTestBase {
 
     @Test
     public void appSupportsContentSecurityPolicy() throws Exception {
-        Response response = client.target("http://address.beta.openregister.org:" + APPLICATION_PORT + "/entries")
+        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/entries")
                 .request()
                 .get();
 
@@ -46,7 +46,7 @@ public class ApplicationTest extends FunctionalTestBase {
 
     @Test
     public void appExplicitlySendsHtmlCharsetInHeader() throws Exception {
-        Response response = client.target("http://address.beta.openregister.org:" + APPLICATION_PORT + "/entries")
+        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/entries")
                 .request()
                 .get();
 
@@ -57,7 +57,7 @@ public class ApplicationTest extends FunctionalTestBase {
 
     @Test
     public void appSupportsContentTypeOptions() throws Exception {
-        Response response = client.target("http://address.beta.openregister.org:" + APPLICATION_PORT + "/entries")
+        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/entries")
                 .request()
                 .get();
 
@@ -66,7 +66,7 @@ public class ApplicationTest extends FunctionalTestBase {
 
     @Test
     public void appSupportsXssProtection() throws Exception {
-        Response response = client.target("http://address.beta.openregister.org:" + APPLICATION_PORT + "/entries")
+        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/entries")
                 .request()
                 .get();
 
@@ -75,7 +75,7 @@ public class ApplicationTest extends FunctionalTestBase {
 
     @Test
     public void app404PageHasXhtmlLangAttributes() throws Exception {
-        Response response = client.target("http://address.beta.openregister.org:" + APPLICATION_PORT + "/missing_page_to_force_a_404")
+        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/missing_page_to_force_a_404")
                 .request()
                 .get();
 

--- a/src/test/java/uk/gov/register/functional/AssetsBundleCustomErrorHandlerTest.java
+++ b/src/test/java/uk/gov/register/functional/AssetsBundleCustomErrorHandlerTest.java
@@ -4,14 +4,20 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.register.functional.app.RegisterRule;
+
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class AssetsBundleCustomErrorHandlerTest extends FunctionalTestBase {
+public class AssetsBundleCustomErrorHandlerTest {
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
+
     @Test
     public void displays404pageForNonexistentAssets() {
         Response response = register.getRequest("/assets/not-an-assets");

--- a/src/test/java/uk/gov/register/functional/AssetsBundleCustomErrorHandlerTest.java
+++ b/src/test/java/uk/gov/register/functional/AssetsBundleCustomErrorHandlerTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class AssetsBundleCustomErrorHandlerTest extends FunctionalTestBase {
     @Test
     public void displays404pageForNonexistentAssets() {
-        Response response = getRequest("/assets/not-an-assets");
+        Response response = register.getRequest("/assets/not-an-assets");
 
         assertThat(response.getStatus(), equalTo(404));
         assertThat(response.getMediaType().isCompatible(MediaType.TEXT_HTML_TYPE), equalTo(true));

--- a/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
@@ -3,7 +3,9 @@ package uk.gov.register.functional;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.register.functional.app.RegisterRule;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.ws.rs.core.MediaType;
@@ -24,8 +26,10 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class DataDownloadFunctionalTest extends FunctionalTestBase {
+public class DataDownloadFunctionalTest {
 
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
     private final String item1 = "{\"street\":\"ellis\",\"address\":\"12345\"}";
     private final String item2 = "{\"street\":\"presley\",\"address\":\"6789\"}";
     private final String item3 =  "{\"street\":\"foo\",\"address\":\"12345\"}";
@@ -33,7 +37,8 @@ public class DataDownloadFunctionalTest extends FunctionalTestBase {
 
     @Before
     public void publishTestMessages() {
-        mintItems(item1, item2, item3, item4, item1);
+        register.wipe();
+        register.mintLines(item1, item2, item3, item4, item1);
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
@@ -38,7 +38,7 @@ public class DataDownloadFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void downloadRegister_shouldReturnAZipfile() throws IOException {
-        Response response = getRequest("/download-register");
+        Response response = register.getRequest("/download-register");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo(MediaType.APPLICATION_OCTET_STREAM));
         assertThat(response.getHeaderString("Content-Disposition"), startsWith("attachment; filename="));
@@ -54,7 +54,7 @@ public class DataDownloadFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void downloadRegister_shouldUseCorrectEntryAndItemJsonFormat() throws IOException {
-        Response response = getRequest("/download-register");
+        Response response = register.getRequest("/download-register");
         InputStream is = response.readEntity(InputStream.class);
 
         List<String> itemJson = getEntries(is).entrySet().stream()
@@ -78,7 +78,7 @@ public class DataDownloadFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void downloadRegister_shouldUseCorrectRegisterJsonFormat() throws IOException {
-        Response response = getRequest("/download-register");
+        Response response = register.getRequest("/download-register");
         InputStream is = response.readEntity(InputStream.class);
 
         JsonNode registerJson = getEntries(is).get("register.json");
@@ -92,7 +92,7 @@ public class DataDownloadFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void downloadRSF_shouldReturnRegisterAsRsfStream() throws IOException {
-        Response response = getRequest("/download-rsf");
+        Response response = register.getRequest("/download-rsf");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo(ExtraMediaType.APPLICATION_RSF));
         assertThat(response.getHeaderString("Content-Disposition"), startsWith("attachment; filename="));
@@ -118,7 +118,7 @@ public class DataDownloadFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void downloadPartialRSF_shouldReturnAPartOfRegisterAsRsfStream() throws IOException {
-        Response response = getRequest("/download-rsf/1/2");
+        Response response = register.getRequest("/download-rsf/1/2");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo(ExtraMediaType.APPLICATION_RSF));
         assertThat(response.getHeaderString("Content-Disposition"), startsWith("attachment; filename="));
@@ -139,22 +139,22 @@ public class DataDownloadFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void downloadPartialRSF_shouldReturnReturn404ForRsfBoundariesInTheIncorrectOrder() throws IOException {
-        Response response = getRequest("/download-rsf/4/1");
+        Response response = register.getRequest("/download-rsf/4/1");
         
         assertThat(response.getStatus(), equalTo(400));
     }
 
     @Test
     public void downloadPartialRSF_shouldReturnReturn404ForRsfBoundariesOutOfBound() throws IOException {
-        Response response = getRequest("/download-rsf/666/1000");
+        Response response = register.getRequest("/download-rsf/666/1000");
 
         assertThat(response.getStatus(), equalTo(400));
     }
 
     @Test
     public void downloadPartialRSF_shouldReturnSameRSFAsFullDownload() {
-        Response fullRsfResponse = getRequest("/download-rsf");
-        Response partialRsfResponse = getRequest("/download-rsf/1/5");
+        Response fullRsfResponse = register.getRequest("/download-rsf");
+        Response partialRsfResponse = register.getRequest("/download-rsf/1/5");
 
         String[] fullRsfLines = getRsfLinesFrom(fullRsfResponse);
         String[] partialRsfLines = getRsfLinesFrom(partialRsfResponse);

--- a/src/test/java/uk/gov/register/functional/EntriesResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntriesResourceFunctionalTest.java
@@ -29,14 +29,14 @@ public class EntriesResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void entries_setsAppropriateFilenameForDownload() {
-        Response response = getRequest("address", "/entries.json");
+        Response response = getRequest("/entries.json");
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString(HttpHeaders.CONTENT_DISPOSITION), containsString("filename=\"address-entries.json\""));
     }
 
     @Test
     public void entriesPageHasXhtmlLangAttributes() throws Throwable {
-        Response response = getRequest("address", "/entries");
+        Response response = getRequest("/entries");
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         Elements htmlElement = doc.select("html");

--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -36,7 +36,7 @@ public class EntryResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void getEntriesView_itemHashesAreRenderedAsLinks() {
-        Response response = getRequest("/entries");
+        Response response = register.getRequest("/entries");
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -50,17 +50,17 @@ public class EntryResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void getEntries_return400ResponseWhenStartIsNotANumber() {
-        assertThat(getRequest("/entries?start=not-a-number").getStatus(), equalTo(400));
+        assertThat(register.target().path("/entries").queryParam("start","not-a-number").request().get().getStatus(), equalTo(400));
     }
 
     @Test
     public void getEntries_return400ResponseWhenLimitIsNotANumber() {
-        assertThat(getRequest("/entries?limit=not-a-number").getStatus(), equalTo(400));
+        assertThat(register.target().path("/entries").queryParam("limit","not-a-number").request().get().getStatus(), equalTo(400));
     }
 
     @Test
     public void getEntriesAsJson() throws JSONException, IOException {
-        Response response = getRequest("/entries.json");
+        Response response = register.getRequest("/entries.json");
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -72,7 +72,7 @@ public class EntryResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void getEntryByEntryNumber() throws JSONException, IOException {
-        Response response = getRequest("/entry/1.json");
+        Response response = register.getRequest("/entry/1.json");
 
         assertThat(response.getStatus(), equalTo(200));
         JsonNode res = Jackson.newObjectMapper().readValue(response.readEntity(String.class), JsonNode.class);
@@ -81,7 +81,7 @@ public class EntryResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void entryView_itemHashIsRenderedAsALink() {
-        Response response = getRequest("/entry/1");
+        Response response = register.getRequest("/entry/1");
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         String text = doc.getElementsByTag("table").select("a[href=/item/" + item1Hash + "]").first().text();
@@ -90,19 +90,19 @@ public class EntryResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void return404ResponseWhenEntryNotExist() {
-        assertThat(getRequest("/entry/5001").getStatus(), equalTo(404));
+        assertThat(register.getRequest("/entry/5001").getStatus(), equalTo(404));
     }
 
     @Test
     public void return404ResponseWhenEntryNumberIsNotAnIntegerValue() {
-        assertThat(getRequest("/entry/a2").getStatus(), equalTo(404));
+        assertThat(register.getRequest("/entry/a2").getStatus(), equalTo(404));
     }
 
     @Test
     public void entryResource_retrievesTimestampsInUTC() throws IOException {
         Instant now = Instant.now();
 
-        Response response = getRequest("/entry/1.json");
+        Response response = register.getRequest("/entry/1.json");
         Map<String, String> responseData = response.readEntity(Map.class);
         Instant entryTimestamp = Instant.parse(responseData.get("entry-timestamp"));
 

--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -8,7 +8,9 @@ import org.json.JSONException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.register.functional.app.RegisterRule;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -23,7 +25,9 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertTrue;
 
-public class EntryResourceFunctionalTest extends FunctionalTestBase {
+public class EntryResourceFunctionalTest {
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
     private final String item1 = "{\"address\":\"6789\",\"street\":\"elvis\"}";
     private final String item2 = "{\"address\":\"6790\",\"street\":\"presley\"}";
     private final String item1Hash = "sha-256:" + DigestUtils.sha256Hex(item1);
@@ -31,7 +35,8 @@ public class EntryResourceFunctionalTest extends FunctionalTestBase {
     
     @Before
     public void publishTestMessages() throws Throwable {
-        mintItems(item1, item2);
+        register.wipe();
+        register.mintLines(item1, item2);
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/functional/FindEntityTest.java
@@ -27,7 +27,7 @@ public class FindEntityTest extends FunctionalTestBase {
         Response response = getRequest("/address/12345.json");
 
         assertThat(response.getStatus(), equalTo(301));
-        String expectedRedirect = "http://address.beta.openregister.org:" + app.getLocalPort() + "/record/12345";
+        String expectedRedirect = "http://localhost:" + app.getLocalPort() + "/record/12345";
         assertThat(response.getHeaderString("Location"), equalTo(expectedRedirect));
     }
 

--- a/src/test/java/uk/gov/register/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/functional/FindEntityTest.java
@@ -4,7 +4,9 @@ import org.json.JSONException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.register.functional.app.RegisterRule;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
@@ -13,15 +15,15 @@ import java.net.URI;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class FindEntityTest extends FunctionalTestBase {
+public class FindEntityTest {
+
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
 
     @Before
     public void publishTestMessages() {
-        mintItems(
-                "{\"street\":\"ellis\",\"address\":\"12345\"}",
-                "{\"street\":\"presley\",\"address\":\"6789\"}",
-                "{\"street\":\"ellis\",\"address\":\"145678\"}"
-        );
+        register.wipe();
+        register.mintLines("{\"street\":\"ellis\",\"address\":\"12345\"}", "{\"street\":\"presley\",\"address\":\"6789\"}", "{\"street\":\"ellis\",\"address\":\"145678\"}");
     }
 
     @Test
@@ -44,5 +46,4 @@ public class FindEntityTest extends FunctionalTestBase {
 
         assertThat(doc.body().getElementById("main").getElementsByAttributeValue("class", "column-two-thirds").first().text(), equalTo("2 records"));
     }
-
 }

--- a/src/test/java/uk/gov/register/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/functional/FindEntityTest.java
@@ -6,7 +6,9 @@ import org.jsoup.nodes.Document;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
+import java.net.URI;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,16 +26,19 @@ public class FindEntityTest extends FunctionalTestBase {
 
     @Test
     public void find_shouldReturnEntryWithThPrimaryKey_whenSearchForPrimaryKey() throws JSONException {
-        Response response = getRequest("/address/12345.json");
+        WebTarget target = register.target();
+        target.property("jersey.config.client.followRedirects",false);
+        Response response = target.path("/address/12345.json").request().get();
 
         assertThat(response.getStatus(), equalTo(301));
-        String expectedRedirect = "http://localhost:" + app.getLocalPort() + "/record/12345";
-        assertThat(response.getHeaderString("Location"), equalTo(expectedRedirect));
+        String expectedRedirect = "/record/12345";
+        URI location = URI.create(response.getHeaderString("Location"));
+        assertThat(location.getPath(), equalTo(expectedRedirect));
     }
 
     @Test
     public void find_returnsTheCorrectTotalRecordsInPaginationHeader() {
-        Response response = getRequest("/records/street/ellis");
+        Response response = register.getRequest("/records/street/ellis");
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
 

--- a/src/test/java/uk/gov/register/functional/FunctionalTestBase.java
+++ b/src/test/java/uk/gov/register/functional/FunctionalTestBase.java
@@ -1,23 +1,9 @@
 package uk.gov.register.functional;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import uk.gov.register.functional.app.RegisterRule;
 import uk.gov.register.functional.db.DBSupport;
 import uk.gov.register.functional.db.TestDAO;
 
 public class FunctionalTestBase {
     protected static final TestDAO testDAO = TestDAO.get("ft_openregister_java", "postgres");
     protected static final DBSupport dbSupport = new DBSupport(testDAO);
-    @ClassRule
-    public static RegisterRule register = new RegisterRule("address");
-
-    @Before
-    public void setup() {
-        register.wipe();
-    }
-
-    protected void mintItems(String... items) {
-        register.mintLines(items);
-    }
 }

--- a/src/test/java/uk/gov/register/functional/FunctionalTestBase.java
+++ b/src/test/java/uk/gov/register/functional/FunctionalTestBase.java
@@ -1,65 +1,23 @@
 package uk.gov.register.functional;
 
-import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import uk.gov.register.RegisterApplication;
-import uk.gov.register.RegisterConfiguration;
-import uk.gov.register.functional.app.WipeDatabaseRule;
+import uk.gov.register.functional.app.RegisterRule;
 import uk.gov.register.functional.db.DBSupport;
 import uk.gov.register.functional.db.TestDAO;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Response;
-
 public class FunctionalTestBase {
-    public static final int APPLICATION_PORT = 9000;
-
-    protected static Client client;
-
     protected static final TestDAO testDAO = TestDAO.get("ft_openregister_java", "postgres");
     protected static final DBSupport dbSupport = new DBSupport(testDAO);
-    protected static Client authenticatingClient;
-    @Rule
-    public TestRule wipe = new WipeDatabaseRule();
-
     @ClassRule
-    public static DropwizardAppRule<RegisterConfiguration> app = new DropwizardAppRule<>(RegisterApplication.class,
-            ResourceHelpers.resourceFilePath("test-app-config.yaml"),
-            ConfigOverride.config("jerseyClient.timeout", "3000ms"));
+    public static RegisterRule register = new RegisterRule("address");
 
-    private static io.dropwizard.client.JerseyClientBuilder testClientBuilder() {
-        return new io.dropwizard.client.JerseyClientBuilder(app.getEnvironment())
-                .using(app.getConfiguration().getJerseyClientConfiguration());
-    }
-
-    @BeforeClass
-    public static void beforeClass() throws InterruptedException {
-        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
-
-        client = testClientBuilder().withProperty("jersey.config.client.followRedirects",false).build("test client");
-
-        authenticatingClient = testClientBuilder().build("authenticating client");
-        authenticatingClient.register(HttpAuthenticationFeature.basicBuilder().credentials("foo", "bar").build());
-    }
-
-    Response getRequest(String path) {
-        return client.target(String.format("http://localhost:%d%s", app.getLocalPort(), path)).request().get();
+    @Before
+    public void setup() {
+        register.wipe();
     }
 
     protected void mintItems(String... items) {
-        for (String item : items) {
-            Response response = authenticatingClient.target(String.format("http://localhost:%d/load", app.getLocalPort())).request()
-                    .post(Entity.json(item));
-            if (response.getStatus() > 399) {
-                throw new RuntimeException("failed to mint items");
-            }
-        }
+        register.mintLines(items);
     }
 }

--- a/src/test/java/uk/gov/register/functional/HomePageFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/HomePageFunctionalTest.java
@@ -1,58 +1,34 @@
 package uk.gov.register.functional;
 
-import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
-import uk.gov.register.functional.app.CleanDatabaseRule;
-import uk.gov.register.RegisterApplication;
-import uk.gov.register.RegisterConfiguration;
+import uk.gov.register.functional.app.RegisterRule;
 
-import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
-import static uk.gov.register.functional.db.TestDBSupport.postgresConnectionString;
 
 public class HomePageFunctionalTest  {
 
     private final String registerName = "postcode";
 
-    private final DropwizardAppRule<RegisterConfiguration> appRule = new DropwizardAppRule<>(RegisterApplication.class,
-            ResourceHelpers.resourceFilePath("test-app-config.yaml"),
-            ConfigOverride.config("jerseyClient.timeout", "3000ms"),
-            ConfigOverride.config("register", registerName));
-
     @Rule
-    public TestRule ruleChain = RuleChain.
-            outerRule(new CleanDatabaseRule()).
-            around(appRule);
-
-    private Client client;
-
-    @Before
-    public void beforeEach(){
-        client = createTestClient();
-    }
+    public final RegisterRule register = new RegisterRule(registerName);
 
     @Test
     public void homePageIsAvailableWhenNoDataInRegister() {
-        Response response = getRequest("/");
+        Response response = register.getRequest("/");
         assertThat(response.getStatus(), equalTo(200));
     }
 
     @Test
     public void homepageHasXhtmlLangAttributes() throws Throwable {
-        Response response = getRequest("/");
+        Response response = register.getRequest("/");
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         Elements htmlElement = doc.select("html");
@@ -65,7 +41,7 @@ public class HomePageFunctionalTest  {
     public void homepageHasCopyrightInMainBodyRenderedAsMarkdown() throws Throwable {
         // assumes that registers.yaml has a `postcode` entry with a copyright field containing markdown links
         // might be good to find a way to specify this in the test
-        Response response = getRequest("/");
+        Response response = register.getRequest("/");
         Document doc = Jsoup.parse(response.readEntity(String.class));
 
         Elements copyrightParagraph = doc.select("main .registry-copyright");
@@ -77,21 +53,11 @@ public class HomePageFunctionalTest  {
     public void homepageHasCopyrightInFooterRenderedAsMarkdown() throws Throwable {
         // assumes that registers.yaml has a `postcode` entry with a copyright field containing markdown links
         // might be good to find a way to specify this in the test
-        Response response = getRequest("/");
+        Response response = register.getRequest("/");
         Document doc = Jsoup.parse(response.readEntity(String.class));
 
         Elements copyrightParagraph = doc.select("footer .registry-copyright");
         Elements links = copyrightParagraph.select("a");
         assertThat(links.size(), greaterThan(0));
-    }
-
-    private Response getRequest(String path) {
-        return client.target(String.format("http://localhost:%d%s", appRule.getLocalPort(), path)).request().get();
-    }
-
-    private Client createTestClient() {
-        return new io.dropwizard.client.JerseyClientBuilder(appRule.getEnvironment())
-                .using(appRule.getConfiguration().getJerseyClientConfiguration())
-                .build("test client");
     }
 }

--- a/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
@@ -3,21 +3,26 @@ package uk.gov.register.functional;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.json.JSONException;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+import uk.gov.register.functional.app.RegisterRule;
 
 import javax.ws.rs.core.Response;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ItemResourceFunctionalTest extends FunctionalTestBase {
+public class ItemResourceFunctionalTest {
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
     private static String item1 = "{\"address\":\"6789\",\"street\":\"presley\"}";
     private static String item2 = "{\"address\":\"145678\",\"street\":\"ellis\"}";
 
     @Before
     public void publishTestMessages() throws Throwable {
-        mintItems(item1, item2);
+        register.wipe();
+        register.mintLines(item1, item2);
     }
 
     @Test
@@ -44,5 +49,4 @@ public class ItemResourceFunctionalTest extends FunctionalTestBase {
 
         assertThat(response.getStatus(), equalTo(404));
     }
-
 }

--- a/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
@@ -24,7 +24,7 @@ public class ItemResourceFunctionalTest extends FunctionalTestBase {
     public void jsonRepresentationOfAnItem() throws JSONException {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 
-        Response response = getRequest(String.format("/item/sha-256:%s.json", sha256Hex));
+        Response response = register.getRequest(String.format("/item/sha-256:%s.json", sha256Hex));
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -33,14 +33,14 @@ public class ItemResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void return404ResponseWhenItemNotExist() throws JSONException {
-        Response response = getRequest("/item/sha-256:notExistHexValue");
+        Response response = register.getRequest("/item/sha-256:notExistHexValue");
 
         assertThat(response.getStatus(), equalTo(404));
     }
 
     @Test
     public void return404ResponseWhenItemHexIsNotInProperFormat() throws JSONException {
-        Response response = getRequest("/item/notExistHexValue");
+        Response response = register.getRequest("/item/notExistHexValue");
 
         assertThat(response.getStatus(), equalTo(404));
     }

--- a/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
@@ -3,7 +3,6 @@ package uk.gov.register.functional;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.apache.http.impl.conn.InMemoryDnsResolver;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.JerseyClient;
 import org.glassfish.jersey.client.JerseyClientBuilder;
@@ -25,7 +24,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -52,7 +50,9 @@ public class LoadSerializedFunctionalTest {
     @BeforeClass
     public static void beforeClass() throws InterruptedException {
         System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
-        client = testClient();
+        client = new io.dropwizard.client.JerseyClientBuilder(appRule.getEnvironment())
+                .using(appRule.getConfiguration().getJerseyClientConfiguration())
+                .build("test client");
     }
 
     @Test
@@ -123,18 +123,6 @@ public class LoadSerializedFunctionalTest {
         ClientConfig configuration = new ClientConfig();
         configuration.register(HttpAuthenticationFeature.basic("foo", "bar"));
         return JerseyClientBuilder.createClient(configuration);
-    }
-
-    private static Client testClient() {
-        InMemoryDnsResolver customDnsResolver = new InMemoryDnsResolver();
-        customDnsResolver.add("address.beta.openregister.org", InetAddress.getLoopbackAddress());
-        customDnsResolver.add("postcode.beta.openregister.org", InetAddress.getLoopbackAddress());
-        customDnsResolver.add("register.beta.openregister.org", InetAddress.getLoopbackAddress());
-        customDnsResolver.add("localhost", InetAddress.getLoopbackAddress());
-        return new io.dropwizard.client.JerseyClientBuilder(appRule.getEnvironment())
-                .using(appRule.getConfiguration().getJerseyClientConfiguration())
-                .using(customDnsResolver)
-                .build("test client");
     }
 
     Response getRequest(String path) {

--- a/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
@@ -66,7 +66,7 @@ public class RecordListResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void newRecords_setsAppropriateFilenameForDownload() {
-        Response response = getRequest("address", "/records.json");
+        Response response = getRequest("/records.json");
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString(HttpHeaders.CONTENT_DISPOSITION), containsString("filename=\"address-records.json\""));
     }
@@ -85,7 +85,7 @@ public class RecordListResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void newRecordsPageHasXhtmlLangAttributes() {
-        Response response = getRequest("address", "/records");
+        Response response = getRequest("/records");
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         Elements htmlElement = doc.select("html");
@@ -125,7 +125,7 @@ public class RecordListResourceFunctionalTest extends FunctionalTestBase {
     public void oldFacetedResourceRedirectsToNewResource(){
         Response response = getRequest("/street/ellis.json");
         assertThat(response.getStatus(), equalTo(301));
-        String expectedRedirect = "http://address.beta.openregister.org:" + app.getLocalPort() + "/records/street/ellis";
+        String expectedRedirect = "http://localhost:" + app.getLocalPort() + "/records/street/ellis";
         assertThat(response.getHeaders().get("Location").get(0), equalTo(expectedRedirect));
     }
 }

--- a/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
@@ -7,32 +7,34 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.register.functional.app.RegisterRule;
 
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import java.net.URI;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class RecordListResourceFunctionalTest extends FunctionalTestBase {
+public class RecordListResourceFunctionalTest {
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
+
     @Before
     public void publishTestMessages() {
-        mintItems(
-                "{\"street\":\"ellis\",\"address\":\"12345\"}",
-                "{\"street\":\"presley\",\"address\":\"6789\"}",
-                "{\"street\":\"ellis\",\"address\":\"145678\"}",
-                "{\"street\":\"updatedEllisName\",\"address\":\"145678\"}",
-                "{\"street\":\"ellis\",\"address\":\"6789\"}"
-        );
+        register.wipe();
+        register.mintLines("{\"street\":\"ellis\",\"address\":\"12345\"}", "{\"street\":\"presley\",\"address\":\"6789\"}", "{\"street\":\"ellis\",\"address\":\"145678\"}", "{\"street\":\"updatedEllisName\",\"address\":\"145678\"}", "{\"street\":\"ellis\",\"address\":\"6789\"}");
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void newRecords_shouldReturnAllCurrentVersionsOnly() throws Exception {
-        Response response = getRequest("/records.json");
+        Response response = register.getRequest("/records.json");
 
         Map<String, Map<String, String>> responseMap = response.readEntity(Map.class);
 
@@ -66,26 +68,29 @@ public class RecordListResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void newRecords_setsAppropriateFilenameForDownload() {
-        Response response = getRequest("/records.json");
+        Response response = register.getRequest("/records.json");
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString(HttpHeaders.CONTENT_DISPOSITION), containsString("filename=\"address-records.json\""));
     }
 
     @Test
     public void newRecords_hasLinkHeaderForNextAndPreviousPage() {
-        Response response = getRequest("/records.json?page-index=1&page-size=1");
+        Response response = register.target().path("/records.json").queryParam("page-index",1).queryParam("page-size",1)
+                .request().get();
         assertThat(response.getHeaderString("Link"), equalTo("<?page-index=2&page-size=1>; rel=\"next\""));
 
-        response = getRequest("/records.json?page-index=2&page-size=1");
+        response = register.target().path("/records.json").queryParam("page-index",2).queryParam("page-size",1)
+                .request().get();
         assertThat(response.getHeaderString("Link"), equalTo("<?page-index=3&page-size=1>; rel=\"next\",<?page-index=1&page-size=1>; rel=\"previous\""));
 
-        response = getRequest("/records.json?page-index=3&page-size=1");
+        response = register.target().path("/records.json").queryParam("page-index",3).queryParam("page-size",1)
+                .request().get();
         assertThat(response.getHeaderString("Link"), equalTo("<?page-index=2&page-size=1>; rel=\"previous\""));
     }
 
     @Test
     public void newRecordsPageHasXhtmlLangAttributes() {
-        Response response = getRequest("/records");
+        Response response = register.getRequest("/records");
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         Elements htmlElement = doc.select("html");
@@ -96,8 +101,8 @@ public class RecordListResourceFunctionalTest extends FunctionalTestBase {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void fetchAllRecordsForAKeyValueCombinatiion() throws JSONException {
-        Response response = getRequest("/records/street/ellis.json");
+    public void fetchAllRecordsForAKeyValueCombination() throws JSONException {
+        Response response = register.getRequest("/records/street/ellis.json");
         Map<String, Map<String, String>> responseMap = response.readEntity(Map.class);
 
         assertThat(responseMap.size(), equalTo(2));
@@ -119,14 +124,16 @@ public class RecordListResourceFunctionalTest extends FunctionalTestBase {
                 .put("key", "12345").build()));
     }
 
-
     //Note: tests below will be removed once the old resources are deleted
     @Test
     public void oldFacetedResourceRedirectsToNewResource(){
-        Response response = getRequest("/street/ellis.json");
+        WebTarget target = register.target();
+        target.property("jersey.config.client.followRedirects",false);
+        Response response = target.path("/street/ellis.json").request().get();
         assertThat(response.getStatus(), equalTo(301));
-        String expectedRedirect = "http://localhost:" + app.getLocalPort() + "/records/street/ellis";
-        assertThat(response.getHeaders().get("Location").get(0), equalTo(expectedRedirect));
+        String expectedRedirect = "/records/street/ellis";
+        URI location = URI.create(response.getHeaderString("Location"));
+        assertThat(location.getPath(), equalTo(expectedRedirect));
     }
 }
 

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -27,7 +27,7 @@ public class RecordResourceFunctionalTest extends FunctionalTestBase {
     public void getRecordByKey() throws JSONException, IOException {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 
-        Response response = getRequest("/record/6789.json");
+        Response response = register.getRequest("/record/6789.json");
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -43,22 +43,22 @@ public class RecordResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void recordResource_return404ResponseWhenRecordNotExist() {
-        assertThat(getRequest("/record/5001.json").getStatus(), equalTo(404));
+        assertThat(register.getRequest("/record/5001.json").getStatus(), equalTo(404));
     }
 
     @Test
     public void recordResource_return400ResponseWhenPageSizeIsNotANumber() {
-        assertThat(getRequest("/records?page-size=not-a-number").getStatus(), equalTo(400));
+        assertThat(register.target().path("/records").queryParam("page-size","not-a-number").request().get().getStatus(), equalTo(400));
     }
 
     @Test
     public void recordResource_return400ResponseWhenPageIndexIsNotANumber() {
-        assertThat(getRequest("/records?page-index=not-a-number").getStatus(), equalTo(400));
+        assertThat(register.target().path("/records").queryParam("page-index","not-a-number").request().get().getStatus(), equalTo(400));
     }
 
     @Test
     public void historyResource_returnsHistoryOfARecord() throws IOException {
-        Response response = getRequest("/record/6789/entries.json");
+        Response response = register.getRequest("/record/6789/entries.json");
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -80,6 +80,6 @@ public class RecordResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void historyResource_return404ResponseWhenRecordNotExist() {
-        assertThat(getRequest("/record/5001/entries.json").getStatus(), equalTo(404));
+        assertThat(register.getRequest("/record/5001/entries.json").getStatus(), equalTo(404));
     }
 }

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -5,7 +5,9 @@ import io.dropwizard.jackson.Jackson;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.json.JSONException;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.register.functional.app.RegisterRule;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -14,13 +16,16 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class RecordResourceFunctionalTest extends FunctionalTestBase {
+public class RecordResourceFunctionalTest {
     private final static String item0 = "{\"address\":\"6789\",\"street\":\"elvis\"}";
     private final static String item1 = "{\"address\":\"6789\",\"street\":\"presley\"}";
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
 
     @Before
     public void publishTestMessages() throws Throwable {
-        mintItems(item0, item1, "{\"address\":\"145678\",\"street\":\"ellis\"}");
+        register.wipe();
+        register.mintLines(item0, item1, "{\"address\":\"145678\",\"street\":\"ellis\"}");
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
@@ -30,7 +30,7 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
     @Test
     public void registerJsonShouldContainEntryViewAddressRegister() throws Throwable {
         populateRegisterRegisterEntries();
-        Response addressRecordInRegisterRegisterResponse = getRequest("/record/address.json");
+        Response addressRecordInRegisterRegisterResponse = register.getRequest("/record/address.json");
         assertThat(addressRecordInRegisterRegisterResponse.getStatus(), equalTo(200));
         Map<?,?> addressRecordMapInRegisterRegister = addressRecordInRegisterRegisterResponse.readEntity(Map.class);
         verifyStringIsAnISODate(addressRecordMapInRegisterRegister.get("entry-timestamp").toString());
@@ -42,7 +42,7 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
     public void registerJsonShouldContainEntryViewRegisterRegister() throws Throwable {
         populateAddressRegisterEntries();
 
-        Response registerResourceFromAddressRegisterResponse = getRequest("/register.json");
+        Response registerResourceFromAddressRegisterResponse = register.getRequest("/register.json");
         assertThat(registerResourceFromAddressRegisterResponse.getStatus(), equalTo(200));
 
         Map registerResourceMapFromAddressRegister = registerResourceFromAddressRegisterResponse.readEntity(Map.class);
@@ -59,7 +59,7 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void registerJsonShouldGenerateValidResponseForEmptyDB(){
-        Response registerResourceFromAddressRegisterResponse = getRequest("/register.json");
+        Response registerResourceFromAddressRegisterResponse = register.getRequest("/register.json");
         assertThat(registerResourceFromAddressRegisterResponse.getStatus(), equalTo(200));
 
         Map<String,?> registerResourceMapFromAddressRegister = registerResourceFromAddressRegisterResponse.readEntity(Map.class);

--- a/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
@@ -30,7 +30,7 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
     @Test
     public void registerJsonShouldContainEntryViewAddressRegister() throws Throwable {
         populateRegisterRegisterEntries();
-        Response addressRecordInRegisterRegisterResponse = getRequest("register", "/record/address.json");
+        Response addressRecordInRegisterRegisterResponse = getRequest("/record/address.json");
         assertThat(addressRecordInRegisterRegisterResponse.getStatus(), equalTo(200));
         Map<?,?> addressRecordMapInRegisterRegister = addressRecordInRegisterRegisterResponse.readEntity(Map.class);
         verifyStringIsAnISODate(addressRecordMapInRegisterRegister.get("entry-timestamp").toString());
@@ -42,7 +42,7 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
     public void registerJsonShouldContainEntryViewRegisterRegister() throws Throwable {
         populateAddressRegisterEntries();
 
-        Response registerResourceFromAddressRegisterResponse = getRequest("address", "/register.json");
+        Response registerResourceFromAddressRegisterResponse = getRequest("/register.json");
         assertThat(registerResourceFromAddressRegisterResponse.getStatus(), equalTo(200));
 
         Map registerResourceMapFromAddressRegister = registerResourceFromAddressRegisterResponse.readEntity(Map.class);
@@ -59,7 +59,7 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void registerJsonShouldGenerateValidResponseForEmptyDB(){
-        Response registerResourceFromAddressRegisterResponse = getRequest("address", "/register.json");
+        Response registerResourceFromAddressRegisterResponse = getRequest("/register.json");
         assertThat(registerResourceFromAddressRegisterResponse.getStatus(), equalTo(200));
 
         Map<String,?> registerResourceMapFromAddressRegister = registerResourceFromAddressRegisterResponse.readEntity(Map.class);

--- a/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.jackson.Jackson;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.register.functional.app.RegisterRule;
 import uk.gov.register.functional.db.TestEntry;
 import uk.gov.register.util.ResourceYamlFileReader;
 
@@ -23,8 +26,15 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.core.IsNot.not;
 
-public class RegisterResourceFunctionalTest extends FunctionalTestBase {
+public class RegisterResourceFunctionalTest {
 
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
+
+    @Before
+    public void setup() {
+        register.wipe();
+    }
     private final Map<?,?> expectedAddressRegisterMap = getAddressRegisterMap();
 
     @Test
@@ -71,7 +81,7 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
     }
 
     private void populateAddressRegisterEntries() {
-        dbSupport.publishEntries(ImmutableList.of(
+        FunctionalTestBase.dbSupport.publishEntries(ImmutableList.of(
                 TestEntry.anEntry(1, "{\"name\":\"ellis\",\"address\":\"12345\"}", "12345"),
                 TestEntry.anEntry(2, "{\"name\":\"presley\",\"address\":\"6789\"}", "6789"),
                 TestEntry.anEntry(3, "{\"name\":\"ellis\",\"address\":\"145678\"}", "145678"),
@@ -95,7 +105,7 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
             return TestEntry.anEntry(entryNumber, writeToString(r), Instant.parse(timestampISO), r.get("register").toString());
         }).collect(Collectors.toList());
 
-        dbSupport.publishEntries("register", registerEntries);
+        FunctionalTestBase.dbSupport.publishEntries("register", registerEntries);
     }
 
     private void assertAddressRegisterMapIsEqualTo(Map<?, ?> sutAddressRecordMapInRegisterRegister) {

--- a/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
@@ -28,7 +28,7 @@ public class VerifiableLogResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void getRegisterProof() {
-        Response response = getRequest("/proof/register/" + proofIdentifier);
+        Response response = register.getRequest("/proof/register/" + proofIdentifier);
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -39,7 +39,7 @@ public class VerifiableLogResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void getEntryProof() {
-        Response response = getRequest("/proof/entry/1/5/" + proofIdentifier);
+        Response response = register.getRequest("/proof/entry/1/5/" + proofIdentifier);
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -53,7 +53,7 @@ public class VerifiableLogResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void getConsistencyProof() {
-        Response response = getRequest("/proof/consistency/2/5/" + proofIdentifier);
+        Response response = register.getRequest("/proof/consistency/2/5/" + proofIdentifier);
 
         assertThat(response.getStatus(), equalTo(200));
 

--- a/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
@@ -1,7 +1,9 @@
 package uk.gov.register.functional;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.register.functional.app.RegisterRule;
 
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -13,17 +15,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 
-public class VerifiableLogResourceFunctionalTest extends FunctionalTestBase {
+public class VerifiableLogResourceFunctionalTest {
 
+    @ClassRule
+    public static RegisterRule register = new RegisterRule("address");
     private final String proofIdentifier = "merkle:sha-256";
 
     @Before
     public void publishTestMessages() throws Throwable {
-        mintItems("{\"address\":\"1111\",\"street\":\"elvis\"}",
-                "{\"address\":\"2222\",\"street\":\"presley\"}",
-                "{\"address\":\"3333\",\"street\":\"ellis\"}",
-                "{\"address\":\"4444\",\"street\":\"pretzel\"}",
-                "{\"address\":\"5555\",\"street\":\"elfsley\"}");
+        register.wipe();
+        register.mintLines("{\"address\":\"1111\",\"street\":\"elvis\"}", "{\"address\":\"2222\",\"street\":\"presley\"}", "{\"address\":\"3333\",\"street\":\"ellis\"}", "{\"address\":\"4444\",\"street\":\"pretzel\"}", "{\"address\":\"5555\",\"street\":\"elfsley\"}");
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -1,0 +1,71 @@
+package uk.gov.register.functional.app;
+
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import uk.gov.register.RegisterApplication;
+import uk.gov.register.RegisterConfiguration;
+import uk.gov.register.views.representations.ExtraMediaType;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.client.Entity.entity;
+
+public class RegisterRule implements TestRule {
+    private final WipeDatabaseRule wipeRule;
+    private Client client;
+    private Client authenticatingClient;
+    private DropwizardAppRule<RegisterConfiguration> appRule;
+
+    private TestRule wholeRule;
+
+    public RegisterRule(String register) {
+        this.appRule = new DropwizardAppRule<>(RegisterApplication.class,
+                ResourceHelpers.resourceFilePath("test-app-config.yaml"),
+                ConfigOverride.config("register", register));
+        wipeRule = new WipeDatabaseRule();
+        wholeRule = RuleChain
+                .outerRule(appRule)
+                .around(wipeRule);
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        Statement me = new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                client = clientBuilder().build("test client");
+                authenticatingClient = clientBuilder().build("authenticating client");
+                authenticatingClient.register(HttpAuthenticationFeature.basicBuilder().credentials("foo", "bar").build());
+                base.evaluate();
+            }
+        };
+        return wholeRule.apply(me, description);
+    }
+
+    public void loadRsf(String rsf) {
+        authenticatingClient.target(String.format("http://localhost:%d/load-rsf", appRule.getLocalPort()))
+                .request()
+                .post(entity(rsf, ExtraMediaType.APPLICATION_RSF_TYPE));
+    }
+
+    public Response getRequest(String path) {
+        return client.target(String.format("http://localhost:%d%s", appRule.getLocalPort(), path)).request().get();
+    }
+
+    public void wipe() {
+        wipeRule.before();
+    }
+
+    private JerseyClientBuilder clientBuilder() {
+        return new JerseyClientBuilder(appRule.getEnvironment())
+                .using(appRule.getConfiguration().getJerseyClientConfiguration());
+    }
+}

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -14,6 +14,9 @@ credentials:
   user: foo
   password: bar
 
+jerseyClient:
+  timeout: 3000ms
+
 database:
   driverClass: org.postgresql.Driver
   url: jdbc:postgresql://localhost:5432/ft_openregister_java


### PR DESCRIPTION
This introduces a RegisterRule abstraction and removes the old FunctionalTestBase.  This results in cleaner, easier to understand tests which are written at the right level of abstraction.

See individual commits for details.

The implementation of RegisterRule is a little messy 🙈 but it's for the greater good! :rage1: 