### PR TITLE
Add `View this register` link for record pages in the register register

### DIFF
--- a/src/main/resources/templates/record.html
+++ b/src/main/resources/templates/record.html
@@ -11,7 +11,8 @@
             Record:
             <h1 class="entry-header" th:text="${primaryKey}">Record Header</h1>
             <p class="entry-source">A record in the <a href="/"
-                                                       th:text="${friendlyRegisterName}"></a>
+                                                       th:text="${friendlyRegisterName}"></a>.
+                <a th:if="${#bools.isTrue(registerId == 'register')}" th:href="${scheme + '://' + primaryKey + '.' + registerDomain}">View this register.</a>
             </p>
         </div>
         <div class="column-third" th:include="main.html :: attribution"></div>


### PR DESCRIPTION
This should only display in on record pages for the register register.
There are plans to build some kind of RegisterResolver to resolve register URLs
but that will be part of a later pull request.