### PR TITLE
support multiple registers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,13 +204,7 @@ task createDeployableBundle(type: Zip) {
     destinationDir file('deployable_bundle') // directory that you want your archive to be placed in
 }
 
-task migrateMainDb(type: JavaExec, dependsOn: ['classes']) {
-    main = 'uk.gov.register.RegisterApplication'
-    classpath = sourceSets.main.runtimeClasspath
-    args = ["db", "migrate", "config.yaml"]
-}
-
-task(run, type: JavaExec, dependsOn: ['classes', 'migrateMainDb']) {
+task(run, type: JavaExec, dependsOn: ['classes']) {
     main = 'uk.gov.register.RegisterApplication'
     classpath = sourceSets.main.runtimeClasspath
     args = ["server", "config.yaml"]

--- a/build.gradle
+++ b/build.gradle
@@ -137,10 +137,8 @@ void stopApp() {
 task(loadSchoolDataForConformance, type: Exec) {
     doFirst{
         exec{
-            executable "$projectDir/drop_schema.sh" args 'src/test/resources/conformance-app-config.yaml'
-        }
-        exec{
-            executable "$projectDir/create_schema.sh" args 'src/test/resources/conformance-app-config.yaml'
+            executable "$projectDir/drop_schema.sh"
+            args 'http://localhost:9090', 'foo:bar'
         }
     }
     mustRunAfter startAppForConformance

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,23 @@ database:
   properties:
     charSet: UTF-8
 
+otherRegisters:
+  register:
+    database:
+      driverClass: org.postgresql.Driver
+      url: jdbc:postgresql://localhost:5432/register
+      user: postgres
+      password:
+
+      #db connection properties
+      initialSize: 1
+      minSize: 1
+      maxSize: 4
+
+      properties:
+        charSet: UTF-8
+
+
 server:
   registerDefaultExceptionMappers: false
   adminConnectors:

--- a/create_schema.sh
+++ b/create_schema.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -eu
-
-config_file=$1
-
-java -jar build/libs/openregister-java-all.jar db migrate $config_file

--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -14,15 +14,6 @@ aws s3 cp s3://${CONFIG_BUCKET}/registers.yaml /srv/openregister-java --region e
 aws s3 cp s3://${CONFIG_BUCKET}/fields.yaml /srv/openregister-java --region eu-west-1
 
 docker run \
-    --rm \
-    --volume /srv/openregister-java:/srv/openregister-java \
-    jstepien/openjdk8 \
-    java \
-      -Xmx"${MAX_JVM_HEAP_SIZE}k" \
-      -Dfile.encoding=UTF-8 \
-      -jar /srv/openregister-java/openregister-java.jar \
-        db migrate /srv/openregister-java/config.yaml
-docker run \
     --detach \
     --name=openregister \
     --publish 80:8080 \

--- a/drop_schema.sh
+++ b/drop_schema.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
-config_file=$1
+base_uri=$1
+user_pass=$2
 
-java -jar build/libs/openregister-java-all.jar db clean $config_file
+curl -f -s -u $user_pass -XDELETE $base_uri/delete-register-data

--- a/src/main/java/uk/gov/register/AssetsBundleCustomErrorHandler.java
+++ b/src/main/java/uk/gov/register/AssetsBundleCustomErrorHandler.java
@@ -10,8 +10,8 @@ import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.WebContext;
 import org.thymeleaf.resourceresolver.FileResourceResolver;
 import org.thymeleaf.templateresolver.TemplateResolver;
-import uk.gov.register.configuration.RegisterNameConfiguration;
-import uk.gov.register.configuration.RegistersConfiguration;
+import uk.gov.register.core.AllTheRegisters;
+import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.core.RegisterData;
 import uk.gov.register.thymeleaf.ThymeleafResourceResolver;
 
@@ -20,6 +20,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 public class AssetsBundleCustomErrorHandler extends ErrorHandler {
     private final Environment environment;
@@ -54,10 +56,14 @@ public class AssetsBundleCustomErrorHandler extends ErrorHandler {
 
         ServletContext sc = baseRequest.getContext();
         ServiceLocator sl = ((ServletContainer) environment.getJerseyServletContainer()).getApplicationHandler().getServiceLocator();
-        RegistersConfiguration rc = sl.getService(RegistersConfiguration.class);
-        RegisterNameConfiguration rnc = sl.getService(RegisterNameConfiguration.class);
-        String registerId = rnc.getRegisterName();
-        RegisterData rd = rc.getRegisterData(registerId);
+        AllTheRegisters registers = sl.getService(AllTheRegisters.class);
+
+        // FIXME this duplicates RequestContext.getHost() because we can't inject a RequestContext here
+        String host = firstNonNull(request.getHeader("X-Forwarded-Host"),request.getHeader("Host"));
+        String registerId = host.split("\\.")[0];
+        EverythingAboutARegister register = registers.getRegisterByName(registerId);
+
+        RegisterData rd = register.getRegisterData();
         String registerName = registerId.replace('-', ' ');
 
         WebContext wc = new WebContext(request, response, sc,

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -28,6 +28,7 @@ import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.core.PostgresRegister;
 import uk.gov.register.core.Register;
 import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterDataFactory;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.core.UriTemplateRegisterResolver;
@@ -101,8 +102,6 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         Flyway flyway = configuration.getFlywayFactory().build(configuration.getDatabase().build(environment.metrics(), "flyway_db"));
         RegistersConfiguration registersConfiguration = new RegistersConfiguration(Optional.ofNullable(System.getProperty("registersYaml")));
         FieldsConfiguration mintFieldsConfiguration = new FieldsConfiguration(Optional.ofNullable(System.getProperty("fieldsYaml")));
-        RegisterData registerData = registersConfiguration.getRegisterData(configuration.getRegisterName());
-        RegisterFieldsConfiguration registerFieldsConfiguration = new RegisterFieldsConfiguration(registerData);
 
         JerseyEnvironment jersey = environment.jersey();
         DropwizardResourceConfig resourceConfig = jersey.getResourceConfig();
@@ -115,8 +114,8 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(flyway).to(Flyway.class);
                 bind(mintFieldsConfiguration).to(FieldsConfiguration.class);
                 bind(registersConfiguration).to(RegistersConfiguration.class);
-                bind(registerData).to(RegisterData.class);
-                bind(registerFieldsConfiguration).to(RegisterFieldsConfiguration.class);
+                bindFactory(RegisterDataFactory.class).to(RegisterData.class);
+                bindAsContract(RegisterFieldsConfiguration.class);
                 bind(jdbi);
                 bind(new PublicBodiesConfiguration(Optional.ofNullable(System.getProperty("publicBodiesYaml")))).to(PublicBodiesConfiguration.class);
 

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -7,9 +7,6 @@ import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
-import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.flyway.FlywayBundle;
-import io.dropwizard.flyway.FlywayFactory;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
@@ -24,8 +21,8 @@ import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.PublicBodiesConfiguration;
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
 import uk.gov.register.configuration.RegistersConfiguration;
-import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.core.AllTheRegisters;
+import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.core.EverythingAboutARegisterProvider;
 import uk.gov.register.core.PostgresRegister;
 import uk.gov.register.core.Register;
@@ -80,18 +77,6 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         bootstrap.addBundle(new AssetsBundle("/assets"));
         bootstrap.addBundle(new AuthBundle());
         bootstrap.addBundle(new CorsBundle());
-
-        bootstrap.addBundle(new FlywayBundle<RegisterConfiguration>() {
-            @Override
-            public DataSourceFactory getDataSourceFactory(RegisterConfiguration configuration) {
-                return configuration.getDatabase();
-            }
-
-            @Override
-            public FlywayFactory getFlywayFactory(RegisterConfiguration configuration) {
-                return configuration.getFlywayFactory();
-            }
-        });
     }
 
     @Override

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -99,6 +99,8 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         DBIFactory dbiFactory = new DBIFactory();
 
         Flyway flyway = configuration.getFlywayFactory().build(configuration.getDatabase().build(environment.metrics(), "flyway_db"));
+        flyway.migrate();
+
         RegistersConfiguration registersConfiguration = new RegistersConfiguration(Optional.ofNullable(System.getProperty("registersYaml")));
         FieldsConfiguration mintFieldsConfiguration = new FieldsConfiguration(Optional.ofNullable(System.getProperty("fieldsYaml")));
 

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -49,8 +49,6 @@ import uk.gov.register.util.CanonicalJsonMapper;
 import uk.gov.register.util.CanonicalJsonValidator;
 import uk.gov.register.util.ObjectReconstructor;
 import uk.gov.register.views.ViewFactory;
-import uk.gov.verifiablelog.store.memoization.InMemoryPowOfTwoNoLeaves;
-import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
@@ -134,7 +132,6 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);
                 bind(ItemConverter.class).to(ItemConverter.class).in(Singleton.class);
                 bind(GovukOrganisationClient.class).to(GovukOrganisationClient.class).in(Singleton.class);
-                bind(InMemoryPowOfTwoNoLeaves.class).to(MemoizationStore.class).in(Singleton.class);
 
                 bind(PostgresRegister.class).to(Register.class).to(RegisterReadOnly.class);
                 bind(UriTemplateRegisterResolver.class).to(RegisterResolver.class);
@@ -151,7 +148,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
 
         if (configuration.cloudWatchEnvironmentName().isPresent()) {
             ScheduledExecutorService cloudwatch = environment.lifecycle().scheduledExecutorService("cloudwatch").threads(1).build();
-            cloudwatch.scheduleAtFixedRate(new CloudWatchHeartbeater(configuration.cloudWatchEnvironmentName().get(), configuration.getRegisterName()), 0, 10000, TimeUnit.MILLISECONDS);
+            cloudwatch.scheduleAtFixedRate(new CloudWatchHeartbeater(configuration.cloudWatchEnvironmentName().get(), configuration.getDefaultRegisterName()), 0, 10000, TimeUnit.MILLISECONDS);
         }
 
         environment.getApplicationContext().setErrorHandler(new AssetsBundleCustomErrorHandler(environment));

--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -16,11 +16,12 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 public class RegisterConfiguration extends Configuration
         implements AuthenticatorConfiguration,
-        RegisterNameConfiguration,
         RegisterDomainConfiguration,
         RegisterContentPagesConfiguration,
         ResourceConfiguration,
@@ -84,26 +85,30 @@ public class RegisterConfiguration extends Configuration
     @SuppressWarnings("unused")
     private FlywayFactory flywayFactory = new FlywayFactory();
 
+    @Valid
+    @JsonProperty
+    private Map<String, EverythingAboutARegisterFactory> otherRegisters = new HashMap<>();
+
     public DataSourceFactory getDatabase() {
         return database;
     }
 
     public EverythingAboutARegisterFactory getDefaultRegister() {
-        return new EverythingAboutARegisterFactory(getRegisterName(), getDatabase(), flywayFactory);
+        return new EverythingAboutARegisterFactory(getDatabase());
     }
 
     public AllTheRegistersFactory getAllTheRegisters() {
-        return new AllTheRegistersFactory(getDefaultRegister());
+        return new AllTheRegistersFactory(getDefaultRegister(), otherRegisters, getDefaultRegisterName());
     }
 
     public FlywayFactory getFlywayFactory() {
         flywayFactory.setLocations(Collections.singletonList("/sql"));
-        flywayFactory.setPlaceholders(Collections.singletonMap("registerName", getRegisterName()));
+        flywayFactory.setPlaceholders(Collections.singletonMap("registerName", getDefaultRegisterName()));
         flywayFactory.setOutOfOrder(true);
         return flywayFactory;
     }
 
-    public String getRegisterName() {
+    public String getDefaultRegisterName() {
         return register;
     }
 

--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -9,6 +9,8 @@ import uk.gov.organisation.client.GovukClientConfiguration;
 import uk.gov.register.auth.AuthenticatorConfiguration;
 import uk.gov.register.auth.RegisterAuthenticatorFactory;
 import uk.gov.register.configuration.*;
+import uk.gov.register.core.AllTheRegistersFactory;
+import uk.gov.register.core.EverythingAboutARegisterFactory;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -84,6 +86,14 @@ public class RegisterConfiguration extends Configuration
 
     public DataSourceFactory getDatabase() {
         return database;
+    }
+
+    public EverythingAboutARegisterFactory getDefaultRegister() {
+        return new EverythingAboutARegisterFactory(getRegisterName(), getDatabase(), flywayFactory);
+    }
+
+    public AllTheRegistersFactory getAllTheRegisters() {
+        return new AllTheRegistersFactory(getDefaultRegister());
     }
 
     public FlywayFactory getFlywayFactory() {

--- a/src/main/java/uk/gov/register/configuration/RegisterFieldsConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/RegisterFieldsConfiguration.java
@@ -3,11 +3,13 @@ package uk.gov.register.configuration;
 import com.google.common.collect.Lists;
 import uk.gov.register.core.RegisterData;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 
 public class RegisterFieldsConfiguration {
     private final ArrayList<String> registerFields;
 
+    @Inject
     public RegisterFieldsConfiguration(RegisterData registerData) {
         this.registerFields = Lists.newArrayList(registerData.getRegister().getFields());
     }

--- a/src/main/java/uk/gov/register/configuration/RegisterNameConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/RegisterNameConfiguration.java
@@ -1,8 +1,0 @@
-package uk.gov.register.configuration;
-
-import org.jvnet.hk2.annotations.Contract;
-
-@Contract
-public interface RegisterNameConfiguration {
-    String getRegisterName();
-}

--- a/src/main/java/uk/gov/register/core/AllTheRegisters.java
+++ b/src/main/java/uk/gov/register/core/AllTheRegisters.java
@@ -1,6 +1,7 @@
 package uk.gov.register.core;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class AllTheRegisters {
     private EverythingAboutARegister defaultRegister;
@@ -15,4 +16,7 @@ public class AllTheRegisters {
         return otherRegisters.getOrDefault(name, defaultRegister);
     }
 
+    public Stream<EverythingAboutARegister> stream() {
+        return Stream.concat(Stream.of(defaultRegister),otherRegisters.values().stream());
+    }
 }

--- a/src/main/java/uk/gov/register/core/AllTheRegisters.java
+++ b/src/main/java/uk/gov/register/core/AllTheRegisters.java
@@ -1,0 +1,14 @@
+package uk.gov.register.core;
+
+public class AllTheRegisters {
+    private EverythingAboutARegister defaultRegister;
+
+    public AllTheRegisters(EverythingAboutARegister defaultRegister) {
+        this.defaultRegister = defaultRegister;
+    }
+
+    public EverythingAboutARegister getRegisterByName(String name) {
+        return defaultRegister;
+    }
+
+}

--- a/src/main/java/uk/gov/register/core/AllTheRegisters.java
+++ b/src/main/java/uk/gov/register/core/AllTheRegisters.java
@@ -1,14 +1,18 @@
 package uk.gov.register.core;
 
+import java.util.Map;
+
 public class AllTheRegisters {
     private EverythingAboutARegister defaultRegister;
+    private final Map<String, EverythingAboutARegister> otherRegisters;
 
-    public AllTheRegisters(EverythingAboutARegister defaultRegister) {
+    public AllTheRegisters(EverythingAboutARegister defaultRegister, Map<String, EverythingAboutARegister> otherRegisters) {
         this.defaultRegister = defaultRegister;
+        this.otherRegisters = otherRegisters;
     }
 
     public EverythingAboutARegister getRegisterByName(String name) {
-        return defaultRegister;
+        return otherRegisters.getOrDefault(name, defaultRegister);
     }
 
 }

--- a/src/main/java/uk/gov/register/core/AllTheRegistersFactory.java
+++ b/src/main/java/uk/gov/register/core/AllTheRegistersFactory.java
@@ -1,0 +1,17 @@
+package uk.gov.register.core;
+
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.setup.Environment;
+import uk.gov.register.configuration.RegistersConfiguration;
+
+public class AllTheRegistersFactory {
+    private EverythingAboutARegisterFactory defaultRegisterFactory;
+
+    public AllTheRegistersFactory(EverythingAboutARegisterFactory defaultRegisterFactory) {
+        this.defaultRegisterFactory = defaultRegisterFactory;
+    }
+
+    public AllTheRegisters build(DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, Environment environment) {
+        return new AllTheRegisters(defaultRegisterFactory.build(dbiFactory, registersConfiguration, environment));
+    }
+}

--- a/src/main/java/uk/gov/register/core/AllTheRegistersFactory.java
+++ b/src/main/java/uk/gov/register/core/AllTheRegistersFactory.java
@@ -4,14 +4,31 @@ import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.register.configuration.RegistersConfiguration;
 
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+
 public class AllTheRegistersFactory {
     private EverythingAboutARegisterFactory defaultRegisterFactory;
+    private final Map<String, EverythingAboutARegisterFactory> otherRegisters;
+    private final String defaultRegisterName;
 
-    public AllTheRegistersFactory(EverythingAboutARegisterFactory defaultRegisterFactory) {
+    public AllTheRegistersFactory(EverythingAboutARegisterFactory defaultRegisterFactory, Map<String, EverythingAboutARegisterFactory> otherRegisters, String defaultRegisterName) {
         this.defaultRegisterFactory = defaultRegisterFactory;
+        this.otherRegisters = otherRegisters;
+        this.defaultRegisterName = defaultRegisterName;
     }
 
     public AllTheRegisters build(DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, Environment environment) {
-        return new AllTheRegisters(defaultRegisterFactory.build(dbiFactory, registersConfiguration, environment));
+        Map<String, EverythingAboutARegister> builtRegisters = otherRegisters.entrySet().stream().collect(toMap(Map.Entry::getKey,
+                e -> buildRegister(e.getKey(), e.getValue(), dbiFactory, registersConfiguration, environment)));
+        return new AllTheRegisters(
+                defaultRegisterFactory.build(defaultRegisterName, dbiFactory, registersConfiguration, environment),
+                builtRegisters
+        );
+    }
+
+    public EverythingAboutARegister buildRegister(String registerName, EverythingAboutARegisterFactory registerFactory, DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, Environment environment) {
+        return registerFactory.build(registerName, dbiFactory, registersConfiguration, environment);
     }
 }

--- a/src/main/java/uk/gov/register/core/EverythingAboutARegister.java
+++ b/src/main/java/uk/gov/register/core/EverythingAboutARegister.java
@@ -1,0 +1,47 @@
+package uk.gov.register.core;
+
+import org.flywaydb.core.Flyway;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.register.configuration.RegisterFieldsConfiguration;
+import uk.gov.register.configuration.RegistersConfiguration;
+import uk.gov.verifiablelog.store.memoization.MemoizationStore;
+
+public class EverythingAboutARegister {
+    private String registerName;
+    private RegistersConfiguration registersConfiguration;
+    private MemoizationStore memoizationStore;
+    private DBI dbi;
+    private Flyway flyway;
+
+    public EverythingAboutARegister(String registerName, RegistersConfiguration registersConfiguration, MemoizationStore memoizationStore, DBI dbi, Flyway flyway) {
+        this.registerName = registerName;
+        this.registersConfiguration = registersConfiguration;
+        this.memoizationStore = memoizationStore;
+        this.dbi = dbi;
+        this.flyway = flyway;
+    }
+
+    public String getRegisterName() {
+        return registerName;
+    }
+
+    public RegisterFieldsConfiguration getFieldsConfiguration() {
+        return new RegisterFieldsConfiguration(getRegisterData());
+    }
+
+    public RegisterData getRegisterData() {
+        return registersConfiguration.getRegisterData(getRegisterName());
+    }
+
+    public MemoizationStore getMemoizationStore() {
+        return memoizationStore;
+    }
+
+    public DBI getDbi() {
+        return dbi;
+    }
+
+    public Flyway getFlyway() {
+        return flyway;
+    }
+}

--- a/src/main/java/uk/gov/register/core/EverythingAboutARegisterFactory.java
+++ b/src/main/java/uk/gov/register/core/EverythingAboutARegisterFactory.java
@@ -1,29 +1,45 @@
 package uk.gov.register.core;
 
-import io.dropwizard.db.PooledDataSourceFactory;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.flyway.FlywayFactory;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.verifiablelog.store.memoization.InMemoryPowOfTwoNoLeaves;
 
-public class EverythingAboutARegisterFactory {
-    private String registerName;
-    private PooledDataSourceFactory database;
-    private FlywayFactory flywayFactory;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Collections;
 
-    public EverythingAboutARegisterFactory(String registerName, PooledDataSourceFactory database, FlywayFactory flywayFactory) {
-        this.registerName = registerName;
-        this.database = database;
-        this.flywayFactory = flywayFactory;
+public class EverythingAboutARegisterFactory {
+    @Valid
+    @NotNull
+    @JsonProperty
+    private DataSourceFactory database;
+
+    @SuppressWarnings("unused, used by Jackson")
+    public EverythingAboutARegisterFactory() {
     }
 
-    public EverythingAboutARegister build(DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, Environment environment) {
+    public EverythingAboutARegisterFactory(DataSourceFactory database) {
+        this.database = database;
+    }
+
+    private FlywayFactory getFlywayFactory(String registerName) {
+        FlywayFactory flywayFactory = new FlywayFactory();
+        flywayFactory.setLocations(Collections.singletonList("/sql"));
+        flywayFactory.setPlaceholders(Collections.singletonMap("registerName", registerName));
+        flywayFactory.setOutOfOrder(true);
+        return flywayFactory;
+    }
+
+    public EverythingAboutARegister build(String registerName, DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, Environment environment) {
         return new EverythingAboutARegister(
                 registerName,
                 registersConfiguration,
                 new InMemoryPowOfTwoNoLeaves(),
                 dbiFactory.build(environment, database, registerName),
-                flywayFactory.build(database.build(environment.metrics(), registerName + "_flyway")));
+                getFlywayFactory(registerName).build(database.build(environment.metrics(), registerName + "_flyway")));
     }
 }

--- a/src/main/java/uk/gov/register/core/EverythingAboutARegisterFactory.java
+++ b/src/main/java/uk/gov/register/core/EverythingAboutARegisterFactory.java
@@ -1,0 +1,29 @@
+package uk.gov.register.core;
+
+import io.dropwizard.db.PooledDataSourceFactory;
+import io.dropwizard.flyway.FlywayFactory;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.setup.Environment;
+import uk.gov.register.configuration.RegistersConfiguration;
+import uk.gov.verifiablelog.store.memoization.InMemoryPowOfTwoNoLeaves;
+
+public class EverythingAboutARegisterFactory {
+    private String registerName;
+    private PooledDataSourceFactory database;
+    private FlywayFactory flywayFactory;
+
+    public EverythingAboutARegisterFactory(String registerName, PooledDataSourceFactory database, FlywayFactory flywayFactory) {
+        this.registerName = registerName;
+        this.database = database;
+        this.flywayFactory = flywayFactory;
+    }
+
+    public EverythingAboutARegister build(DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, Environment environment) {
+        return new EverythingAboutARegister(
+                registerName,
+                registersConfiguration,
+                new InMemoryPowOfTwoNoLeaves(),
+                dbiFactory.build(environment, database, registerName),
+                flywayFactory.build(database.build(environment.metrics(), registerName + "_flyway")));
+    }
+}

--- a/src/main/java/uk/gov/register/core/EverythingAboutARegisterProvider.java
+++ b/src/main/java/uk/gov/register/core/EverythingAboutARegisterProvider.java
@@ -1,24 +1,29 @@
 package uk.gov.register.core;
 
 import org.glassfish.hk2.api.Factory;
-import uk.gov.register.configuration.RegisterNameConfiguration;
+import org.glassfish.hk2.api.PerLookup;
+import uk.gov.register.resources.RequestContext;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 public class EverythingAboutARegisterProvider implements Factory<EverythingAboutARegister> {
-    private final RegisterNameConfiguration registerNameConfiguration;
     private final AllTheRegisters allTheRegisters;
+    private final Provider<RequestContext> requestContext;
 
     @Inject
-    public EverythingAboutARegisterProvider(RegisterNameConfiguration registerNameConfiguration,
-                                            AllTheRegisters allTheRegisters) {
-        this.registerNameConfiguration = registerNameConfiguration;
+    public EverythingAboutARegisterProvider(AllTheRegisters allTheRegisters,
+                                            Provider<RequestContext> requestContext) {
         this.allTheRegisters = allTheRegisters;
+        this.requestContext = requestContext;
     }
 
     @Override
+    @PerLookup
     public EverythingAboutARegister provide() {
-        return allTheRegisters.getRegisterByName(registerNameConfiguration.getRegisterName());
+        String host = requestContext.get().getHost();
+        String register = host.split("\\.")[0];
+        return allTheRegisters.getRegisterByName(register);
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/EverythingAboutARegisterProvider.java
+++ b/src/main/java/uk/gov/register/core/EverythingAboutARegisterProvider.java
@@ -1,0 +1,28 @@
+package uk.gov.register.core;
+
+import org.glassfish.hk2.api.Factory;
+import uk.gov.register.configuration.RegisterNameConfiguration;
+
+import javax.inject.Inject;
+
+public class EverythingAboutARegisterProvider implements Factory<EverythingAboutARegister> {
+    private final RegisterNameConfiguration registerNameConfiguration;
+    private final AllTheRegisters allTheRegisters;
+
+    @Inject
+    public EverythingAboutARegisterProvider(RegisterNameConfiguration registerNameConfiguration,
+                                            AllTheRegisters allTheRegisters) {
+        this.registerNameConfiguration = registerNameConfiguration;
+        this.allTheRegisters = allTheRegisters;
+    }
+
+    @Override
+    public EverythingAboutARegister provide() {
+        return allTheRegisters.getRegisterByName(registerNameConfiguration.getRegisterName());
+    }
+
+    @Override
+    public void dispose(EverythingAboutARegister instance) {
+
+    }
+}

--- a/src/main/java/uk/gov/register/core/RegisterDataFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterDataFactory.java
@@ -1,24 +1,20 @@
 package uk.gov.register.core;
 
 import org.glassfish.hk2.api.Factory;
-import uk.gov.register.configuration.RegisterNameConfiguration;
-import uk.gov.register.configuration.RegistersConfiguration;
 
 import javax.inject.Inject;
 
 public class RegisterDataFactory implements Factory<RegisterData> {
-    private RegistersConfiguration registersConfiguration;
-    private RegisterNameConfiguration configuration;
+    private final EverythingAboutARegister everythingAboutARegister;
 
     @Inject
-    public RegisterDataFactory(RegistersConfiguration registersConfiguration, RegisterNameConfiguration configuration) {
-        this.registersConfiguration = registersConfiguration;
-        this.configuration = configuration;
+    public RegisterDataFactory(EverythingAboutARegister everythingAboutARegister) {
+        this.everythingAboutARegister = everythingAboutARegister;
     }
 
     @Override
     public RegisterData provide() {
-        return registersConfiguration.getRegisterData(configuration.getRegisterName());
+        return everythingAboutARegister.getRegisterData();
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/RegisterDataFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterDataFactory.java
@@ -3,18 +3,19 @@ package uk.gov.register.core;
 import org.glassfish.hk2.api.Factory;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 public class RegisterDataFactory implements Factory<RegisterData> {
-    private final EverythingAboutARegister everythingAboutARegister;
+    private final Provider<EverythingAboutARegister> everythingAboutARegister;
 
     @Inject
-    public RegisterDataFactory(EverythingAboutARegister everythingAboutARegister) {
+    public RegisterDataFactory(Provider<EverythingAboutARegister> everythingAboutARegister) {
         this.everythingAboutARegister = everythingAboutARegister;
     }
 
     @Override
     public RegisterData provide() {
-        return everythingAboutARegister.getRegisterData();
+        return everythingAboutARegister.get().getRegisterData();
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/RegisterDataFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterDataFactory.java
@@ -1,0 +1,28 @@
+package uk.gov.register.core;
+
+import org.glassfish.hk2.api.Factory;
+import uk.gov.register.configuration.RegisterNameConfiguration;
+import uk.gov.register.configuration.RegistersConfiguration;
+
+import javax.inject.Inject;
+
+public class RegisterDataFactory implements Factory<RegisterData> {
+    private RegistersConfiguration registersConfiguration;
+    private RegisterNameConfiguration configuration;
+
+    @Inject
+    public RegisterDataFactory(RegistersConfiguration registersConfiguration, RegisterNameConfiguration configuration) {
+        this.registersConfiguration = registersConfiguration;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public RegisterData provide() {
+        return registersConfiguration.getRegisterData(configuration.getRegisterName());
+    }
+
+    @Override
+    public void dispose(RegisterData instance) {
+
+    }
+}

--- a/src/main/java/uk/gov/register/resources/DataDownload.java
+++ b/src/main/java/uk/gov/register/resources/DataDownload.java
@@ -1,9 +1,9 @@
 package uk.gov.register.resources;
 
 import io.dropwizard.views.View;
-import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.configuration.ResourceConfiguration;
 import uk.gov.register.core.Entry;
+import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.RegisterDetail;
 import uk.gov.register.core.RegisterReadOnly;
@@ -30,10 +30,10 @@ public class DataDownload {
     private RegisterSerialisationFormatService rsfService;
 
     @Inject
-    public DataDownload(RegisterReadOnly register, ViewFactory viewFactory, RegisterNameConfiguration registerNameConfiguration, ResourceConfiguration resourceConfiguration, RegisterSerialisationFormatService rsfService) {
+    public DataDownload(RegisterReadOnly register, ViewFactory viewFactory, EverythingAboutARegister aboutTheRegister, ResourceConfiguration resourceConfiguration, RegisterSerialisationFormatService rsfService) {
         this.register = register;
         this.viewFactory = viewFactory;
-        this.registerPrimaryKey = registerNameConfiguration.getRegisterName();
+        this.registerPrimaryKey = aboutTheRegister.getRegisterName();
         this.resourceConfiguration = resourceConfiguration;
         this.rsfService = rsfService;
     }

--- a/src/main/java/uk/gov/register/resources/DataUpload.java
+++ b/src/main/java/uk/gov/register/resources/DataUpload.java
@@ -5,8 +5,8 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.core.Entry;
+import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.serialization.RegisterSerialisationFormat;
@@ -33,15 +33,15 @@ public class DataUpload {
     private final RegisterService registerService;
     private final ObjectReconstructor objectReconstructor;
     private final RegisterSerialisationFormatService registerSerialisationFormatService;
-    private RegisterNameConfiguration registerNameConfiguration;
+    private EverythingAboutARegister register;
 
 
     @Inject
-    public DataUpload(RegisterService registerService, ObjectReconstructor objectReconstructor, RegisterSerialisationFormatService registerSerialisationFormatService, RegisterNameConfiguration registerNameConfiguration) {
+    public DataUpload(RegisterService registerService, ObjectReconstructor objectReconstructor, RegisterSerialisationFormatService registerSerialisationFormatService, EverythingAboutARegister register) {
         this.registerService = registerService;
         this.objectReconstructor = objectReconstructor;
         this.registerSerialisationFormatService = registerSerialisationFormatService;
-        this.registerNameConfiguration = registerNameConfiguration;
+        this.register = register;
     }
 
     @Context
@@ -77,7 +77,7 @@ public class DataUpload {
 
     private void mintItem(Register register, AtomicInteger currentEntryNumber, Item item) {
         register.putItem(item);
-        register.appendEntry(new Entry(currentEntryNumber.incrementAndGet(), item.getSha256hex(), Instant.now(), item.getValue(registerNameConfiguration.getRegisterName())));
+        register.appendEntry(new Entry(currentEntryNumber.incrementAndGet(), item.getSha256hex(), Instant.now(), item.getValue(this.register.getRegisterName())));
     }
 }
 

--- a/src/main/java/uk/gov/register/resources/DeleteRegisterDataResource.java
+++ b/src/main/java/uk/gov/register/resources/DeleteRegisterDataResource.java
@@ -1,6 +1,7 @@
 package uk.gov.register.resources;
 
 import org.flywaydb.core.Flyway;
+import uk.gov.register.core.EverythingAboutARegister;
 
 import javax.annotation.security.PermitAll;
 import javax.inject.Inject;
@@ -13,8 +14,8 @@ public class DeleteRegisterDataResource {
     private Flyway flyway;
 
     @Inject
-    public DeleteRegisterDataResource(Flyway flyway) {
-        this.flyway = flyway;
+    public DeleteRegisterDataResource(EverythingAboutARegister everythingAboutARegister) {
+        this.flyway = everythingAboutARegister.getFlyway();
     }
 
     @DELETE

--- a/src/main/java/uk/gov/register/resources/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/EntryResource.java
@@ -1,8 +1,8 @@
 package uk.gov.register.resources;
 
 import io.dropwizard.jersey.params.IntParam;
-import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.core.Entry;
+import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.providers.params.IntegerParam;
 import uk.gov.register.views.AttributionView;
@@ -26,12 +26,12 @@ public class EntryResource {
     private final String registerPrimaryKey;
 
     @Inject
-    public EntryResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext, RegisterNameConfiguration registerNameConfiguration) {
+    public EntryResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext, EverythingAboutARegister aboutThisRegister) {
         this.register = register;
         this.viewFactory = viewFactory;
         this.requestContext = requestContext;
         this.httpServletResponseAdapter = new HttpServletResponseAdapter(requestContext.httpServletResponse);
-        this.registerPrimaryKey = registerNameConfiguration.getRegisterName();
+        this.registerPrimaryKey = aboutThisRegister.getRegisterName();
     }
 
     @GET

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -1,8 +1,8 @@
 package uk.gov.register.resources;
 
 import io.dropwizard.jersey.params.IntParam;
-import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.core.Entry;
+import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.core.Record;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.providers.params.IntegerParam;
@@ -28,12 +28,12 @@ public class RecordResource {
     private final String registerPrimaryKey;
 
     @Inject
-    public RecordResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext, RegisterNameConfiguration registerNameConfiguration) {
+    public RecordResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext, EverythingAboutARegister aboutThisRegister) {
         this.register = register;
         this.viewFactory = viewFactory;
         this.requestContext = requestContext;
         this.httpServletResponseAdapter = new HttpServletResponseAdapter(requestContext.httpServletResponse);
-        registerPrimaryKey = registerNameConfiguration.getRegisterName();
+        registerPrimaryKey = aboutThisRegister.getRegisterName();
     }
 
     @GET

--- a/src/main/java/uk/gov/register/resources/RequestContext.java
+++ b/src/main/java/uk/gov/register/resources/RequestContext.java
@@ -9,6 +9,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Context;
 import java.util.Optional;
 
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+
 @Service
 public class RequestContext implements SchemeContext {
 
@@ -29,6 +31,11 @@ public class RequestContext implements SchemeContext {
     public String getScheme() {
         Optional<String> header = Optional.ofNullable(httpServletRequest.getHeader("X-Forwarded-Proto"));
         return header.orElse(httpServletRequest.getScheme());
+    }
+
+    public String getHost() {
+        return firstNonNull(httpServletRequest.getHeader("X-Forwarded-Host"),
+                httpServletRequest.getHeader("Host"));
     }
 
     public HttpServletRequest getHttpServletRequest() {

--- a/src/main/java/uk/gov/register/resources/SearchResource.java
+++ b/src/main/java/uk/gov/register/resources/SearchResource.java
@@ -1,7 +1,7 @@
 package uk.gov.register.resources;
 
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
-import uk.gov.register.configuration.RegisterNameConfiguration;
+import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.inject.Inject;
@@ -21,8 +21,8 @@ public class SearchResource {
     private final RegisterFieldsConfiguration registerFieldsConfiguration;
 
     @Inject
-    public SearchResource(RegisterNameConfiguration registerNameConfiguration, RegisterFieldsConfiguration registerFieldsConfiguration) {
-        registerPrimaryKey = registerNameConfiguration.getRegisterName();
+    public SearchResource(EverythingAboutARegister aboutThisRegister, RegisterFieldsConfiguration registerFieldsConfiguration) {
+        registerPrimaryKey = aboutThisRegister.getRegisterName();
         this.registerFieldsConfiguration = registerFieldsConfiguration;
     }
 

--- a/src/main/java/uk/gov/register/service/RegisterService.java
+++ b/src/main/java/uk/gov/register/service/RegisterService.java
@@ -2,6 +2,7 @@ package uk.gov.register.service;
 
 import org.skife.jdbi.v2.DBI;
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
+import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.core.PostgresRegister;
 import uk.gov.register.core.Register;
 import uk.gov.register.core.RegisterData;
@@ -19,12 +20,12 @@ public class RegisterService {
     private final RegisterFieldsConfiguration registerFieldsConfiguration;
 
     @Inject
-    public RegisterService(RegisterData registerData, DBI dbi, MemoizationStore memoizationStore, ItemValidator itemValidator, RegisterFieldsConfiguration registerFieldsConfiguration) {
-        this.registerData = registerData;
-        this.dbi = dbi;
-        this.memoizationStore = memoizationStore;
+    public RegisterService(ItemValidator itemValidator, EverythingAboutARegister everythingAboutARegister) {
+        this.registerData = everythingAboutARegister.getRegisterData();
+        this.dbi = everythingAboutARegister.getDbi();
+        this.memoizationStore = everythingAboutARegister.getMemoizationStore();
         this.itemValidator = itemValidator;
-        this.registerFieldsConfiguration = registerFieldsConfiguration;
+        this.registerFieldsConfiguration = everythingAboutARegister.getFieldsConfiguration();
     }
 
     public void asAtomicRegisterOperation(Consumer<Register> callback) {

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
@@ -6,6 +6,7 @@ import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.tweak.HandleCallback;
 import org.skife.jdbi.v2.tweak.HandleConsumer;
 import uk.gov.register.core.Entry;
+import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
 import uk.gov.register.db.*;
@@ -18,9 +19,9 @@ public class PostgresDriverNonTransactional extends PostgresDriver {
     private DBI dbi;
 
     @Inject
-    public PostgresDriverNonTransactional(DBI dbi, MemoizationStore memoizationStore) {
-        super(memoizationStore);
-        this.dbi = dbi;
+    public PostgresDriverNonTransactional(EverythingAboutARegister everythingAboutARegister) {
+        super(everythingAboutARegister.getMemoizationStore());
+        this.dbi = everythingAboutARegister.getDbi();
     }
 
     protected PostgresDriverNonTransactional(DBI dbi, MemoizationStore memoizationStore,

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -11,6 +11,7 @@ import uk.gov.register.service.ItemConverter;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.ws.rs.BadRequestException;
 import java.time.Instant;
 import java.util.Collection;
@@ -23,7 +24,7 @@ public class ViewFactory {
     private final ItemConverter itemConverter;
     private final PublicBodiesConfiguration publicBodiesConfiguration;
     private final GovukOrganisationClient organisationClient;
-    private final RegisterData registerData;
+    private final Provider<RegisterData> registerData;
     private final RegisterDomainConfiguration registerDomainConfiguration;
     private final RegisterContentPages registerContentPages;
     private final RegisterResolver registerResolver;
@@ -36,7 +37,7 @@ public class ViewFactory {
                        GovukOrganisationClient organisationClient,
                        RegisterDomainConfiguration registerDomainConfiguration,
                        RegisterContentPagesConfiguration registerContentPagesConfiguration,
-                       RegisterData registerData,
+                       Provider<RegisterData> registerData,
                        RegisterTrackingConfiguration registerTrackingConfiguration,
                        RegisterResolver registerResolver) {
         this.requestContext = requestContext;
@@ -51,11 +52,11 @@ public class ViewFactory {
     }
 
     public ThymeleafView thymeleafView(String templateName) {
-        return new ThymeleafView(requestContext, templateName, registerData, registerTrackingConfiguration, registerResolver);
+        return new ThymeleafView(requestContext, templateName, registerData.get(), registerTrackingConfiguration, registerResolver);
     }
 
     public BadRequestExceptionView badRequestExceptionView(BadRequestException e) {
-        return new BadRequestExceptionView(requestContext, e, registerData, registerTrackingConfiguration, registerResolver);
+        return new BadRequestExceptionView(requestContext, e, registerData.get(), registerTrackingConfiguration, registerResolver);
     }
 
     public HomePageView homePageView(int totalRecords, int totalEntries, Optional<Instant> lastUpdated) {
@@ -66,50 +67,50 @@ public class ViewFactory {
                 totalRecords,
                 totalEntries,
                 lastUpdated,
-                registerData,
+                registerData.get(),
                 registerContentPages,
                 registerTrackingConfiguration,
                 registerResolver);
     }
 
     public DownloadPageView downloadPageView(Boolean enableDownloadResource) {
-        return new DownloadPageView(requestContext, registerData, enableDownloadResource, registerTrackingConfiguration, registerResolver);
+        return new DownloadPageView(requestContext, registerData.get(), enableDownloadResource, registerTrackingConfiguration, registerResolver);
     }
 
     public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, Optional<Instant> lastUpdated) {
-        return new RegisterDetailView(totalRecords, totalEntries, lastUpdated, registerData, registerDomainConfiguration.getRegisterDomain());
+        return new RegisterDetailView(totalRecords, totalEntries, lastUpdated, registerData.get(), registerDomainConfiguration.getRegisterDomain());
     }
 
     public ItemView getItemView(Item item) {
-        return new ItemView(requestContext, getRegistry(), getBranding(), itemConverter, item, registerData, registerTrackingConfiguration, registerResolver);
+        return new ItemView(requestContext, getRegistry(), getBranding(), itemConverter, item, registerData.get(), registerTrackingConfiguration, registerResolver);
     }
 
     public EntryView getEntryView(Entry entry) {
-        return new EntryView(requestContext, getRegistry(), getBranding(), entry, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryView(requestContext, getRegistry(), getBranding(), entry, registerData.get(), registerTrackingConfiguration, registerResolver);
     }
 
     public EntryListView getEntriesView(Collection<Entry> entries, Pagination pagination) {
-        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, registerData.get(), registerTrackingConfiguration, registerResolver);
     }
 
     public EntryListView getRecordEntriesView(String recordKey, Collection<Entry> entries, Pagination pagination) {
-        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, recordKey, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, recordKey, registerData.get(), registerTrackingConfiguration, registerResolver);
     }
 
     public RecordView getRecordView(Record record) {
-        return new RecordView(requestContext, getRegistry(), getBranding(), itemConverter, record, registerData, registerTrackingConfiguration, registerResolver);
+        return new RecordView(requestContext, getRegistry(), getBranding(), itemConverter, record, registerData.get(), registerTrackingConfiguration, registerResolver);
     }
 
     public RecordListView getRecordListView(List<Record> records, Pagination pagination) {
-        return new RecordListView(requestContext, getRegistry(), getBranding(), pagination, itemConverter, records, registerData, registerTrackingConfiguration, registerResolver);
+        return new RecordListView(requestContext, getRegistry(), getBranding(), pagination, itemConverter, records, registerData.get(), registerTrackingConfiguration, registerResolver);
     }
 
     private PublicBody getRegistry() {
-        return publicBodiesConfiguration.getPublicBody(registerData.getRegister().getRegistry());
+        return publicBodiesConfiguration.getPublicBody(registerData.get().getRegister().getRegistry());
     }
 
     private Optional<GovukOrganisation.Details> getBranding() {
-        Optional<GovukOrganisation> organisation = organisationClient.getOrganisation(registerData.getRegister().getRegistry());
+        Optional<GovukOrganisation> organisation = organisationClient.getOrganisation(registerData.get().getRegister().getRegistry());
         return organisation.map(GovukOrganisation::getDetails);
     }
 }

--- a/src/main/java/uk/gov/register/views/representations/turtle/EntryListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/EntryListTurtleWriter.java
@@ -2,7 +2,6 @@ package uk.gov.register.views.representations.turtle;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.RegisterData;
 import uk.gov.register.core.RegisterResolver;
@@ -20,23 +19,21 @@ import java.util.stream.Collectors;
 @Produces(ExtraMediaType.TEXT_TTL)
 public class EntryListTurtleWriter extends TurtleRepresentationWriter<EntryListView> {
 
-    private RegisterData registerData;
-    private RegisterNameConfiguration registerNameConfiguration;
+    private javax.inject.Provider<RegisterData> registerData;
     private RegisterTrackingConfiguration registerTrackingConfiguration;
 
     @Inject
-    public EntryListTurtleWriter(RequestContext requestContext, RegisterData registerData, RegisterNameConfiguration registerNameConfiguration, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registerNameConfiguration, registerResolver);
+    public EntryListTurtleWriter(RequestContext requestContext, javax.inject.Provider<RegisterData> registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registerData, registerResolver);
         this.registerData = registerData;
-        this.registerNameConfiguration = registerNameConfiguration;
         this.registerTrackingConfiguration = registerTrackingConfiguration;
     }
 
     @Override
     protected Model rdfModelFor(EntryListView view) {
         Model model = ModelFactory.createDefaultModel();
-        for (EntryView entryView : view.getEntries().stream().map(e -> new EntryView(requestContext, view.getRegistry(), view.getBranding(), e, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList())) {
-            model.add(new EntryTurtleWriter(requestContext, registerNameConfiguration, registerResolver).rdfModelFor(entryView));
+        for (EntryView entryView : view.getEntries().stream().map(e -> new EntryView(requestContext, view.getRegistry(), view.getBranding(), e, registerData.get(), registerTrackingConfiguration, registerResolver)).collect(Collectors.toList())) {
+            model.add(new EntryTurtleWriter(requestContext, registerData, registerResolver).rdfModelFor(entryView));
         }
         return model;
     }

--- a/src/main/java/uk/gov/register/views/representations/turtle/EntryTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/EntryTurtleWriter.java
@@ -3,7 +3,7 @@ package uk.gov.register.views.representations.turtle;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
-import uk.gov.register.configuration.RegisterNameConfiguration;
+import uk.gov.register.core.RegisterData;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.views.EntryView;
@@ -18,8 +18,8 @@ import javax.ws.rs.ext.Provider;
 public class EntryTurtleWriter extends TurtleRepresentationWriter<EntryView> {
 
     @Inject
-    public EntryTurtleWriter(RequestContext requestContext, RegisterNameConfiguration registerNameConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registerNameConfiguration, registerResolver);
+    public EntryTurtleWriter(RequestContext requestContext, javax.inject.Provider<RegisterData> registerData, RegisterResolver registerResolver) {
+        super(requestContext, registerData, registerResolver);
     }
 
     @Override

--- a/src/main/java/uk/gov/register/views/representations/turtle/ItemTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/ItemTurtleWriter.java
@@ -4,10 +4,10 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
-import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.core.FieldValue;
 import uk.gov.register.core.LinkValue;
 import uk.gov.register.core.ListValue;
+import uk.gov.register.core.RegisterData;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.views.ItemView;
@@ -25,8 +25,8 @@ import java.util.Map;
 public class ItemTurtleWriter extends TurtleRepresentationWriter<ItemView> {
 
     @Inject
-    public ItemTurtleWriter(RequestContext requestContext, RegisterNameConfiguration registerNameConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registerNameConfiguration, registerResolver);
+    public ItemTurtleWriter(RequestContext requestContext, javax.inject.Provider<RegisterData> registerData, RegisterResolver registerResolver) {
+        super(requestContext, registerData, registerResolver);
     }
 
     @Override

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordListTurtleWriter.java
@@ -2,7 +2,6 @@ package uk.gov.register.views.representations.turtle;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.RegisterData;
 import uk.gov.register.core.RegisterResolver;
@@ -20,23 +19,21 @@ import javax.ws.rs.ext.Provider;
 public class RecordListTurtleWriter extends TurtleRepresentationWriter<RecordListView> {
 
     private final ItemConverter itemConverter;
-    private RegisterData registerData;
-    private RegisterNameConfiguration registerNameConfiguration;
+    private javax.inject.Provider<RegisterData> registerData;
     private RegisterTrackingConfiguration registerTrackingConfiguration;
 
     @Inject
-    public RecordListTurtleWriter(RequestContext requestContext, ItemConverter itemConverter, RegisterData registerData, RegisterNameConfiguration registerNameConfiguration, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registerNameConfiguration, registerResolver);
+    public RecordListTurtleWriter(RequestContext requestContext, ItemConverter itemConverter, javax.inject.Provider<RegisterData> registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registerData, registerResolver);
         this.itemConverter = itemConverter;
         this.registerData = registerData;
-        this.registerNameConfiguration = registerNameConfiguration;
         this.registerTrackingConfiguration = registerTrackingConfiguration;
     }
 
     @Override
     protected Model rdfModelFor(RecordListView view) {
         Model model = ModelFactory.createDefaultModel();
-        view.getRecords().stream().forEach(r -> model.add(new RecordTurtleWriter(requestContext, itemConverter, registerData, registerNameConfiguration, registerTrackingConfiguration, registerResolver).rdfModelFor(r)));
+        view.getRecords().stream().forEach(r -> model.add(new RecordTurtleWriter(requestContext, itemConverter, registerData, registerTrackingConfiguration, registerResolver).rdfModelFor(r)));
         return model;
     }
 }

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
@@ -1,7 +1,6 @@
 package uk.gov.register.views.representations.turtle;
 
 import org.apache.jena.rdf.model.*;
-import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.RegisterData;
 import uk.gov.register.core.RegisterResolver;
@@ -24,28 +23,26 @@ import java.util.Map;
 public class RecordTurtleWriter extends TurtleRepresentationWriter<RecordView> {
 
     private final ItemConverter itemConverter;
-    private RegisterData registerData;
-    private RegisterNameConfiguration registerNameConfiguration;
+    private javax.inject.Provider<RegisterData> registerData;
     private RegisterTrackingConfiguration registerTrackingConfiguration;
 
     @Inject
-    public RecordTurtleWriter(RequestContext requestContext, ItemConverter itemConverter, RegisterData registerData, RegisterNameConfiguration registerNameConfiguration, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registerNameConfiguration, registerResolver);
+    public RecordTurtleWriter(RequestContext requestContext, ItemConverter itemConverter, javax.inject.Provider<RegisterData> registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registerData, registerResolver);
         this.itemConverter = itemConverter;
         this.registerData = registerData;
-        this.registerNameConfiguration = registerNameConfiguration;
         this.registerTrackingConfiguration = registerTrackingConfiguration;
         this.registerResolver = registerResolver;
     }
 
     @Override
     protected Model rdfModelFor(RecordView view) {
-        EntryView entryView = new EntryView(requestContext, view.getRegistry(), view.getBranding(), view.getRecord().entry, registerData, registerTrackingConfiguration, registerResolver);
-        ItemView itemView = new ItemView(requestContext, view.getRegistry(), view.getBranding(), itemConverter, view.getRecord().item, registerData, registerTrackingConfiguration, registerResolver);
+        EntryView entryView = new EntryView(requestContext, view.getRegistry(), view.getBranding(), view.getRecord().entry, registerData.get(), registerTrackingConfiguration, registerResolver);
+        ItemView itemView = new ItemView(requestContext, view.getRegistry(), view.getBranding(), itemConverter, view.getRecord().item, registerData.get(), registerTrackingConfiguration, registerResolver);
 
         Model recordModel = ModelFactory.createDefaultModel();
-        Model entryModel = new EntryTurtleWriter(requestContext, registerNameConfiguration, registerResolver).rdfModelFor(entryView);
-        Model itemModel = new ItemTurtleWriter(requestContext, registerNameConfiguration, registerResolver).rdfModelFor(itemView);
+        Model entryModel = new EntryTurtleWriter(requestContext, registerData, registerResolver).rdfModelFor(entryView);
+        Model itemModel = new ItemTurtleWriter(requestContext, registerData, registerResolver).rdfModelFor(itemView);
 
         Resource recordResource = recordModel.createResource(recordUri(view.getPrimaryKey()).toString());
         addPropertiesToResource(recordResource, entryModel.getResource(entryUri(Integer.toString(entryView.getEntry().getEntryNumber())).toString()));

--- a/src/main/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriter.java
@@ -2,11 +2,12 @@ package uk.gov.register.views.representations.turtle;
 
 import io.dropwizard.views.View;
 import org.apache.jena.rdf.model.Model;
-import uk.gov.register.configuration.RegisterNameConfiguration;
+import uk.gov.register.core.RegisterData;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.views.representations.RepresentationWriter;
 
+import javax.inject.Provider;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -19,13 +20,13 @@ import java.net.URI;
 
 public abstract class TurtleRepresentationWriter<T extends View> extends RepresentationWriter<T> {
     protected static final String SPEC_PREFIX = "https://openregister.github.io/specification/#";
+    private final Provider<RegisterData> register;
     protected RegisterResolver registerResolver;
-    private String registerPrimaryKey;
 
-    protected TurtleRepresentationWriter(RequestContext requestContext, RegisterNameConfiguration registerNameConfiguration, RegisterResolver registerResolver) {
+    protected TurtleRepresentationWriter(RequestContext requestContext, Provider<RegisterData> register, RegisterResolver registerResolver) {
+        this.register = register;
         this.registerResolver = registerResolver;
         this.requestContext = requestContext;
-        this.registerPrimaryKey = registerNameConfiguration.getRegisterName();
     }
 
     @Override
@@ -40,7 +41,7 @@ public abstract class TurtleRepresentationWriter<T extends View> extends Represe
     }
 
     protected URI ourBaseUri() {
-        return registerResolver.baseUriFor(registerPrimaryKey);
+        return registerResolver.baseUriFor(register.get().getRegister().getRegisterName());
     }
 
     protected URI itemUri(String itemHash) {

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -4,8 +4,8 @@ import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.flywaydb.core.Flyway;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -19,13 +19,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.client.Entity.entity;
-import static uk.gov.register.functional.db.TestDBSupport.testEntryDAO;
-import static uk.gov.register.functional.db.TestDBSupport.testItemDAO;
-import static uk.gov.register.functional.db.TestDBSupport.testRecordDAO;
 import static uk.gov.register.views.representations.ExtraMediaType.APPLICATION_RSF_TYPE;
 
 public class RegisterRule implements TestRule {
+    private final WipeDatabaseRule wipeRule;
     private DropwizardAppRule<RegisterConfiguration> appRule;
+
+    private TestRule wholeRule;
 
     private WebTarget authenticatedTarget;
     private Client client;
@@ -34,6 +34,10 @@ public class RegisterRule implements TestRule {
         this.appRule = new DropwizardAppRule<>(RegisterApplication.class,
                 ResourceHelpers.resourceFilePath("test-app-config.yaml"),
                 configOverrides);
+        wipeRule = new WipeDatabaseRule();
+        wholeRule = RuleChain
+                .outerRule(appRule)
+                .around(wipeRule);
     }
 
     private ConfigOverride[] constructOverrides(String register, ConfigOverride[] overrides) {
@@ -48,29 +52,13 @@ public class RegisterRule implements TestRule {
         Statement me = new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                beforeTest();
+                client = clientBuilder().build("test client");
+                authenticatedTarget = client.target("http://localhost:" + appRule.getLocalPort());
+                authenticatedTarget.register(HttpAuthenticationFeature.basicBuilder().credentials("foo", "bar").build());
                 base.evaluate();
             }
         };
-        return appRule.apply(me, description);
-    }
-
-    /*
-     * executed before each test, but after appRule has set up the dropwizard app
-     */
-    private void beforeTest() {
-        client = clientBuilder().build("test client");
-        authenticatedTarget = client.target("http://localhost:" + appRule.getLocalPort());
-        authenticatedTarget.register(HttpAuthenticationFeature.basicBuilder().credentials("foo", "bar").build());
-
-        migrateDb();
-        wipe();
-    }
-
-    private void migrateDb() {
-        RegisterConfiguration configuration = appRule.getConfiguration();
-        Flyway flyway = configuration.getFlywayFactory().build(configuration.getDatabase().build(appRule.getEnvironment().metrics(), "flyway_db"));
-        flyway.migrate();
+        return wholeRule.apply(me, description);
     }
 
     public WebTarget target() {
@@ -98,9 +86,7 @@ public class RegisterRule implements TestRule {
     }
 
     public void wipe() {
-        testEntryDAO.wipeData();
-        testItemDAO.wipeData();
-        testRecordDAO.wipeData();
+        wipeRule.before();
     }
 
     private JerseyClientBuilder clientBuilder() {

--- a/src/test/java/uk/gov/register/resources/DeleteRegisterDataResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/DeleteRegisterDataResourceTest.java
@@ -1,16 +1,9 @@
 package uk.gov.register.resources;
 
-import org.flywaydb.core.Flyway;
-import org.junit.Before;
 import org.junit.Test;
-import uk.gov.register.core.RegisterReadOnly;
-import uk.gov.register.views.HomePageView;
-import uk.gov.register.views.ViewFactory;
+import uk.gov.register.core.EverythingAboutARegister;
 
 import javax.ws.rs.core.Response;
-import java.security.NoSuchAlgorithmException;
-import java.time.Instant;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -20,14 +13,14 @@ public class DeleteRegisterDataResourceTest {
 
     @Test
     public void shouldUseFlywayToDeleteData() throws Exception {
-        Flyway flywayMock = mock(Flyway.class);
-        DeleteRegisterDataResource sutResource = new DeleteRegisterDataResource(flywayMock);
+        EverythingAboutARegister registerMock = mock(EverythingAboutARegister.class, RETURNS_DEEP_STUBS);
+        DeleteRegisterDataResource sutResource = new DeleteRegisterDataResource(registerMock);
 
         Response response = sutResource.deleteRegisterData();
 
         assertThat(response.getStatus(), equalTo(200));
-        verify(flywayMock, times(1)).clean();
-        verify(flywayMock, times(1)).migrate();
+        verify(registerMock.getFlyway(), times(1)).clean();
+        verify(registerMock.getFlyway(), times(1)).migrate();
     }
 }
 

--- a/src/test/java/uk/gov/register/resources/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/SearchResourceTest.java
@@ -5,8 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
-import uk.gov.register.core.RegisterData;
-import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.core.EverythingAboutARegister;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.ws.rs.NotFoundException;
@@ -26,14 +25,13 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class SearchResourceTest {
     SearchResource resource;
-    RegisterData registerData;
     RegisterFieldsConfiguration registerFieldsConfiguration;
+    EverythingAboutARegister thisRegister;
 
     @Before
     public void setUp() throws Exception {
-        RegisterMetadata registerMetadata = mock(RegisterMetadata.class);
-        registerData = mock(RegisterData.class);
-        when(registerData.getRegister()).thenReturn(registerMetadata);
+        thisRegister = mock(EverythingAboutARegister.class);
+        when(thisRegister.getRegisterName()).thenReturn("school");
         registerFieldsConfiguration = mock(RegisterFieldsConfiguration.class);
     }
 
@@ -49,14 +47,14 @@ public class SearchResourceTest {
 
     @Test(expected = NotFoundException.class)
     public void find_doesNotRedirect_whenKeyDoesNotExistAsFieldInRegister() throws Exception {
-        resource = new SearchResource(() -> "school", registerFieldsConfiguration);
+        resource = new SearchResource(thisRegister, registerFieldsConfiguration);
         resource.find("country-name", "United Kingdom");
     }
 
     @Test
     public void find_returns301_whenKeyExistsAsFieldInRegister() throws Exception {
         when(registerFieldsConfiguration.containsField("country-name")).thenReturn(true);
-        resource = new SearchResource(() -> "school", registerFieldsConfiguration);
+        resource = new SearchResource(thisRegister, registerFieldsConfiguration);
 
         Response r = (Response) resource.find("country-name", "United Kingdom");
         assertThat(r.getStatus(), equalTo(301));

--- a/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
@@ -2,6 +2,7 @@ package uk.gov.register.views.representations.turtle;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,6 +40,7 @@ public class TurtleRepresentationWriterTest {
             "link-values", new Field("link-values", "", "address", Cardinality.MANY, ""),
             "string-values", new Field("string-values", "", "", Cardinality.MANY, "")
             );
+    private RegisterData registerData;
 
     @Before
     public void setUp() throws Exception {
@@ -46,6 +48,7 @@ public class TurtleRepresentationWriterTest {
             @Override
             public String getScheme() { return "http"; }
         };
+        registerData = new RegisterData(ImmutableMap.of("register", new TextNode("address")));
 
         FieldsConfiguration fieldsConfiguration = mock(FieldsConfiguration.class);
         when(fieldsConfiguration.getField(anyString())).thenAnswer(invocation -> {
@@ -70,7 +73,7 @@ public class TurtleRepresentationWriterTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        ItemTurtleWriter writer = new ItemTurtleWriter(requestContext, () -> "address", registerResolver);
+        ItemTurtleWriter writer = new ItemTurtleWriter(requestContext, () -> registerData, registerResolver);
         writer.writeTo(itemView, ItemView.class, null, null, null, null, outputStream);
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);
@@ -83,7 +86,7 @@ public class TurtleRepresentationWriterTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        EntryTurtleWriter writer = new EntryTurtleWriter(requestContext, () -> "address", registerResolver);
+        EntryTurtleWriter writer = new EntryTurtleWriter(requestContext, () -> registerData, registerResolver);
         writer.writeTo(entryView, ItemView.class, null, null, null, null, outputStream);
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);
@@ -103,7 +106,7 @@ public class TurtleRepresentationWriterTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        ItemTurtleWriter writer = new ItemTurtleWriter(requestContext, () -> "address", registerResolver);
+        ItemTurtleWriter writer = new ItemTurtleWriter(requestContext, () -> registerData, registerResolver);
         writer.writeTo(itemView, ItemView.class, null, null, null, null, outputStream);
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);
@@ -126,7 +129,7 @@ public class TurtleRepresentationWriterTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        ItemTurtleWriter writer = new ItemTurtleWriter(requestContext, () -> "address", registerResolver);
+        ItemTurtleWriter writer = new ItemTurtleWriter(requestContext, () -> registerData, registerResolver);
         writer.writeTo(itemView, ItemView.class, null, null, null, null, outputStream);
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);

--- a/src/test/resources/conformance-app-config.yaml
+++ b/src/test/resources/conformance-app-config.yaml
@@ -30,3 +30,4 @@ database:
     charSet: UTF-8
 
 enableDownloadResource: true
+enableRegisterDataDelete: true


### PR DESCRIPTION
This introduces a new configuration item `otherRegisters`, which
allows you to specify a map from register names to database
configurations for other registers that this app can serve.

The app decides which register to use on a per-request basis, by
inspecting the X-Forwarded-Host or Host headers, and pulling out the
bit before the first dot.  If it matches a named register in
`otherRegisters`, it serves from that register; otherwise, it serves
from itself.

To do this, there is a new class AllTheRegisters, which allows you to
pick out a register using its getRegisterByName() method.  This
returns an EverythingAboutARegister instance.
EverythingAboutARegister has all the things you need for an individual
register instance - MemoizationStore, DBI, RegisterMetadata, etc.

I also removed RegisterNameConfiguration, as that is no longer a
globally unique thing.  You now need to inject
EverythingAboutARegister or RegisterData and get the name from that.

All this code was just a first attempt and a proof-of-concept.  Here
are some outstanding questions:

 - what's our strategy to move forward with this?  do we want to
   deploy this to multiple environments?
 - do we want to stick with the "default register" model? I did this
   so that we could make a forwards-compatible change to the
   configuration file format, but should we ensure that each register
   is explicitly called?
 - have we got the right abstractions here?  Is
   EverythingAboutARegister really duplicating the responsibility that
   PostgresRegister already has?  Should those two classes be merged?
 - what's going on with all this dependency injection stuff? Can we
   simplify it, by getting rid of some of the `Factory<>`s and
   `Provider<>`s?

I've tested this locally, manually, but there are some bits I haven't
tested:

 - I haven't tested proofs, to ensure that the MemoizationStores are
   truly isolated from each other
