### PR TITLE
Change "custodian" to "registry"

### DIFF
--- a/src/main/java/uk/gov/register/views/AttributionView.java
+++ b/src/main/java/uk/gov/register/views/AttributionView.java
@@ -12,24 +12,24 @@ import java.util.Optional;
 
 public class AttributionView extends ThymeleafView {
 
-    private final PublicBody custodian;
+    private final PublicBody registry;
 
-    private final Optional<GovukOrganisation.Details> custodianBranding;
+    private final Optional<GovukOrganisation.Details> registryBranding;
 
-    public AttributionView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+    public AttributionView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
         super(requestContext, templateName, registerData, registerTrackingConfiguration, registerResolver);
-        this.custodian = custodian;
-        this.custodianBranding = custodianBranding;
+        this.registry = registry;
+        this.registryBranding = registryBranding;
     }
 
     @SuppressWarnings("unused, used by templates")
-    public PublicBody getCustodian() {
-        return custodian;
+    public PublicBody getRegistry() {
+        return registry;
     }
 
     @SuppressWarnings("unused, used by templates")
     public Optional<GovukOrganisation.Details> getBranding() {
-        return custodianBranding;
+        return registryBranding;
     }
 }
 

--- a/src/main/java/uk/gov/register/views/CsvRepresentationView.java
+++ b/src/main/java/uk/gov/register/views/CsvRepresentationView.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 
 public abstract class CsvRepresentationView<T> extends AttributionView {
 
-    public CsvRepresentationView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, templateName, registerData, registerTrackingConfiguration, registerResolver);
+    public CsvRepresentationView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, registryBranding, templateName, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public abstract CsvRepresentation<T> csvRepresentation();

--- a/src/main/java/uk/gov/register/views/EntryListView.java
+++ b/src/main/java/uk/gov/register/views/EntryListView.java
@@ -19,15 +19,15 @@ public class EntryListView extends CsvRepresentationView {
     private Collection<Entry> entries;
     private final Optional<String> recordKey;
 
-    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Collection<Entry> entries, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext,custodian, custodianBranding, "entries.html", registerData, registerTrackingConfiguration, registerResolver);
+    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Collection<Entry> entries, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext,registry, registryBranding, "entries.html", registerData, registerTrackingConfiguration, registerResolver);
         this.pagination = pagination;
         this.entries = entries;
         this.recordKey = Optional.empty();
     }
 
-    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Collection<Entry> entries, String recordKey, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, "entries.html", registerData, registerTrackingConfiguration, registerResolver);
+    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Collection<Entry> entries, String recordKey, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, registryBranding, "entries.html", registerData, registerTrackingConfiguration, registerResolver);
         this.pagination = pagination;
         this.entries = entries;
         this.recordKey = Optional.of(recordKey);

--- a/src/main/java/uk/gov/register/views/EntryView.java
+++ b/src/main/java/uk/gov/register/views/EntryView.java
@@ -15,8 +15,8 @@ import java.util.Optional;
 public class EntryView extends CsvRepresentationView<Entry> {
     private Entry entry;
 
-    public EntryView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Entry entry, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, "entry.html", registerData, registerTrackingConfiguration, registerResolver);
+    public EntryView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Entry entry, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, registryBranding, "entry.html", registerData, registerTrackingConfiguration, registerResolver);
         this.entry = entry;
     }
 

