### PR TITLE
extract CorsBundle

### DIFF
--- a/src/main/java/uk/gov/register/filters/CorsBundle.java
+++ b/src/main/java/uk/gov/register/filters/CorsBundle.java
@@ -1,0 +1,28 @@
+package uk.gov.register.filters;
+
+import io.dropwizard.Bundle;
+import io.dropwizard.jetty.MutableServletContextHandler;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlets.CrossOriginFilter;
+
+import javax.servlet.DispatcherType;
+import java.util.EnumSet;
+
+public class CorsBundle implements Bundle {
+    @Override
+    public void initialize(Bootstrap<?> bootstrap) {}
+
+    @Override
+    public void run(Environment environment) {
+        MutableServletContextHandler applicationContext = environment.getApplicationContext();
+        FilterHolder filterHolder = applicationContext
+                .addFilter(CrossOriginFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
+        filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, "*");
+        filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_HEADERS_PARAM, "X-Requested-With,Content-Type,Accept,Origin");
+        filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, "GET,HEAD");
+
+        filterHolder.setInitParameter(CrossOriginFilter.ALLOW_CREDENTIALS_PARAM, "false");
+    }
+}


### PR DESCRIPTION
The code to set up the CrossOriginFilter is pretty generic, in that it
could easily be applied to other projects without modification.  We
can extract this into a Bundle and try to keep the RegisterApplication
smaller.

I hardcoded the specific CORS configuration values for the moment.  If
we ever do extract CorsBundle into a library, we can turn it into a
ConfiguredBundle at that point.