### PR TITLE
migrate database outside of the app itself

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ void startApp() {
 }
 
 void waitForApplicationToStart() {
-    URL target = new URL('http://localhost:9090/')
+    URL target = new URL('http://localhost:9091/healthcheck')
 
     int counter = 0
     boolean appRunning = false
@@ -137,10 +137,10 @@ void stopApp() {
 task(loadSchoolDataForConformance, type: Exec) {
     doFirst{
         exec{
-            executable "$projectDir/drop_schema.sh" args 'src/test/resources/test-app-config.yaml'
+            executable "$projectDir/drop_schema.sh" args 'src/test/resources/conformance-app-config.yaml'
         }
         exec{
-            executable "$projectDir/create_schema.sh" args 'src/test/resources/test-app-config.yaml'
+            executable "$projectDir/create_schema.sh" args 'src/test/resources/conformance-app-config.yaml'
         }
     }
     mustRunAfter startAppForConformance
@@ -204,7 +204,13 @@ task createDeployableBundle(type: Zip) {
     destinationDir file('deployable_bundle') // directory that you want your archive to be placed in
 }
 
-task(run, type: JavaExec, dependsOn: ['classes']) {
+task migrateMainDb(type: JavaExec, dependsOn: ['classes']) {
+    main = 'uk.gov.register.RegisterApplication'
+    classpath = sourceSets.main.runtimeClasspath
+    args = ["db", "migrate", "config.yaml"]
+}
+
+task(run, type: JavaExec, dependsOn: ['classes', 'migrateMainDb']) {
     main = 'uk.gov.register.RegisterApplication'
     classpath = sourceSets.main.runtimeClasspath
     args = ["server", "config.yaml"]

--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -14,6 +14,15 @@ aws s3 cp s3://${CONFIG_BUCKET}/registers.yaml /srv/openregister-java --region e
 aws s3 cp s3://${CONFIG_BUCKET}/fields.yaml /srv/openregister-java --region eu-west-1
 
 docker run \
+    --name=openregister-migrate \
+    --volume /srv/openregister-java:/srv/openregister-java \
+    jstepien/openjdk8 \
+    java \
+      -Xmx"${MAX_JVM_HEAP_SIZE}k" \
+      -Dfile.encoding=UTF-8 \
+      -jar /srv/openregister-java/openregister-java.jar \
+        db migrate /srv/openregister-java/config.yaml
+docker run \
     --detach \
     --name=openregister \
     --publish 80:8080 \
@@ -25,4 +34,5 @@ docker run \
       -Dfile.encoding=UTF-8 \
       -DregistersYaml=/srv/openregister-java/registers.yaml \
       -DfieldsYaml=/srv/openregister-java/fields.yaml \
-      -jar /srv/openregister-java/openregister-java.jar server /srv/openregister-java/config.yaml
+      -jar /srv/openregister-java/openregister-java.jar \
+        server /srv/openregister-java/config.yaml

--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -14,7 +14,7 @@ aws s3 cp s3://${CONFIG_BUCKET}/registers.yaml /srv/openregister-java --region e
 aws s3 cp s3://${CONFIG_BUCKET}/fields.yaml /srv/openregister-java --region eu-west-1
 
 docker run \
-    --name=openregister-migrate \
+    --rm \
     --volume /srv/openregister-java:/srv/openregister-java \
     jstepien/openjdk8 \
     java \

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -16,7 +16,6 @@ import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
-import org.flywaydb.core.Flyway;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.skife.jdbi.v2.DBI;
 import uk.gov.organisation.client.GovukOrganisationClient;
@@ -94,10 +93,6 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
     public void run(RegisterConfiguration configuration, Environment environment) throws Exception {
         DBIFactory dbiFactory = new DBIFactory();
         DBI jdbi = dbiFactory.build(environment, configuration.getDatabase(), "postgres");
-
-        Flyway flyway = configuration.getFlywayFactory().build(configuration.getDatabase().build(environment.metrics(), "flyway_db"));
-        flyway.setBaselineVersionAsString("0");
-        flyway.migrate();
 
         RegistersConfiguration registersConfiguration = new RegistersConfiguration(Optional.ofNullable(System.getProperty("registersYaml")));
         FieldsConfiguration mintFieldsConfiguration = new FieldsConfiguration(Optional.ofNullable(System.getProperty("fieldsYaml")));

--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -84,7 +84,6 @@ public class RegisterConfiguration extends Configuration
     }
 
     public FlywayFactory getFlywayFactory() {
-        flywayFactory.setBaselineOnMigrate(true);
         flywayFactory.setLocations(Collections.singletonList("/sql"));
         flywayFactory.setPlaceholders(Collections.singletonMap("registerName", getRegisterName()));
         flywayFactory.setOutOfOrder(true);

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -70,7 +70,6 @@ public class RegisterRule implements TestRule {
     private void migrateDb() {
         RegisterConfiguration configuration = appRule.getConfiguration();
         Flyway flyway = configuration.getFlywayFactory().build(configuration.getDatabase().build(appRule.getEnvironment().metrics(), "flyway_db"));
-        flyway.setBaselineVersionAsString("0");
         flyway.migrate();
     }
 

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -6,8 +6,6 @@ import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.flywaydb.core.Flyway;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
-import org.junit.rules.ExternalResource;
-import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -21,20 +19,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.client.Entity.entity;
+import static uk.gov.register.functional.db.TestDBSupport.testEntryDAO;
+import static uk.gov.register.functional.db.TestDBSupport.testItemDAO;
+import static uk.gov.register.functional.db.TestDBSupport.testRecordDAO;
 import static uk.gov.register.views.representations.ExtraMediaType.APPLICATION_RSF_TYPE;
 
 public class RegisterRule implements TestRule {
-    private final WipeDatabaseRule wipeRule;
     private DropwizardAppRule<RegisterConfiguration> appRule;
-
-    private class DbSetupRule extends ExternalResource {
-        @Override
-        protected void before() throws Throwable {
-            beforeTest();
-        }
-    }
-
-    private TestRule wholeRule;
 
     private WebTarget authenticatedTarget;
     private Client client;
@@ -43,11 +34,6 @@ public class RegisterRule implements TestRule {
         this.appRule = new DropwizardAppRule<>(RegisterApplication.class,
                 ResourceHelpers.resourceFilePath("test-app-config.yaml"),
                 configOverrides);
-        wipeRule = new WipeDatabaseRule();
-        wholeRule = RuleChain
-                .outerRule(appRule)
-                .around(wipeRule)
-                .around(new DbSetupRule());
     }
 
     private ConfigOverride[] constructOverrides(String register, ConfigOverride[] overrides) {
@@ -59,7 +45,14 @@ public class RegisterRule implements TestRule {
 
     @Override
     public Statement apply(Statement base, Description description) {
-        return wholeRule.apply(base, description);
+        Statement me = new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                beforeTest();
+                base.evaluate();
+            }
+        };
+        return appRule.apply(me, description);
     }
 
     /*
@@ -102,7 +95,9 @@ public class RegisterRule implements TestRule {
     }
 
     public void wipe() {
-        wipeRule.before();
+        testEntryDAO.wipeData();
+        testItemDAO.wipeData();
+        testRecordDAO.wipeData();
     }
 
     private JerseyClientBuilder clientBuilder() {


### PR DESCRIPTION
This changes the app so that it doesn't migrate its own database on app
startup.  This means that whenever the app runs, something else needs to
ensure the database has been migrated appropriately.  There are four
situations:

 - for actual deployment, the start-service.sh script runs the
   migration (using a command I manually tested on an existing EC2 box)
 - for ./run-application, we have an extra gradle task migrateMainDb
 - for functional tests, RegisterRule migrates the database before
   running the tests
 - for conformance tests, there was already the appropriate usage of
   {create,drop}_schema.sh, but the waitForApplicationToStart()
   operation broke because the app didn't return a 200 response on the
   application port when the database hadn't been migrated already.  I
   replaced this with a call to /healthcheck on the admin port instead.

The longer-term goal is to entirely separate application deployment from
database deployment, so that we can have automatic rollbacks for apps
and have a separate deployment pipeline for database migrations.