--- a/src/main/java/uk/gov/register/views/HomePageView.java
+++ b/src/main/java/uk/gov/register/views/HomePageView.java
@@ -26,8 +26,8 @@ public class HomePageView extends AttributionView {
     private final RegisterContentPages registerContentPages;
 
     public HomePageView(
-            PublicBody custodian,
-            Optional<GovukOrganisation.Details> custodianBranding,
+            PublicBody registry,
+            Optional<GovukOrganisation.Details> registryBranding,
             RequestContext requestContext,
             int totalRecords,
             int totalEntries,
@@ -35,7 +35,7 @@ public class HomePageView extends AttributionView {
             RegisterData registerData,
             RegisterContentPages registerContentPages,
             RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, "home.html", registerData, registerTrackingConfiguration, registerResolver);
+        super(requestContext, registry, registryBranding, "home.html", registerData, registerTrackingConfiguration, registerResolver);
         this.totalRecords = totalRecords;
         this.totalEntries = totalEntries;
         this.lastUpdated = lastUpdated;

--- a/src/main/java/uk/gov/register/views/ItemView.java
+++ b/src/main/java/uk/gov/register/views/ItemView.java
@@ -20,8 +20,8 @@ public class ItemView extends CsvRepresentationView {
     private ItemConverter itemConverter;
     private Item item;
 
-    public ItemView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Item item, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, branding, "item.html", registerData, registerTrackingConfiguration, registerResolver);
+    public ItemView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Item item, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, branding, "item.html", registerData, registerTrackingConfiguration, registerResolver);
         this.itemConverter = itemConverter;
         this.item = item;
     }

--- a/src/main/java/uk/gov/register/views/RecordListView.java
+++ b/src/main/java/uk/gov/register/views/RecordListView.java
@@ -26,8 +26,8 @@ public class RecordListView extends CsvRepresentationView {
     private ItemConverter itemConverter;
     private List<Record> records;
 
-    public RecordListView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Pagination pagination, ItemConverter itemConverter, List<Record> records, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, "records.html", registerData, registerTrackingConfiguration, registerResolver);
+    public RecordListView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, Pagination pagination, ItemConverter itemConverter, List<Record> records, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, branding, "records.html", registerData, registerTrackingConfiguration, registerResolver);
         this.pagination = pagination;
         this.itemConverter = itemConverter;
         this.records = records;
