### PR TITLE
Use batching for inserts. Keep limited debug statements. Do not write…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,3 +34,4 @@ logging:
   # Logger-specific levels.
   loggers:
     "uk.gov": DEBUG
+    "org.skife.jdbi.v2": TRACE

--- a/config.yaml
+++ b/config.yaml
@@ -24,7 +24,7 @@ register: school
 
 enableDownloadResource: true
 
-historyPageUrl: https://registers-history.herokuapp.com/country
+historyPageUrl: https://registers-history.herokuapp.com/school-eng
 
 # Logging settings.
 logging:

--- a/src/main/java/uk/gov/register/db/CurrentKeysUpdateDAO.java
+++ b/src/main/java/uk/gov/register/db/CurrentKeysUpdateDAO.java
@@ -4,6 +4,7 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 import org.skife.jdbi.v2.unstable.BindIn;
 
@@ -12,9 +13,11 @@ public interface CurrentKeysUpdateDAO {
     String CURRENT_KEYS_TABLE = "current_keys";
 
     @SqlBatch("delete from " + CURRENT_KEYS_TABLE + " where key = :key")
+    @BatchChunkSize(1000)
     int[] removeRecordWithKeys(@Bind("key") Iterable<String> allKeys);
 
     @SqlBatch("insert into " + CURRENT_KEYS_TABLE + "(entry_number, key) values(:entry_number, :key)")
+    @BatchChunkSize(1000)
     void writeCurrentKeys(@BindBean Iterable<CurrentKey> values);
 
     @SqlUpdate("update total_records set count=count+:noOfNewRecords")

--- a/src/main/java/uk/gov/register/db/EntryDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryDAO.java
@@ -1,11 +1,13 @@
 package uk.gov.register.db;
 
 import org.skife.jdbi.v2.sqlobject.*;
+import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 import uk.gov.register.core.Entry;
 import uk.gov.register.store.postgres.BindEntry;
 
 public interface EntryDAO {
     @SqlBatch("insert into entry(entry_number, sha256hex, timestamp, key) values(:entry_number, :sha256hex, :timestampAsLong, :key)")
+    @BatchChunkSize(1000)
     void insertInBatch(@BindEntry Iterable<Entry> entries);
 
     @SqlQuery("select value from current_entry_number")

--- a/src/main/java/uk/gov/register/db/ItemDAO.java
+++ b/src/main/java/uk/gov/register/db/ItemDAO.java
@@ -1,10 +1,12 @@
 package uk.gov.register.db;
 
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
+import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 import uk.gov.register.core.Item;
 import uk.gov.register.store.postgres.BindItem;
 
 public interface ItemDAO {
     @SqlBatch("insert into item(sha256hex, content) values(:sha256hex, :content) on conflict do nothing")
+    @BatchChunkSize(1000)
     void insertInBatch(@BindItem Iterable<Item> items);
 }

--- a/src/main/java/uk/gov/register/resources/DeleteRegisterDataResource.java
+++ b/src/main/java/uk/gov/register/resources/DeleteRegisterDataResource.java
@@ -23,7 +23,6 @@ public class DeleteRegisterDataResource {
     @DataDeleteNotAllowed
     public Response deleteRegisterData() {
         flyway.clean();
-        flyway.setBaselineVersionAsString("0");
         flyway.migrate();
         return Response.status(200).entity("Data has been deleted").build();
     }

--- a/src/main/java/uk/gov/register/resources/RegisterCommandReader.java
+++ b/src/main/java/uk/gov/register/resources/RegisterCommandReader.java
@@ -39,10 +39,12 @@ public class RegisterCommandReader implements MessageBodyReader<RegisterSerialis
     }
 
     private RegisterSerialisationFormat parseCommands(InputStream commandStream) {
+        LOG.debug("reading commands");
         BufferedReader buffer = new BufferedReader(new InputStreamReader(commandStream));
         final CommandParser parser = new CommandParser();
         buffer.lines().forEach(s -> parser.addCommand(s));
         Iterator<RegisterCommand> commands = parser.getCommands();
+        LOG.debug("finished reading commands");
         // don't close the reader as the caller will close the input stream
         return new RegisterSerialisationFormat(commands);
 

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
@@ -99,7 +99,7 @@ public abstract class PostgresDriver implements BackingStoreDriver {
 
     @Override
     public int getTotalEntries() {
-        return withHandleRead(handle -> entryQueryDAOFromHandle.apply(handle).getTotalEntries());
+        return withHandle(handle -> entryQueryDAOFromHandle.apply(handle).getTotalEntries());
     }
 
     @Override
@@ -178,8 +178,6 @@ public abstract class PostgresDriver implements BackingStoreDriver {
     protected abstract void useHandle(HandleConsumer callback);
 
     protected abstract <ReturnType> ReturnType withHandle(HandleCallback<ReturnType> callback);
-
-    protected abstract <ReturnType> ReturnType withHandleRead(HandleCallback<ReturnType> callback);
 
     protected abstract <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback);
 }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
@@ -99,7 +99,7 @@ public abstract class PostgresDriver implements BackingStoreDriver {
 
     @Override
     public int getTotalEntries() {
-        return withHandle(handle -> entryQueryDAOFromHandle.apply(handle).getTotalEntries());
+        return withHandleRead(handle -> entryQueryDAOFromHandle.apply(handle).getTotalEntries());
     }
 
     @Override
@@ -178,6 +178,8 @@ public abstract class PostgresDriver implements BackingStoreDriver {
     protected abstract void useHandle(HandleConsumer callback);
 
     protected abstract <ReturnType> ReturnType withHandle(HandleCallback<ReturnType> callback);
+
+    protected abstract <ReturnType> ReturnType withHandleRead(HandleCallback<ReturnType> callback);
 
     protected abstract <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback);
 }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
@@ -57,11 +57,6 @@ public class PostgresDriverNonTransactional extends PostgresDriver {
     }
 
     @Override
-    protected <ReturnType> ReturnType withHandleRead(HandleCallback<ReturnType> callback) {
-        return dbi.withHandle(callback);
-    }
-
-    @Override
     protected <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback) {
         return dbi.inTransaction((handle, status) -> callback.withHandle(handle));
     }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
@@ -57,6 +57,11 @@ public class PostgresDriverNonTransactional extends PostgresDriver {
     }
 
     @Override
+    protected <ReturnType> ReturnType withHandleRead(HandleCallback<ReturnType> callback) {
+        return dbi.withHandle(callback);
+    }
+
+    @Override
     protected <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback) {
         return dbi.inTransaction((handle, status) -> callback.withHandle(handle));
     }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
@@ -122,6 +122,11 @@ public class PostgresDriverTransactional extends PostgresDriver {
     }
 
     @Override
+    protected <ReturnType> ReturnType withHandleRead(HandleCallback<ReturnType> callback) {
+        return readDataUsingExistingHandle(callback);
+    }
+
+    @Override
     protected <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback) {
         return writeDataUsingExistingHandle(callback);
     }
