### PR TITLE
Revert "Enhance all the things - make sure that GA events are fired "

### DIFF
--- a/src/main/resources/assets/js/analytics.js
+++ b/src/main/resources/assets/js/analytics.js
@@ -25,7 +25,7 @@ GOVUK.registers.analytics = (function () {
           callbackExecuted = true;
           fnHitCallback();
         }
-      };
+      }
       setTimeout(executeHitCallback, 1000);
 
       ga('send', 'event', category, action, targetLabel, { hitCallback: executeHitCallback });


### PR DESCRIPTION
Reverts openregister/openregister-java#97

This seems to be causing intermittent problems in beta - clicking on the "next page" link results in going to `/undefined`.