### PR TITLE
Make sure variables (callbackExecuted flag) used in analytics.js codes are not global

### DIFF
--- a/src/main/resources/assets/js/analytics.js
+++ b/src/main/resources/assets/js/analytics.js
@@ -19,7 +19,7 @@ GOVUK.registers.analytics = (function () {
 
   sendEvent = function(category, action, targetLabel, fnHitCallback){
     checkTrackerAndExecute(function(){
-      callbackExecuted = false;
+      var callbackExecuted = false;
       var executeHitCallback = function () {
         if (!callbackExecuted) {
           callbackExecuted = true;


### PR DESCRIPTION
Just a cleanup of GA code, variable used as a flag in GA timeout and callback can be (and should be) local.