@@ -137,6 +142,14 @@ public class PostgresDriverTransactional extends PostgresDriver {
     private <ReturnType> ReturnType writeDataUsingExistingHandle(HandleCallback<ReturnType> callback) {
         try {
             writeStagedData();
+            return callback.withHandle(handle);
+        } catch (Exception ex) {
+            throw new CallbackFailedException(ex);
+        }
+    }
+
+    private <ReturnType> ReturnType readDataUsingExistingHandle(HandleCallback<ReturnType> callback) {
+        try {
             return callback.withHandle(handle);
         } catch (Exception ex) {
             throw new CallbackFailedException(ex);

--- a/src/main/java/uk/gov/register/views/AttributionView.java
+++ b/src/main/java/uk/gov/register/views/AttributionView.java
@@ -12,24 +12,24 @@ import java.util.Optional;
 
 public class AttributionView extends ThymeleafView {
 
-    private final PublicBody custodian;
+    private final PublicBody registry;
 
-    private final Optional<GovukOrganisation.Details> custodianBranding;
+    private final Optional<GovukOrganisation.Details> registryBranding;
 
-    public AttributionView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+    public AttributionView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
         super(requestContext, templateName, registerData, registerTrackingConfiguration, registerResolver);
-        this.custodian = custodian;
-        this.custodianBranding = custodianBranding;
+        this.registry = registry;
+        this.registryBranding = registryBranding;
     }
 
     @SuppressWarnings("unused, used by templates")
-    public PublicBody getCustodian() {
-        return custodian;
+    public PublicBody getRegistry() {
+        return registry;
     }
 
     @SuppressWarnings("unused, used by templates")
     public Optional<GovukOrganisation.Details> getBranding() {
-        return custodianBranding;
+        return registryBranding;
     }
 }
 

--- a/src/main/java/uk/gov/register/views/CsvRepresentationView.java
+++ b/src/main/java/uk/gov/register/views/CsvRepresentationView.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 
 public abstract class CsvRepresentationView<T> extends AttributionView {
 
-    public CsvRepresentationView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, templateName, registerData, registerTrackingConfiguration, registerResolver);
+    public CsvRepresentationView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, registryBranding, templateName, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public abstract CsvRepresentation<T> csvRepresentation();

--- a/src/main/java/uk/gov/register/views/EntryListView.java
+++ b/src/main/java/uk/gov/register/views/EntryListView.java
@@ -19,15 +19,15 @@ public class EntryListView extends CsvRepresentationView {
     private Collection<Entry> entries;
     private final Optional<String> recordKey;
 
-    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Collection<Entry> entries, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext,custodian, custodianBranding, "entries.html", registerData, registerTrackingConfiguration, registerResolver);
+    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Collection<Entry> entries, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext,registry, registryBranding, "entries.html", registerData, registerTrackingConfiguration, registerResolver);
         this.pagination = pagination;
         this.entries = entries;
         this.recordKey = Optional.empty();
     }
 
-    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Collection<Entry> entries, String recordKey, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, "entries.html", registerData, registerTrackingConfiguration, registerResolver);
+    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Collection<Entry> entries, String recordKey, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, registryBranding, "entries.html", registerData, registerTrackingConfiguration, registerResolver);
         this.pagination = pagination;
         this.entries = entries;
         this.recordKey = Optional.of(recordKey);

