### PR TITLE
Choose a JVM max heap size derived from the host's total RAM

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -6,6 +6,8 @@ INSTANCE_ID=$(curl 169.254.169.254/2014-11-05/meta-data/instance-id)
 REGISTER_NAME=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Register --region eu-west-1 --query 'Tags[0].Value' --output text)
 ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Environment --region eu-west-1 --query 'Tags[0].Value' --output text)
 CONFIG_BUCKET=openregister.${ENV}.config
+TOTAL_MEMORY=$(awk '($1 == "MemTotal:") { print $2 }' /proc/meminfo)
+MAX_JVM_HEAP_SIZE=$(($TOTAL_MEMORY-512*1024))
 
 aws s3 cp s3://${CONFIG_BUCKET}/${REGISTER_NAME}/openregister/config.yaml /srv/openregister-java --region eu-west-1
 aws s3 cp s3://${CONFIG_BUCKET}/registers.yaml /srv/openregister-java --region eu-west-1
@@ -17,4 +19,10 @@ docker run \
     --publish 80:8080 \
     --restart "unless-stopped" \
     --volume /srv/openregister-java:/srv/openregister-java \
-    jstepien/openjdk8 java -Xmx8g -Dfile.encoding=UTF-8 -DregistersYaml=/srv/openregister-java/registers.yaml -DfieldsYaml=/srv/openregister-java/fields.yaml -jar /srv/openregister-java/openregister-java.jar server /srv/openregister-java/config.yaml
+    jstepien/openjdk8 \
+    java \
+      -Xmx"${MAX_JVM_HEAP_SIZE}k" \
+      -Dfile.encoding=UTF-8 \
+      -DregistersYaml=/srv/openregister-java/registers.yaml \
+      -DfieldsYaml=/srv/openregister-java/fields.yaml \
+      -jar /srv/openregister-java/openregister-java.jar server /srv/openregister-java/config.yaml


### PR DESCRIPTION
This should mean that even though our apps might exhaust the available heap they won't also kill the container they run in. You will get a `java.lang.OutOfMemoryError` exception rather than the JVM dying completely.

This is only really sensible to do given we only run one app container on a given instance; if we start running multiple app containers on the same instance we will probably need to look at using cgroups to limit memory and adjusting the heap size from `/sys/fs/cgroup/memory/memory.limit_in_bytes`.