@@ -42,7 +42,7 @@ public class RecordListView extends CsvRepresentationView {
     }
 
     public List<RecordView> getRecords() {
-        return records.stream().map(r -> new RecordView(requestContext, getCustodian(), getBranding(), itemConverter, r, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList());
+        return records.stream().map(r -> new RecordView(requestContext, getRegistry(), getBranding(), itemConverter, r, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList());
     }
 
     public Pagination getPagination() {

--- a/src/main/java/uk/gov/register/views/RecordView.java
+++ b/src/main/java/uk/gov/register/views/RecordView.java
@@ -24,8 +24,8 @@ public class RecordView extends CsvRepresentationView {
     private ItemConverter itemConverter;
     private final Record record;
 
-    public RecordView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, ItemConverter itemConverter, Record record, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, custodian, custodianBranding, "record.html", registerData, registerTrackingConfiguration, registerResolver);
+    public RecordView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Record record, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+        super(requestContext, registry, branding, "record.html", registerData, registerTrackingConfiguration, registerResolver);
         this.itemConverter = itemConverter;
         this.record = record;
         this.registerPrimaryKey = registerData.getRegister().getRegisterName();

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -60,7 +60,7 @@ public class ViewFactory {
 
     public HomePageView homePageView(int totalRecords, int totalEntries, Optional<Instant> lastUpdated) {
         return new HomePageView(
-                getCustodian(),
+                getRegistry(),
                 getBranding(),
                 requestContext,
                 totalRecords,
@@ -81,30 +81,30 @@ public class ViewFactory {
     }
 
     public ItemView getItemView(Item item) {
-        return new ItemView(requestContext, getCustodian(), getBranding(), itemConverter, item, registerData, registerTrackingConfiguration, registerResolver);
+        return new ItemView(requestContext, getRegistry(), getBranding(), itemConverter, item, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public EntryView getEntryView(Entry entry) {
-        return new EntryView(requestContext, getCustodian(), getBranding(), entry, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryView(requestContext, getRegistry(), getBranding(), entry, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public EntryListView getEntriesView(Collection<Entry> entries, Pagination pagination) {
-        return new EntryListView(requestContext, pagination, getCustodian(), getBranding(), entries, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public EntryListView getRecordEntriesView(String recordKey, Collection<Entry> entries, Pagination pagination) {
-        return new EntryListView(requestContext, pagination, getCustodian(), getBranding(), entries, recordKey, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, recordKey, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public RecordView getRecordView(Record record) {
-        return new RecordView(requestContext, getCustodian(), getBranding(), itemConverter, record, registerData, registerTrackingConfiguration, registerResolver);
+        return new RecordView(requestContext, getRegistry(), getBranding(), itemConverter, record, registerData, registerTrackingConfiguration, registerResolver);
     }
 
     public RecordListView getRecordListView(List<Record> records, Pagination pagination) {
-        return new RecordListView(requestContext, getCustodian(), getBranding(), pagination, itemConverter, records, registerData, registerTrackingConfiguration, registerResolver);
+        return new RecordListView(requestContext, getRegistry(), getBranding(), pagination, itemConverter, records, registerData, registerTrackingConfiguration, registerResolver);
     }
 
-    private PublicBody getCustodian() {
+    private PublicBody getRegistry() {
         return publicBodiesConfiguration.getPublicBody(registerData.getRegister().getRegistry());
     }
 

--- a/src/main/java/uk/gov/register/views/representations/turtle/EntryListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/EntryListTurtleWriter.java
@@ -35,7 +35,7 @@ public class EntryListTurtleWriter extends TurtleRepresentationWriter<EntryListV
     @Override
     protected Model rdfModelFor(EntryListView view) {
         Model model = ModelFactory.createDefaultModel();
-        for (EntryView entryView : view.getEntries().stream().map(e -> new EntryView(requestContext, view.getCustodian(), view.getBranding(), e, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList())) {
+        for (EntryView entryView : view.getEntries().stream().map(e -> new EntryView(requestContext, view.getRegistry(), view.getBranding(), e, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList())) {
             model.add(new EntryTurtleWriter(requestContext, registerNameConfiguration, registerResolver).rdfModelFor(entryView));
         }
         return model;

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
@@ -40,8 +40,8 @@ public class RecordTurtleWriter extends TurtleRepresentationWriter<RecordView> {
 
     @Override
     protected Model rdfModelFor(RecordView view) {
-        EntryView entryView = new EntryView(requestContext, view.getCustodian(), view.getBranding(), view.getRecord().entry, registerData, registerTrackingConfiguration, registerResolver);
-        ItemView itemView = new ItemView(requestContext, view.getCustodian(), view.getBranding(), itemConverter, view.getRecord().item, registerData, registerTrackingConfiguration, registerResolver);
+        EntryView entryView = new EntryView(requestContext, view.getRegistry(), view.getBranding(), view.getRecord().entry, registerData, registerTrackingConfiguration, registerResolver);
+        ItemView itemView = new ItemView(requestContext, view.getRegistry(), view.getBranding(), itemConverter, view.getRecord().item, registerData, registerTrackingConfiguration, registerResolver);
 
         Model recordModel = ModelFactory.createDefaultModel();
         Model entryModel = new EntryTurtleWriter(requestContext, registerNameConfiguration, registerResolver).rdfModelFor(entryView);

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -11,7 +11,7 @@
             <div class="homepage-intro" th:utext="${registerText}">The register of UK government registers.</div>
             <dl class="primary-metadata">
                 <dt>Managed by:</dt>
-                <dd><th:block th:include="main.html :: organisation(${custodian}, ${branding})"></th:block></dd>
+                <dd><th:block th:include="main.html :: organisation(${registry}, ${branding})"></th:block></dd>
                 <dt>Total records:</dt>
                 <dd><a href="/records"><th:block th:text="${totalRecords}">Total</th:block><span class="visuallyhidden"> records</span></a></dd>
                 <dt>Total entries:</dt>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -54,7 +54,7 @@
 <div th:fragment="attribution">
     <div class="organisation">
         <span class="managed-by">Managed by:</span>
-        <th:block th:include="main.html::organisation(${custodian}, ${branding})"></th:block>
+        <th:block th:include="main.html::organisation(${registry}, ${branding})"></th:block>
     </div>
 </div>
 


### PR DESCRIPTION
As the register history pages show, the "custodian" of a register is a
named individual; while the organisation the custodian belongs to is
known as a "registry".  Our code should use this same language.

I've tested this locally to make sure the templates continue to get
the custodian/registry branding stuff correctly.