### PR TITLE
Use RegisterReadOnly interface, not RegisterData, in views

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -24,6 +24,7 @@ import uk.gov.register.auth.AuthBundle;
 import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.PublicBodiesConfiguration;
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
+import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.core.PostgresRegister;
 import uk.gov.register.core.Register;
@@ -134,7 +135,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(GovukOrganisationClient.class).to(GovukOrganisationClient.class).in(Singleton.class);
                 bind(InMemoryPowOfTwoNoLeaves.class).to(MemoizationStore.class).in(Singleton.class);
 
-                bind(PostgresRegister.class).to(Register.class).to(RegisterReadOnly.class);
+                bind(PostgresRegister.class).to(Register.class).to(RegisterReadOnly.class).to(RegisterNameConfiguration.class);
                 bind(UriTemplateRegisterResolver.class).to(RegisterResolver.class);
                 bind(configuration);
                 bind(client).to(Client.class);

--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 public class RegisterConfiguration extends Configuration
         implements AuthenticatorConfiguration,
-        RegisterNameConfiguration,
         RegisterDomainConfiguration,
         RegisterContentPagesConfiguration,
         ResourceConfiguration,

--- a/src/main/java/uk/gov/register/core/EntryLog.java
+++ b/src/main/java/uk/gov/register/core/EntryLog.java
@@ -7,7 +7,6 @@ import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
 
 import javax.xml.bind.DatatypeConverter;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Iterator;
@@ -57,7 +56,7 @@ public class EntryLog {
         return backingStoreDriver.getLastUpdatedTime();
     }
 
