### PR TITLE
Enhance all the things - make sure that GA events are fired 

### DIFF
--- a/src/main/resources/assets/js/analytics-download-type.js
+++ b/src/main/resources/assets/js/analytics-download-type.js
@@ -1,11 +1,11 @@
 (function(){
-    var elems = document.getElementsByClassName("js-download");
+  var elems = document.getElementsByClassName("js-download");
 
-    setupEventAnalytics(elems, "Data", "download", function(e){
-        return e.target.getAttribute("data-download-type") || "unrecognised";
-    });
+  GOVUK.registers.analytics.setupEvent(elems, "Data", "download", function(e){
+    return e.target.getAttribute("data-download-type") || "unrecognised";
+  });
 
-    setupEventAnalytics(elems, "Data", "download", function(e){
-        return "data-download";
-    });
+  GOVUK.registers.analytics.setupEvent(elems, "Data", "download", function(e){
+    return "data-download";
+  });
 })();

--- a/src/main/resources/assets/js/analytics-external-links.js
+++ b/src/main/resources/assets/js/analytics-external-links.js
@@ -1,14 +1,15 @@
 (function(){
-    var elems = document.getElementsByTagName('a');
-    var filtered = new Array();
+  var elems = document.getElementsByTagName('a');
+  var filtered = new Array();
 
-    for(var j = 0; j < elems.length; j++) {
-        var href = elems[j].getAttribute("href");
-        if (! (href.startsWith("/") || href.startsWith("#") || href.startsWith("mailto:")) ) {
-            filtered.push(elems[j]);
-        }
+  for(var j = 0; j < elems.length; j++) {
+    var href = elems[j].getAttribute("href");
+    if (! (href.startsWith("/") || href.startsWith("#") || href.startsWith("mailto:")) ) {
+      filtered.push(elems[j]);
     }
+  }
 
-    setupEventAnalytics(filtered, "Link", "external", function(e){ return e.target.href; });
+  GOVUK.registers.analytics.setupEvent(filtered, "Link", "external", function(e){ 
+    return e.target.href; 
+  });
 })();
-

--- a/src/main/resources/assets/js/analytics.js
+++ b/src/main/resources/assets/js/analytics.js
@@ -1,32 +1,74 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+var GOVUK = GOVUK || {};
+GOVUK.registers = GOVUK.registers || {};
 
-if (typeof gaTrackingId !== 'undefined') {
-    ga('create', gaTrackingId, 'auto', {
-        'allowLinker': false
-    });
+GOVUK.registers.analytics = (function () {
+  var setupGA, setupEvents, sendPageview, sendEvent;
 
-    ga('send', 'pageview');
-}
+  var trackerId;
+  var isTrackerPresent = function(){
+    return (typeof trackerId !== 'undefined') && (trackerId !== '');
+  };
 
-var setupEventAnalytics = function(elems, category, action, fnLabel){
-    for(var i=0; i < elems.length; i++) {
+  var checkTrackerAndExecute = function(fnToExecute, errorMsg){
+    if(isTrackerPresent()){
+        fnToExecute();
+    } else {
+      console.error("GA tracker not present. " + errorMsg || "");
+    }
+  };
+
+  sendEvent = function(category, action, targetLabel, fnHitCallback){
+    checkTrackerAndExecute(function(){
+      callbackExecuted = false;
+      var executeHitCallback = function () {
+        if (!callbackExecuted) {
+          callbackExecuted = true;
+          fnHitCallback();
+        }
+      }
+      setTimeout(executeHitCallback, 1000);
+
+      ga('send', 'event', category, action, targetLabel, { hitCallback: executeHitCallback });
+    }, "Cannot send event.")
+  };
+
+  sendPageview = function(){
+    checkTrackerAndExecute(function(){
+      ga('send', 'pageview');
+    }, "Cannot send pageview.");
+  };
+
+  setupGA = function(trackingId) {
+    trackerId = trackingId;
+    checkTrackerAndExecute(function(){
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', trackerId, 'auto');
+    }, "Cannot initialise GA.");
+  };
+
+  setupEvent = function(elems, category, action, fnLabel){
+    checkTrackerAndExecute(function(){
+      for(var i=0; i < elems.length; i++) {
         elems[i].addEventListener("click", function(e){
-            var targetLabel = fnLabel(e);
-            console.log("sending event - category: "+ category + " action: "+ action + " label: "+ targetLabel +" target: "+ e.target);
-            ga('send', 'event', category, action, targetLabel);
+          e.preventDefault();
+          var targetLabel = fnLabel(e);
+          sendEvent(category, action, targetLabel, function(){ document.location = e.target.href; });
         }, false);
-    };
-};
+      };
+    }, "Cannot setup event");
+  };
 
-var setupVirtualPageviewAnalytics = function(elems, fnPath){
-    for(var i=0; i < elems.length; i++) {
-        elems[i].addEventListener("click", function(e){
-            var targetPath = fnPath(e);
-            console.log("sending virtual pageview - path: "+targetPath+" target: "+ e.target);
-            ga('send', 'pageview', targetPath);
-        }, false);
-    };
-};
+  return {
+    setupGA: setupGA,
+    setupEvent: setupEvent,
+    sendPageview: sendPageview,
+    sendEvent: sendEvent
+  };
+}());
+
+GOVUK.registers.analytics.setupGA(gaTrackingId);
+GOVUK.registers.analytics.sendPageview();

--- a/src/main/resources/assets/js/analytics.js
+++ b/src/main/resources/assets/js/analytics.js
@@ -25,7 +25,7 @@ GOVUK.registers.analytics = (function () {
           callbackExecuted = true;
           fnHitCallback();
         }
-      }
+      };
       setTimeout(executeHitCallback, 1000);
 
       ga('send', 'event', category, action, targetLabel, { hitCallback: executeHitCallback });


### PR DESCRIPTION
when navigating to external links or downloading the data on all browsers

The problem was that firefox was redirecting before the ga event was sent. The solution is to cancel browser default action, send GA event and then continue (with timeout on GA event). Google analytics: 
https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#knowing_when_the_hit_has_been_sent

https://trello.com/c/8jMQNDqA/488-bug-google-analytics-events-for-download-page-aren-t-tracked-in-firefox-exception-handling