--- a/src/main/java/uk/gov/register/views/EntryView.java
+++ b/src/main/java/uk/gov/register/views/EntryView.java
@@ -15,8 +15,8 @@ import java.util.Optional;
 public class EntryView extends CsvRepresentationView<Entry> {
     private Entry entry;
 
-    public EntryView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Entry entry, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, "entry.html", registerData, registerTrackingConfiguration, registerResolver);
+    public EntryView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Entry entry, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, registryBranding, "entry.html", registerData, registerTrackingConfiguration, registerResolver);
         this.entry = entry;
     }
 

--- a/src/main/java/uk/gov/register/views/HomePageView.java
+++ b/src/main/java/uk/gov/register/views/HomePageView.java
@@ -26,8 +26,8 @@ public class HomePageView extends AttributionView {
     private final RegisterContentPages registerContentPages;
 
     public HomePageView(
-            PublicBody custodian,
-            Optional<GovukOrganisation.Details> custodianBranding,
+            PublicBody registry,
+            Optional<GovukOrganisation.Details> registryBranding,
             RequestContext requestContext,
             int totalRecords,
             int totalEntries,
@@ -35,7 +35,7 @@ public class HomePageView extends AttributionView {
             RegisterData registerData,
             RegisterContentPages registerContentPages,
             RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, "home.html", registerData, registerTrackingConfiguration, registerResolver);
+        super(requestContext, registry, registryBranding, "home.html", registerData, registerTrackingConfiguration, registerResolver);
         this.totalRecords = totalRecords;
         this.totalEntries = totalEntries;
         this.lastUpdated = lastUpdated;

--- a/src/main/java/uk/gov/register/views/ItemView.java
+++ b/src/main/java/uk/gov/register/views/ItemView.java
@@ -20,8 +20,8 @@ public class ItemView extends CsvRepresentationView {
     private ItemConverter itemConverter;
     private Item item;
 
-    public ItemView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Item item, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, branding, "item.html", registerData, registerTrackingConfiguration, registerResolver);
+    public ItemView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Item item, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, branding, "item.html", registerData, registerTrackingConfiguration, registerResolver);
         this.itemConverter = itemConverter;
         this.item = item;
     }

