### PR TITLE
Serve /entries and /records with `inline` disposition

### DIFF
--- a/src/main/java/uk/gov/register/resources/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/EntryResource.java
@@ -58,7 +58,7 @@ public class EntryResource {
 
     private void setHeaders(StartLimitPagination startLimitPagination) {
         requestContext.resourceExtension().ifPresent(
-                ext -> httpServletResponseAdapter.addContentDispositionHeader(registerPrimaryKey + "-entries." + ext)
+                ext -> httpServletResponseAdapter.addInlineContentDispositionHeader(registerPrimaryKey + "-entries." + ext)
         );
 
         if (startLimitPagination.hasNextPage()) {

--- a/src/main/java/uk/gov/register/resources/HttpServletResponseAdapter.java
+++ b/src/main/java/uk/gov/register/resources/HttpServletResponseAdapter.java
@@ -13,8 +13,8 @@ class HttpServletResponseAdapter {
         this.httpServletResponse = httpServletResponse;
     }
 
-    void addContentDispositionHeader(String fileName) {
-        ContentDisposition contentDisposition = ContentDisposition.type("attachment").fileName(fileName).build();
+    void addInlineContentDispositionHeader(String fileName) {
+        ContentDisposition contentDisposition = ContentDisposition.type("inline").fileName(fileName).build();
         httpServletResponse.addHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString());
     }
 

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -79,7 +79,7 @@ public class RecordResource {
         IndexSizePagination pagination = new IndexSizePagination(pageIndex.map(IntParam::get), pageSize.map(IntParam::get), register.getTotalRecords());
 
         requestContext.resourceExtension().ifPresent(
-                ext -> httpServletResponseAdapter.addContentDispositionHeader(registerPrimaryKey + "-records." + ext)
+                ext -> httpServletResponseAdapter.addInlineContentDispositionHeader(registerPrimaryKey + "-records." + ext)
         );
 
         if (pagination.hasNextPage()) {

--- a/src/test/java/uk/gov/register/resources/HttpServletResponseAdapterTest.java
+++ b/src/test/java/uk/gov/register/resources/HttpServletResponseAdapterTest.java
@@ -20,9 +20,9 @@ public class HttpServletResponseAdapterTest {
     public void addContentDispositionHeader_setsTheContentDispositionHeader() {
         HttpServletResponseAdapter httpServletResponseAdapter = new HttpServletResponseAdapter(httpServletResponse);
 
-        httpServletResponseAdapter.addContentDispositionHeader("foo");
+        httpServletResponseAdapter.addInlineContentDispositionHeader("foo");
 
-        verify(httpServletResponse).addHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"foo\"");
+        verify(httpServletResponse).addHeader(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"foo\"");
     }
 
     @Test


### PR DESCRIPTION
In 4ab4fa32b6b, we added Content-Disposition as a way of controlling
the filename used when downloading data from a register.  Prior to
that commit, if you tried to download
`https://country.register.gov.uk/records.json`, you'd get a file
called `records.json` - afterwards, you got a file called
`country-records.json`.

However, it also had a negative side-effect of forcing download of all
data formats, rather than allowing you to view them in the browser.

I was reading the Content-Disposition RFC (6266) today and I realised
we could set the filename without otherwise changing the browser
behaviour by setting a value of `inline` instead of `attachment`.

Turns out reading the documentation is useful! :grimacing:

I deliberately haven't changed the DataDownloadResource or the RSF
stuff - those (I guess?) should still be `attachment`.