-    public RegisterProof getRegisterProof() throws NoSuchAlgorithmException {
+    public RegisterProof getRegisterProof() {
         String rootHash =  backingStoreDriver.withVerifiableLog(verifiableLog ->
                 bytesToString(verifiableLog.getCurrentRootHash()));
 

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -25,6 +25,7 @@ public class PostgresRegister implements Register {
     private final EntryLog entryLog;
     private final ItemStore itemStore;
     private final RegisterFieldsConfiguration registerFieldsConfiguration;
+    private final RegisterMetadata registerMetadata;
 
     @Inject
     public PostgresRegister(RegisterData registerData,
@@ -37,6 +38,7 @@ public class PostgresRegister implements Register {
         this.itemStore = new ItemStore(backingStoreDriver, itemValidator, registerName);
         this.recordIndex = new RecordIndex(backingStoreDriver);
         this.registerFieldsConfiguration = registerFieldsConfiguration;
+        this.registerMetadata = registerData.getRegister();
     }
 
     @Override
@@ -158,6 +160,11 @@ public class PostgresRegister implements Register {
     @Override
     public Iterator<Item> getItemIterator(int start, int end) {
         return itemStore.getIterator(start, end);
+    }
+
+    @Override
+    public RegisterMetadata getRegisterMetadata() {
+        return registerMetadata;
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -12,7 +12,6 @@ import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
 
 import javax.inject.Inject;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -122,7 +121,7 @@ public class PostgresRegister implements Register {
     }
 
     @Override
-    public RegisterProof getRegisterProof() throws NoSuchAlgorithmException {
+    public RegisterProof getRegisterProof() {
         return entryLog.getRegisterProof();
     }
 

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -160,4 +160,9 @@ public class PostgresRegister implements Register {
     public Iterator<Item> getItemIterator(int start, int end) {
         return itemStore.getIterator(start, end);
     }
+
+    @Override
+    public String getRegisterName() {
+        return registerName;
+    }
 }

--- a/src/main/java/uk/gov/register/core/RegisterReadOnly.java
+++ b/src/main/java/uk/gov/register/core/RegisterReadOnly.java
@@ -6,7 +6,6 @@ import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
 
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Iterator;
@@ -32,7 +31,7 @@ public interface RegisterReadOnly extends RegisterNameConfiguration {
 
     List<Record> max100RecordsFacetedByKeyValue(String key, String value);
 
-    RegisterProof getRegisterProof() throws NoSuchAlgorithmException;
+    RegisterProof getRegisterProof();
     RegisterProof getRegisterProof(int entryNo);
     EntryProof getEntryProof(int entryNumber, int totalEntries);
     ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2);

--- a/src/main/java/uk/gov/register/core/RegisterReadOnly.java
+++ b/src/main/java/uk/gov/register/core/RegisterReadOnly.java
@@ -41,4 +41,6 @@ public interface RegisterReadOnly extends RegisterNameConfiguration {
 
     Iterator<Item> getItemIterator();
     Iterator<Item> getItemIterator(int start, int end);
+
+    RegisterMetadata getRegisterMetadata();
 }

--- a/src/main/java/uk/gov/register/core/RegisterReadOnly.java
+++ b/src/main/java/uk/gov/register/core/RegisterReadOnly.java
@@ -1,5 +1,6 @@
 package uk.gov.register.core;
 
+import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.util.HashValue;
 import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
@@ -12,7 +13,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
-public interface RegisterReadOnly {
+public interface RegisterReadOnly extends RegisterNameConfiguration {
     Optional<Item> getItemBySha256(HashValue hash);
     Collection<Item> getAllItems();
 

--- a/src/main/java/uk/gov/register/service/RegisterSerialisationFormatService.java
+++ b/src/main/java/uk/gov/register/service/RegisterSerialisationFormatService.java
@@ -10,7 +10,6 @@ import uk.gov.register.util.HashValue;
 import uk.gov.register.views.RegisterProof;
 
 import javax.inject.Inject;
-import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
 
 public class RegisterSerialisationFormatService {
@@ -36,16 +35,12 @@ public class RegisterSerialisationFormatService {
         Iterator<RegisterCommand> itemCommandsIterator = Iterators.transform(register.getItemIterator(), AddItemCommand::new);
         Iterator<RegisterCommand> entryCommandIterator = Iterators.transform(register.getEntryIterator(), AppendEntryCommand::new);
 
-        try {
-            return new RegisterSerialisationFormat(Iterators.concat(
-                    Iterators.forArray(new AssertRootHashCommand(emptyRegisterProof)),
-                    itemCommandsIterator,
-                    entryCommandIterator,
-                    Iterators.forArray(new AssertRootHashCommand(register.getRegisterProof()))
-            ));
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
+        return new RegisterSerialisationFormat(Iterators.concat(
+                Iterators.forArray(new AssertRootHashCommand(emptyRegisterProof)),
+                itemCommandsIterator,
+                entryCommandIterator,
+                Iterators.forArray(new AssertRootHashCommand(register.getRegisterProof()))
+        ));
     }
 
     public RegisterSerialisationFormat createRegisterSerialisationFormat(int totalEntries1, int totalEntries2) {

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
@@ -6,7 +6,7 @@ import org.markdownj.MarkdownProcessor;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.LinkResolver;
 import uk.gov.register.core.RegisterMetadata;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 
@@ -18,18 +18,18 @@ import java.util.Optional;
 
 public class ThymeleafView extends View {
     protected final RequestContext requestContext;
-    private final RegisterData registerData;
     private final RegisterResolver registerResolver;
+    private final RegisterReadOnly register;
     private Optional<String> registerTrackingId;
     private String thymeleafTemplateName;
     protected final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
-    public ThymeleafView(RequestContext requestContext, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+    public ThymeleafView(RequestContext requestContext, String templateName, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
         super(templateName, StandardCharsets.UTF_8);
         this.requestContext = requestContext;
-        this.registerData = registerData;
         this.registerTrackingId = registerTrackingConfiguration.getRegisterTrackingId();
         this.registerResolver = registerResolver;
+        this.register = register;
     }
 
     @Override
@@ -56,11 +56,11 @@ public class ThymeleafView extends View {
     }
 
     public String getRegisterId() {
-        return registerData.getRegister().getRegisterName();
+        return register.getRegisterName();
     }
 
     public RegisterMetadata getRegister() {
-        return registerData.getRegister();
+        return register.getRegisterMetadata();
     }
 
     @SuppressWarnings("unused, used by templates")

--- a/src/main/java/uk/gov/register/views/AttributionView.java
+++ b/src/main/java/uk/gov/register/views/AttributionView.java
@@ -3,7 +3,7 @@ package uk.gov.register.views;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.PublicBody;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.thymeleaf.ThymeleafView;
@@ -16,8 +16,8 @@ public class AttributionView extends ThymeleafView {
 
     private final Optional<GovukOrganisation.Details> registryBranding;
 
-    public AttributionView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, templateName, registerData, registerTrackingConfiguration, registerResolver);
+    public AttributionView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, String templateName, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
+        super(requestContext, templateName, registerTrackingConfiguration, registerResolver, register);
         this.registry = registry;
         this.registryBranding = registryBranding;
     }

--- a/src/main/java/uk/gov/register/views/BadRequestExceptionView.java
+++ b/src/main/java/uk/gov/register/views/BadRequestExceptionView.java
@@ -1,7 +1,7 @@
 package uk.gov.register.views;
 
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.thymeleaf.ThymeleafView;
@@ -11,8 +11,8 @@ import javax.ws.rs.BadRequestException;
 public class BadRequestExceptionView extends ThymeleafView {
     private final BadRequestException exception;
 
-    public BadRequestExceptionView(RequestContext requestContext, BadRequestException exception, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, "400.html", registerData, registerTrackingConfiguration, registerResolver);
+    public BadRequestExceptionView(RequestContext requestContext, BadRequestException exception, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
+        super(requestContext, "400.html", registerTrackingConfiguration, registerResolver, register);
         this.exception = exception;
     }
 

--- a/src/main/java/uk/gov/register/views/CsvRepresentationView.java
+++ b/src/main/java/uk/gov/register/views/CsvRepresentationView.java
@@ -3,7 +3,7 @@ package uk.gov.register.views;
 import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.PublicBody;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.views.representations.CsvRepresentation;
@@ -12,8 +12,8 @@ import java.util.Optional;
 
 public abstract class CsvRepresentationView<T> extends AttributionView {
 
-    public CsvRepresentationView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, String templateName, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registry, registryBranding, templateName, registerData, registerTrackingConfiguration, registerResolver);
+    public CsvRepresentationView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, String templateName, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
+        super(requestContext, registry, registryBranding, templateName, registerTrackingConfiguration, registerResolver, register);
     }
 
     public abstract CsvRepresentation<T> csvRepresentation();

--- a/src/main/java/uk/gov/register/views/DownloadPageView.java
+++ b/src/main/java/uk/gov/register/views/DownloadPageView.java
@@ -1,7 +1,7 @@
 package uk.gov.register.views;
 
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.thymeleaf.ThymeleafView;
 import uk.gov.register.resources.RequestContext;
@@ -10,8 +10,8 @@ public class DownloadPageView extends ThymeleafView {
 
     private final Boolean downloadEnabled;
 
-    public DownloadPageView(RequestContext requestContext, RegisterData registerData, Boolean enableDownloadResource, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, "download.html", registerData, registerTrackingConfiguration, registerResolver);
+    public DownloadPageView(RequestContext requestContext, Boolean enableDownloadResource, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
+        super(requestContext, "download.html", registerTrackingConfiguration, registerResolver, register);
         this.downloadEnabled = enableDownloadResource;
     }
 

--- a/src/main/java/uk/gov/register/views/EntryListView.java
+++ b/src/main/java/uk/gov/register/views/EntryListView.java
@@ -5,7 +5,7 @@ import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.PublicBody;
 import uk.gov.register.core.Entry;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.Pagination;
 import uk.gov.register.resources.RequestContext;
@@ -19,15 +19,15 @@ public class EntryListView extends CsvRepresentationView {
     private Collection<Entry> entries;
     private final Optional<String> recordKey;
 
-    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Collection<Entry> entries, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext,registry, registryBranding, "entries.html", registerData, registerTrackingConfiguration, registerResolver);
+    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Collection<Entry> entries, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
+        super(requestContext,registry, registryBranding, "entries.html", registerTrackingConfiguration, registerResolver, register);
         this.pagination = pagination;
         this.entries = entries;
         this.recordKey = Optional.empty();
     }
 
-    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Collection<Entry> entries, String recordKey, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registry, registryBranding, "entries.html", registerData, registerTrackingConfiguration, registerResolver);
+    public EntryListView(RequestContext requestContext, Pagination pagination, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Collection<Entry> entries, String recordKey, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
+        super(requestContext, registry, registryBranding, "entries.html", registerTrackingConfiguration, registerResolver, register);
         this.pagination = pagination;
         this.entries = entries;
         this.recordKey = Optional.of(recordKey);

--- a/src/main/java/uk/gov/register/views/EntryView.java
+++ b/src/main/java/uk/gov/register/views/EntryView.java
@@ -5,7 +5,7 @@ import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.PublicBody;
 import uk.gov.register.core.Entry;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.views.representations.CsvRepresentation;
@@ -15,8 +15,8 @@ import java.util.Optional;
 public class EntryView extends CsvRepresentationView<Entry> {
     private Entry entry;
 
-    public EntryView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Entry entry, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registry, registryBranding, "entry.html", registerData, registerTrackingConfiguration, registerResolver);
+    public EntryView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> registryBranding, Entry entry, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
+        super(requestContext, registry, registryBranding, "entry.html", registerTrackingConfiguration, registerResolver, register);
         this.entry = entry;
     }
 

--- a/src/main/java/uk/gov/register/views/HomePageView.java
+++ b/src/main/java/uk/gov/register/views/HomePageView.java
@@ -4,7 +4,7 @@ import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.configuration.RegisterContentPages;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.PublicBody;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 
@@ -32,10 +32,11 @@ public class HomePageView extends AttributionView {
             int totalRecords,
             int totalEntries,
             Optional<Instant> lastUpdated,
-            RegisterData registerData,
             RegisterContentPages registerContentPages,
-            RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registry, registryBranding, "home.html", registerData, registerTrackingConfiguration, registerResolver);
+            RegisterTrackingConfiguration registerTrackingConfiguration,
+            RegisterResolver registerResolver,
+            RegisterReadOnly register) {
+        super(requestContext, registry, registryBranding, "home.html", registerTrackingConfiguration, registerResolver, register);
         this.totalRecords = totalRecords;
         this.totalEntries = totalEntries;
         this.lastUpdated = lastUpdated;

--- a/src/main/java/uk/gov/register/views/ItemView.java
+++ b/src/main/java/uk/gov/register/views/ItemView.java
@@ -6,7 +6,7 @@ import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.PublicBody;
 import uk.gov.register.core.FieldValue;
 import uk.gov.register.core.Item;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.service.ItemConverter;
@@ -20,8 +20,8 @@ public class ItemView extends CsvRepresentationView {
     private ItemConverter itemConverter;
     private Item item;
 
-    public ItemView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Item item, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registry, branding, "item.html", registerData, registerTrackingConfiguration, registerResolver);
+    public ItemView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Item item, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
+        super(requestContext, registry, branding, "item.html", registerTrackingConfiguration, registerResolver, register);
         this.itemConverter = itemConverter;
         this.item = item;
     }

--- a/src/main/java/uk/gov/register/views/RecordListView.java
+++ b/src/main/java/uk/gov/register/views/RecordListView.java
@@ -5,7 +5,7 @@ import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.PublicBody;
 import uk.gov.register.core.Record;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.Pagination;
 import uk.gov.register.resources.RequestContext;
@@ -19,21 +19,21 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class RecordListView extends CsvRepresentationView {
-    private final RegisterData registerData;
     private final RegisterResolver registerResolver;
+    private final RegisterReadOnly register;
     private RegisterTrackingConfiguration registerTrackingConfiguration;
     private Pagination pagination;
     private ItemConverter itemConverter;
     private List<Record> records;
 
-    public RecordListView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, Pagination pagination, ItemConverter itemConverter, List<Record> records, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registry, branding, "records.html", registerData, registerTrackingConfiguration, registerResolver);
+    public RecordListView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, Pagination pagination, ItemConverter itemConverter, List<Record> records, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
+        super(requestContext, registry, branding, "records.html", registerTrackingConfiguration, registerResolver, register);
         this.pagination = pagination;
         this.itemConverter = itemConverter;
         this.records = records;
-        this.registerData = registerData;
         this.registerTrackingConfiguration = registerTrackingConfiguration;
         this.registerResolver = registerResolver;
+        this.register = register;
     }
 
     @JsonValue
@@ -42,7 +42,7 @@ public class RecordListView extends CsvRepresentationView {
     }
 
     public List<RecordView> getRecords() {
-        return records.stream().map(r -> new RecordView(requestContext, getRegistry(), getBranding(), itemConverter, r, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList());
+        return records.stream().map(r -> new RecordView(requestContext, getRegistry(), getBranding(), itemConverter, r, registerTrackingConfiguration, registerResolver, register)).collect(Collectors.toList());
     }
 
     public Pagination getPagination() {

--- a/src/main/java/uk/gov/register/views/RecordView.java
+++ b/src/main/java/uk/gov/register/views/RecordView.java
@@ -9,7 +9,7 @@ import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.PublicBody;
 import uk.gov.register.core.FieldValue;
 import uk.gov.register.core.Record;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.service.ItemConverter;
@@ -24,11 +24,11 @@ public class RecordView extends CsvRepresentationView {
     private ItemConverter itemConverter;
     private final Record record;
 
-    public RecordView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Record record, RegisterData registerData, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
-        super(requestContext, registry, branding, "record.html", registerData, registerTrackingConfiguration, registerResolver);
+    public RecordView(RequestContext requestContext, PublicBody registry, Optional<GovukOrganisation.Details> branding, ItemConverter itemConverter, Record record, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
+        super(requestContext, registry, branding, "record.html", registerTrackingConfiguration, registerResolver, register);
         this.itemConverter = itemConverter;
         this.record = record;
-        this.registerPrimaryKey = registerData.getRegister().getRegisterName();
+        this.registerPrimaryKey = register.getRegisterName();
     }
 
     public String getPrimaryKey() {

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -27,6 +27,7 @@ public class ViewFactory {
     private final RegisterDomainConfiguration registerDomainConfiguration;
     private final RegisterContentPages registerContentPages;
     private final RegisterResolver registerResolver;
+    private final RegisterReadOnly register;
     private RegisterTrackingConfiguration registerTrackingConfiguration;
 
     @Inject
@@ -38,7 +39,8 @@ public class ViewFactory {
                        RegisterContentPagesConfiguration registerContentPagesConfiguration,
                        RegisterData registerData,
                        RegisterTrackingConfiguration registerTrackingConfiguration,
-                       RegisterResolver registerResolver) {
+                       RegisterResolver registerResolver,
+                       RegisterReadOnly register) {
         this.requestContext = requestContext;
         this.itemConverter = itemConverter;
         this.publicBodiesConfiguration = publicBodiesConfiguration;
@@ -48,14 +50,15 @@ public class ViewFactory {
         this.registerContentPages = new RegisterContentPages(registerContentPagesConfiguration.getRegisterHistoryPageUrl());
         this.registerTrackingConfiguration = registerTrackingConfiguration;
         this.registerResolver = registerResolver;
+        this.register = register;
     }
 
     public ThymeleafView thymeleafView(String templateName) {
-        return new ThymeleafView(requestContext, templateName, registerData, registerTrackingConfiguration, registerResolver);
+        return new ThymeleafView(requestContext, templateName, registerTrackingConfiguration, registerResolver, register);
     }
 
     public BadRequestExceptionView badRequestExceptionView(BadRequestException e) {
-        return new BadRequestExceptionView(requestContext, e, registerData, registerTrackingConfiguration, registerResolver);
+        return new BadRequestExceptionView(requestContext, e, registerTrackingConfiguration, registerResolver, register);
     }
 
     public HomePageView homePageView(int totalRecords, int totalEntries, Optional<Instant> lastUpdated) {
@@ -66,14 +69,13 @@ public class ViewFactory {
                 totalRecords,
                 totalEntries,
                 lastUpdated,
-                registerData,
                 registerContentPages,
                 registerTrackingConfiguration,
-                registerResolver);
+                registerResolver, register);
     }
 
     public DownloadPageView downloadPageView(Boolean enableDownloadResource) {
-        return new DownloadPageView(requestContext, registerData, enableDownloadResource, registerTrackingConfiguration, registerResolver);
+        return new DownloadPageView(requestContext, enableDownloadResource, registerTrackingConfiguration, registerResolver, register);
     }
 
     public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, Optional<Instant> lastUpdated) {
@@ -81,27 +83,27 @@ public class ViewFactory {
     }
 
     public ItemView getItemView(Item item) {
-        return new ItemView(requestContext, getRegistry(), getBranding(), itemConverter, item, registerData, registerTrackingConfiguration, registerResolver);
+        return new ItemView(requestContext, getRegistry(), getBranding(), itemConverter, item, registerTrackingConfiguration, registerResolver, register);
     }
 
     public EntryView getEntryView(Entry entry) {
-        return new EntryView(requestContext, getRegistry(), getBranding(), entry, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryView(requestContext, getRegistry(), getBranding(), entry, registerTrackingConfiguration, registerResolver, register);
     }
 
     public EntryListView getEntriesView(Collection<Entry> entries, Pagination pagination) {
-        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, registerTrackingConfiguration, registerResolver, register);
     }
 
     public EntryListView getRecordEntriesView(String recordKey, Collection<Entry> entries, Pagination pagination) {
-        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, recordKey, registerData, registerTrackingConfiguration, registerResolver);
+        return new EntryListView(requestContext, pagination, getRegistry(), getBranding(), entries, recordKey, registerTrackingConfiguration, registerResolver, register);
     }
 
     public RecordView getRecordView(Record record) {
-        return new RecordView(requestContext, getRegistry(), getBranding(), itemConverter, record, registerData, registerTrackingConfiguration, registerResolver);
+        return new RecordView(requestContext, getRegistry(), getBranding(), itemConverter, record, registerTrackingConfiguration, registerResolver, register);
     }
 
     public RecordListView getRecordListView(List<Record> records, Pagination pagination) {
-        return new RecordListView(requestContext, getRegistry(), getBranding(), pagination, itemConverter, records, registerData, registerTrackingConfiguration, registerResolver);
+        return new RecordListView(requestContext, getRegistry(), getBranding(), pagination, itemConverter, records, registerTrackingConfiguration, registerResolver, register);
     }
 
     private PublicBody getRegistry() {

--- a/src/main/java/uk/gov/register/views/representations/turtle/EntryListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/EntryListTurtleWriter.java
@@ -4,7 +4,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.views.EntryListView;
@@ -20,22 +20,22 @@ import java.util.stream.Collectors;
 @Produces(ExtraMediaType.TEXT_TTL)
 public class EntryListTurtleWriter extends TurtleRepresentationWriter<EntryListView> {
 
-    private RegisterData registerData;
+    private final RegisterReadOnly register;
     private RegisterNameConfiguration registerNameConfiguration;
     private RegisterTrackingConfiguration registerTrackingConfiguration;
 
     @Inject
-    public EntryListTurtleWriter(RequestContext requestContext, RegisterData registerData, RegisterNameConfiguration registerNameConfiguration, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+    public EntryListTurtleWriter(RequestContext requestContext, RegisterNameConfiguration registerNameConfiguration, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
         super(requestContext, registerNameConfiguration, registerResolver);
-        this.registerData = registerData;
         this.registerNameConfiguration = registerNameConfiguration;
         this.registerTrackingConfiguration = registerTrackingConfiguration;
+        this.register = register;
     }
 
     @Override
     protected Model rdfModelFor(EntryListView view) {
         Model model = ModelFactory.createDefaultModel();
-        for (EntryView entryView : view.getEntries().stream().map(e -> new EntryView(requestContext, view.getRegistry(), view.getBranding(), e, registerData, registerTrackingConfiguration, registerResolver)).collect(Collectors.toList())) {
+        for (EntryView entryView : view.getEntries().stream().map(e -> new EntryView(requestContext, view.getRegistry(), view.getBranding(), e, registerTrackingConfiguration, registerResolver, register)).collect(Collectors.toList())) {
             model.add(new EntryTurtleWriter(requestContext, registerNameConfiguration, registerResolver).rdfModelFor(entryView));
         }
         return model;

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordListTurtleWriter.java
@@ -4,7 +4,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.service.ItemConverter;
@@ -20,23 +20,23 @@ import javax.ws.rs.ext.Provider;
 public class RecordListTurtleWriter extends TurtleRepresentationWriter<RecordListView> {
 
     private final ItemConverter itemConverter;
-    private RegisterData registerData;
+    private final RegisterReadOnly register;
     private RegisterNameConfiguration registerNameConfiguration;
     private RegisterTrackingConfiguration registerTrackingConfiguration;
 
     @Inject
-    public RecordListTurtleWriter(RequestContext requestContext, ItemConverter itemConverter, RegisterData registerData, RegisterNameConfiguration registerNameConfiguration, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+    public RecordListTurtleWriter(RequestContext requestContext, ItemConverter itemConverter, RegisterNameConfiguration registerNameConfiguration, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
         super(requestContext, registerNameConfiguration, registerResolver);
         this.itemConverter = itemConverter;
-        this.registerData = registerData;
         this.registerNameConfiguration = registerNameConfiguration;
         this.registerTrackingConfiguration = registerTrackingConfiguration;
+        this.register = register;
     }
 
     @Override
     protected Model rdfModelFor(RecordListView view) {
         Model model = ModelFactory.createDefaultModel();
-        view.getRecords().stream().forEach(r -> model.add(new RecordTurtleWriter(requestContext, itemConverter, registerData, registerNameConfiguration, registerTrackingConfiguration, registerResolver).rdfModelFor(r)));
+        view.getRecords().stream().forEach(r -> model.add(new RecordTurtleWriter(requestContext, itemConverter, registerNameConfiguration, registerTrackingConfiguration, registerResolver, register).rdfModelFor(r)));
         return model;
     }
 }

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
@@ -4,6 +4,7 @@ import org.apache.jena.rdf.model.*;
 import uk.gov.register.configuration.RegisterNameConfiguration;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.service.ItemConverter;
@@ -24,24 +25,24 @@ import java.util.Map;
 public class RecordTurtleWriter extends TurtleRepresentationWriter<RecordView> {
 
     private final ItemConverter itemConverter;
-    private RegisterData registerData;
+    private final RegisterReadOnly register;
     private RegisterNameConfiguration registerNameConfiguration;
     private RegisterTrackingConfiguration registerTrackingConfiguration;
 
     @Inject
-    public RecordTurtleWriter(RequestContext requestContext, ItemConverter itemConverter, RegisterData registerData, RegisterNameConfiguration registerNameConfiguration, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver) {
+    public RecordTurtleWriter(RequestContext requestContext, ItemConverter itemConverter, RegisterNameConfiguration registerNameConfiguration, RegisterTrackingConfiguration registerTrackingConfiguration, RegisterResolver registerResolver, RegisterReadOnly register) {
         super(requestContext, registerNameConfiguration, registerResolver);
         this.itemConverter = itemConverter;
-        this.registerData = registerData;
         this.registerNameConfiguration = registerNameConfiguration;
         this.registerTrackingConfiguration = registerTrackingConfiguration;
         this.registerResolver = registerResolver;
+        this.register = register;
     }
 
     @Override
     protected Model rdfModelFor(RecordView view) {
-        EntryView entryView = new EntryView(requestContext, view.getRegistry(), view.getBranding(), view.getRecord().entry, registerData, registerTrackingConfiguration, registerResolver);
-        ItemView itemView = new ItemView(requestContext, view.getRegistry(), view.getBranding(), itemConverter, view.getRecord().item, registerData, registerTrackingConfiguration, registerResolver);
+        EntryView entryView = new EntryView(requestContext, view.getRegistry(), view.getBranding(), view.getRecord().entry, registerTrackingConfiguration, registerResolver, register);
+        ItemView itemView = new ItemView(requestContext, view.getRegistry(), view.getBranding(), itemConverter, view.getRecord().item, registerTrackingConfiguration, registerResolver, register);
 
         Model recordModel = ModelFactory.createDefaultModel();
         Model entryModel = new EntryTurtleWriter(requestContext, registerNameConfiguration, registerResolver).rdfModelFor(entryView);

--- a/src/test/java/uk/gov/register/core/EmptyRegister.java
+++ b/src/test/java/uk/gov/register/core/EmptyRegister.java
@@ -1,0 +1,171 @@
+package uk.gov.register.core;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.NotImplementedException;
+import uk.gov.register.util.HashValue;
+import uk.gov.register.views.ConsistencyProof;
+import uk.gov.register.views.EntryProof;
+import uk.gov.register.views.RegisterProof;
+import uk.gov.verifiablelog.VerifiableLog;
+import uk.gov.verifiablelog.store.MerkleLeafStore;
+
+import javax.xml.bind.DatatypeConverter;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+public class EmptyRegister implements RegisterReadOnly {
+    private final VerifiableLog verifiableLog;
+    private final String registerName;
+    private final RegisterMetadata registerMetadata;
+
+    public EmptyRegister(RegisterMetadata registerMetadata) {
+        this.registerName = registerMetadata.getRegisterName();
+        this.registerMetadata = registerMetadata;
+        verifiableLog = new VerifiableLog(DigestUtils.getSha256Digest(), new EmptyMerkleLeafStore());
+    }
+
+    public EmptyRegister(String registerName) {
+        this(new RegisterMetadata(registerName, Collections.emptyList(), null, null, null, "alpha"));
+    }
+
+    public EmptyRegister() {
+        this("widget");
+    }
+
+    @Override
+    public String getRegisterName() {
+        return registerName;
+    }
+
+    @Override
+    public Optional<Item> getItemBySha256(HashValue hash) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Collection<Item> getAllItems() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Optional<Entry> getEntry(int entryNumber) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Collection<Entry> getEntries(int start, int limit) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Entry> getAllEntries() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public int getTotalEntries() {
+        return 0;
+    }
+
+    @Override
+    public Optional<Instant> getLastUpdatedTime() {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean containsField(String fieldName) {
+        throw new NotImplementedException("test code anyway /shrug");
+    }
+
+    @Override
+    public Optional<Record> getRecord(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public int getTotalRecords() {
+        return 0;
+    }
+
+    @Override
+    public Collection<Entry> allEntriesOfRecord(String key) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Record> getRecords(int limit, int offset) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Record> max100RecordsFacetedByKeyValue(String key, String value) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public RegisterProof getRegisterProof() {
+        String rootHash = bytesToString(verifiableLog.getCurrentRootHash());
+        return new RegisterProof(new HashValue(HashingAlgorithm.SHA256, rootHash));
+    }
+
+    @Override
+    public RegisterProof getRegisterProof(int entryNo) {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public EntryProof getEntryProof(int entryNumber, int totalEntries) {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2) {
+        // The only valid call is between size 0 and size 0, which is the empty proof
+        return new ConsistencyProof(Collections.emptyList());
+    }
+
+    @Override
+    public Iterator<Entry> getEntryIterator() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public Iterator<Entry> getEntryIterator(int start, int end) {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public Iterator<Item> getItemIterator() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public Iterator<Item> getItemIterator(int start, int end) {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public RegisterMetadata getRegisterMetadata() {
+        return registerMetadata;
+    }
+
+    private static class EmptyMerkleLeafStore implements MerkleLeafStore {
+        @Override
+        public byte[] getLeafValue(int i) {
+            return new byte[0];
+        }
+
+        @Override
+        public int totalLeaves() {
+            return 0;
+        }
+    }
+
+    private String bytesToString(byte[] bytes) {
+        return DatatypeConverter.printHexBinary(bytes).toLowerCase();
+    }
+}

--- a/src/test/java/uk/gov/register/resources/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/SearchResourceTest.java
@@ -5,8 +5,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
-import uk.gov.register.core.RegisterData;
-import uk.gov.register.core.RegisterMetadata;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.ws.rs.NotFoundException;
@@ -26,14 +24,10 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class SearchResourceTest {
     SearchResource resource;
-    RegisterData registerData;
     RegisterFieldsConfiguration registerFieldsConfiguration;
 
     @Before
     public void setUp() throws Exception {
-        RegisterMetadata registerMetadata = mock(RegisterMetadata.class);
-        registerData = mock(RegisterData.class);
-        when(registerData.getRegister()).thenReturn(registerMetadata);
         registerFieldsConfiguration = mock(RegisterFieldsConfiguration.class);
     }
 

--- a/src/test/java/uk/gov/register/thymeleaf/ThymeleafViewAnalyticsTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/ThymeleafViewAnalyticsTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.register.core.EmptyRegister;
 import uk.gov.register.resources.RequestContext;
 
 import java.net.URI;
@@ -21,7 +22,7 @@ public class ThymeleafViewAnalyticsTest {
 
     @Test
     public void shouldAnalyticsCode() {
-        ThymeleafView sutView = new ThymeleafView(mockRequestContext, "", null, () -> validCode, register -> URI.create("http://" + register + ".test.register.gov.uk"));
+        ThymeleafView sutView = new ThymeleafView(mockRequestContext, "", () -> validCode, register -> URI.create("http://" + register + ".test.register.gov.uk"), new EmptyRegister());
         assertThat(sutView.getRegisterTrackingId(), equalTo(Optional.of("UA-12345678-1")));
     }
 }

--- a/src/test/java/uk/gov/register/thymeleaf/ThymeleafViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/ThymeleafViewTest.java
@@ -1,16 +1,16 @@
 package uk.gov.register.thymeleaf;
 
-import com.fasterxml.jackson.databind.node.TextNode;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.register.core.RegisterData;
+import uk.gov.register.core.EmptyRegister;
+import uk.gov.register.core.RegisterMetadata;
 import uk.gov.register.resources.RequestContext;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -25,10 +25,9 @@ public class ThymeleafViewTest {
 
     @Before
     public void setUp() throws Exception {
-        RegisterData register = new RegisterData(ImmutableMap.of(
-                "register", new TextNode("company-limited-by-guarantee"),
-                "copyright", new TextNode("Copyright text [with link](http://www.example.com/copyright)")));
-        thymeleafView = new ThymeleafView(requestContext, "don't care", register, () -> Optional.empty(), registerName -> URI.create("http://" + registerName + ".test.register.gov.uk"));
+        RegisterMetadata registerMetadata = new RegisterMetadata("company-limited-by-guarantee", Collections.emptyList(), "Copyright text [with link](http://www.example.com/copyright)", null, null, null);
+        EmptyRegister register = new EmptyRegister(registerMetadata);
+        thymeleafView = new ThymeleafView(requestContext, "don't care", () -> Optional.empty(), registerName -> URI.create("http://" + registerName + ".test.register.gov.uk"), register);
     }
 
     @Test

--- a/src/test/java/uk/gov/register/views/DownloadPageViewTest.java
+++ b/src/test/java/uk/gov/register/views/DownloadPageViewTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Mock;
+import uk.gov.register.core.EmptyRegister;
 import uk.gov.register.resources.RequestContext;
 
 import java.net.URI;
@@ -33,7 +34,7 @@ public class DownloadPageViewTest {
 
     @Test
     public void getDownloadEnabled_returnsTheSameValuePassedInConstructor() throws Exception {
-        DownloadPageView downloadPageView = new DownloadPageView(mockRequestContext, null , enableResourceDownload, () -> Optional.empty(), register -> URI.create("http://" + register + ".test.register.gov.uk"));
+        DownloadPageView downloadPageView = new DownloadPageView(mockRequestContext, enableResourceDownload, () -> Optional.empty(), register -> URI.create("http://" + register + ".test.register.gov.uk"), new EmptyRegister());
         assertThat(downloadPageView.getDownloadEnabled(), equalTo(enableResourceDownload));
     }
 }

--- a/src/test/java/uk/gov/register/views/RecordListViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordListViewTest.java
@@ -1,7 +1,5 @@
 package uk.gov.register.views;
 
-import com.fasterxml.jackson.databind.node.TextNode;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.dropwizard.jackson.Jackson;
 import org.json.JSONException;
@@ -45,8 +43,8 @@ public class RecordListViewTest {
                         new Item(new HashValue(HashingAlgorithm.SHA256, "cd"), Jackson.newObjectMapper().readTree("{\"address\":\"456\", \"street\":\"bar\"}"))
                 )
         );
-        RegisterData registerData = new RegisterData(ImmutableMap.of("register", new TextNode("address")));
-        RecordListView recordListView = new RecordListView(requestContext, null, null, null, new ItemConverter(new FieldsConfiguration(Optional.empty())), records, registerData, () -> Optional.empty(), register -> URI.create("http://" + register + ".test.register.gov.uk"));
+        RegisterReadOnly register = new EmptyRegister("address");
+        RecordListView recordListView = new RecordListView(requestContext, null, null, null, new ItemConverter(new FieldsConfiguration(Optional.empty())), records, () -> Optional.empty(), registerName -> URI.create("http://" + registerName + ".test.register.gov.uk"), register);
 
         Map<String, RecordView> result = recordListView.recordsJson();
         assertThat(result.size(), equalTo(2));

--- a/src/test/java/uk/gov/register/views/RecordViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordViewTest.java
@@ -10,7 +10,6 @@ import uk.gov.register.util.HashValue;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -22,7 +21,7 @@ public class RecordViewTest {
         ObjectMapper objectMapper = Jackson.newObjectMapper();
 
         Record record = new Record(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), Instant.ofEpochSecond(1470403440), "b"), new Item(new HashValue(HashingAlgorithm.SHA256, "ab"), objectMapper.readTree("{\"a\":\"b\"}")));
-        RecordView recordView = new RecordView(null, null, null, null, record, new RegisterData(Collections.emptyMap()), () -> Optional.empty(), register -> URI.create("http://" + register + ".test.register.gov.uk"));
+        RecordView recordView = new RecordView(null, null, null, null, record, () -> Optional.empty(), register -> URI.create("http://" + register + ".test.register.gov.uk"), new EmptyRegister());
 
         String result = objectMapper.writeValueAsString(recordView);
 

--- a/src/test/java/uk/gov/register/views/representations/CsvWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/CsvWriterTest.java
@@ -31,7 +31,7 @@ public class CsvWriterTest {
     public void writes_EntryListView_to_output_stream() throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         csvWriter.writeTo(new EntryListView(null, null, null, Optional.empty(),
-                        ImmutableList.of(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "1234abcd"), Instant.ofEpochSecond(1400000000L), "abc")), null, () -> Optional.empty(), register -> URI.create("http://" + register + ".test.register.gov.uk")),
+                        ImmutableList.of(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "1234abcd"), Instant.ofEpochSecond(1400000000L), "abc")), () -> Optional.empty(), register -> URI.create("http://" + register + ".test.register.gov.uk"), new EmptyRegister()),
                 EntryListView.class,
                 null,
                 null,

--- a/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
@@ -66,7 +66,7 @@ public class TurtleRepresentationWriterTest {
                 "key3", new StringValue("val\"ue3"),
                 "key4", new StringValue("value4")
         );
-        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item(new HashValue(HashingAlgorithm.SHA256, "hash"), objectMapper.valueToTree(map)), null, () -> Optional.empty(), registerResolver);
+        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item(new HashValue(HashingAlgorithm.SHA256, "hash"), objectMapper.valueToTree(map)), () -> Optional.empty(), registerResolver, new EmptyRegister());
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
@@ -79,7 +79,7 @@ public class TurtleRepresentationWriterTest {
 
     @Test
     public void rendersEntryIdentifierFromRequestContext() throws Exception {
-        EntryView entryView = new EntryView(requestContext, null, null, new Entry(52, new HashValue(HashingAlgorithm.SHA256, "hash"), Instant.now(), "key"), null, () -> Optional.empty(), registerResolver);
+        EntryView entryView = new EntryView(requestContext, null, null, new Entry(52, new HashValue(HashingAlgorithm.SHA256, "hash"), Instant.now(), "key"), () -> Optional.empty(), registerResolver, new EmptyRegister());
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
@@ -99,7 +99,7 @@ public class TurtleRepresentationWriterTest {
                         "name", new StringValue("foo")
                 );
 
-        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash"), objectMapper.valueToTree(map)), null, () -> Optional.empty(), registerResolver);
+        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash"), objectMapper.valueToTree(map)), () -> Optional.empty(), registerResolver, new EmptyRegister());
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
@@ -122,7 +122,7 @@ public class TurtleRepresentationWriterTest {
                         "name", new StringValue("foo")
                 );
 
-        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item(new HashValue(HashingAlgorithm.SHA256, "hash"), objectMapper.valueToTree(map)), null, () -> Optional.empty(), registerResolver);
+        ItemView itemView = new ItemView(requestContext, null, null, itemConverter, new Item(new HashValue(HashingAlgorithm.SHA256, "hash"), objectMapper.valueToTree(map)), () -> Optional.empty(), registerResolver, new EmptyRegister());
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 


### PR DESCRIPTION
This migrates the views to use the RegisterReadOnly interface instead
of RegisterData.  It also adds getRegisterName() and
getRegisterMetadata() to that interface.

My idea here is that we can start to migrate other things to the
RegisterReadOnly interface - like getting the custodian and the
branding.

This also will help with the work I'm doing towards multiple registers
in one app server.