--- a/src/main/java/uk/gov/register/views/RecordListView.java
+++ b/src/main/java/uk/gov/register/views/RecordListView.java
@@ -26,8 +26,8 @@ public class RecordListView extends CsvRepresentationView {
     private ItemConverter itemConverter;
     private List<Record> records;
 
-    public RecordListView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Pagination pagination, ItemConverter itemConverter, List<Record> records, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, "records.html", registerData, registerTrackingConfiguration, registerResolver);
+    public RecordListView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, Pagination pagination, ItemConverter itemConverter, List<Record> records, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, branding, "records.html", registerData, registerTrackingConfiguration, registerResolver);
         this.pagination = pagination;
         this.itemConverter = itemConverter;
         this.records = records;
@@ -42,7 +42,7 @@ public class RecordListView extends CsvRepresentationView {
     }
 
     public List<RecordView> getRecords() {
-        return records.stream().map(r -> new RecordView(requestContext, getCustodian(), getBranding(), itemConverter, r, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList());
+        return records.stream().map(r -> new RecordView(requestContext, getRegistry(), getBranding(), itemConverter, r, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList());
     }
 
     public Pagination getPagination() {

--- a/src/main/java/uk/gov/register/views/RecordView.java
+++ b/src/main/java/uk/gov/register/views/RecordView.java
@@ -24,8 +24,8 @@ public class RecordView extends CsvRepresentationView {
     private ItemConverter itemConverter;
     private final Record record;
 
-    public RecordView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, ItemConverter itemConverter, Record record, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, "record.html", registerData, registerTrackingConfiguration, registerResolver);
+    public RecordView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Record record, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, branding, "record.html", registerData, registerTrackingConfiguration, registerResolver);
         this.itemConverter = itemConverter;
         this.record = record;
         this.registerPrimaryKey = registerData.getRegister().getRegisterName();

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -60,7 +60,7 @@ public class ViewFactory {
 
     public HomePageView homePageView(int totalRecords, int totalEntries, Optional<Instant> lastUpdated) {
         return new HomePageView(
-                getCustodian(),
+                getRegistry(),
                 getBranding(),
                 requestContext,
                 totalRecords,
@@ -81,30 +81,30 @@ public class ViewFactory {
     }
 
     public ItemView getItemView(Item item) {
-        return new ItemView(requestContext, getCustodian(), getBranding(), itemConverter, item, registerData, registerTrackingConfiguration, registerResolver);
+        return new ItemView(requestContext, getRegistry(), getBranding(), itemConverter, item, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public EntryView getEntryView(Entry entry) {
-        return new EntryView(requestContext, getCustodian(), getBranding(), entry, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryView(requestContext, getRegistry(), getBranding(), entry, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public EntryListView getEntriesView(Collection<Entry> entries, Pagination pagination) {
-        return new EntryListView(requestContext, pagination, getCustodian(), getBranding(), entries, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public EntryListView getRecordEntriesView(String recordKey, Collection<Entry> entries, Pagination pagination) {
-        return new EntryListView(requestContext, pagination, getCustodian(), getBranding(), entries, recordKey, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, recordKey, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public RecordView getRecordView(Record record) {
-        return new RecordView(requestContext, getCustodian(), getBranding(), itemConverter, record, registerData, registerTrackingConfiguration, registerResolver);
+        return new RecordView(requestContext, getRegistry(), getBranding(), itemConverter, record, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public RecordListView getRecordListView(List<Record> records, Pagination pagination) {
-        return new RecordListView(requestContext, getCustodian(), getBranding(), pagination, itemConverter, records, registerData, registerTrackingConfiguration, registerResolver);
+        return new RecordListView(requestContext, getRegistry(), getBranding(), pagination, itemConverter, records, registerData, registerTrackingConfiguration, registerResolver);
     }
 
-    private PublicBody getCustodian() {
+    private PublicBody getRegistry() {
         return publicBodiesConfiguration.getPublicBody(registerData.getRegister().getRegistry());
     }
 

--- a/src/main/java/uk/gov/register/views/representations/turtle/EntryListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/EntryListTurtleWriter.java
@@ -35,7 +35,7 @@ public class EntryListTurtleWriter extends TurtleRepresentationWriter<EntryListV
     @Override
     protected Model rdfModelFor(EntryListView view) {
         Model model = ModelFactory.createDefaultModel();
-        for (EntryView entryView : view.getEntries().stream().map(e -> new EntryView(requestContext, view.getCustodian(), view.getBranding(), e, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList())) {
+        for (EntryView entryView : view.getEntries().stream().map(e -> new EntryView(requestContext, view.getRegistry(), view.getBranding(), e, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList())) {
             model.add(new EntryTurtleWriter(requestContext, registerNameConfiguration, registerResolver).rdfModelFor(entryView));
         }
         return model;

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
@@ -40,8 +40,8 @@ public class RecordTurtleWriter extends TurtleRepresentationWriter<RecordView> {
 
     @Override
     protected Model rdfModelFor(RecordView view) {
-        EntryView entryView = new EntryView(requestContext, view.getCustodian(), view.getBranding(), view.getRecord().entry, registerData, registerTrackingConfiguration, registerResolver);
-        ItemView itemView = new ItemView(requestContext, view.getCustodian(), view.getBranding(), itemConverter, view.getRecord().item, registerData, registerTrackingConfiguration, registerResolver);
+        EntryView entryView = new EntryView(requestContext, view.getRegistry(), view.getBranding(), view.getRecord().entry, registerData, registerTrackingConfiguration, registerResolver);
+        ItemView itemView = new ItemView(requestContext, view.getRegistry(), view.getBranding(), itemConverter, view.getRecord().item, registerData, registerTrackingConfiguration, registerResolver);
 
         Model recordModel = ModelFactory.createDefaultModel();
         Model entryModel = new EntryTurtleWriter(requestContext, registerNameConfiguration, registerResolver).rdfModelFor(entryView);

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -11,7 +11,7 @@
             <div class="homepage-intro" th:utext="${registerText}">The register of UK government registers.</div>
             <dl class="primary-metadata">
                 <dt>Managed by:</dt>
-                <dd><th:block th:include="main.html :: organisation(${custodian}, ${branding})"></th:block></dd>
+                <dd><th:block th:include="main.html :: organisation(${registry}, ${branding})"></th:block></dd>
                 <dt>Total records:</dt>
                 <dd><a href="/records"><th:block th:text="${totalRecords}">Total</th:block><span class="visuallyhidden"> records</span></a></dd>
                 <dt>Total entries:</dt>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -54,7 +54,7 @@
 <div th:fragment="attribution">
     <div class="organisation">
         <span class="managed-by">Managed by:</span>
-        <th:block th:include="main.html::organisation(${custodian}, ${branding})"></th:block>
+        <th:block th:include="main.html::organisation(${registry}, ${branding})"></th:block>
     </div>
 </div>
 


### PR DESCRIPTION
… staged changes before reading entries count.

The new register transaction code means that after parsing the RSF into commands all item and entry objects are held in memory and after validation they are written to the database. We run out of memory if the collections of items/entries are inserted as a single batch. Adding the BatchChunkSize annotation allows the insertion to be done in batches within a single transaction.

When Entries are created we need to calculate the entry number which is the maximum entry number of existing entries either in the database or in memory. Previously we wrote all staged items/entries to the database before reading the maximum entry number. This resulted in an interaction with the DB every time. I've added a method to read from the db without writing staged item/entries first and used that to get the total number of entries. 