### PR TITLE
spring clean

### DIFF
--- a/src/main/java/uk/gov/register/db/CurrentKeysUpdateDAO.java
+++ b/src/main/java/uk/gov/register/db/CurrentKeysUpdateDAO.java
@@ -5,7 +5,6 @@ import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
-import org.skife.jdbi.v2.unstable.BindIn;
 
 @UseStringTemplate3StatementLocator
 public interface CurrentKeysUpdateDAO {

--- a/src/main/java/uk/gov/register/exceptions/OrphanItemException.java
+++ b/src/main/java/uk/gov/register/exceptions/OrphanItemException.java
@@ -16,7 +16,7 @@ public class OrphanItemException extends RuntimeException {
         errorJson = JsonNodeFactory.instance.objectNode();
         errorJson.put("message", message);
         ArrayNode orphanArray = errorJson.putArray("orphanItems");
-        orphanItems.stream().forEach(i -> orphanArray.add(i.getContent()));
+        orphanItems.forEach(i -> orphanArray.add(i.getContent()));
     }
 
     public ObjectNode getErrorJson() {

--- a/src/main/java/uk/gov/register/exceptions/RootHashAssertionException.java
+++ b/src/main/java/uk/gov/register/exceptions/RootHashAssertionException.java
@@ -6,8 +6,4 @@ public class RootHashAssertionException extends RuntimeException {
         super(message);
     }
 
-    public RootHashAssertionException(String message, Exception e) {
-        super(message, e);
-    }
-
 }

--- a/src/main/java/uk/gov/register/exceptions/SerializedRegisterParseException.java
+++ b/src/main/java/uk/gov/register/exceptions/SerializedRegisterParseException.java
@@ -1,7 +1,5 @@
 package uk.gov.register.exceptions;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 public class SerializedRegisterParseException extends RuntimeException {
 
     public SerializedRegisterParseException(String message) {

--- a/src/main/java/uk/gov/register/providers/OrphanItemExceptionMapper.java
+++ b/src/main/java/uk/gov/register/providers/OrphanItemExceptionMapper.java
@@ -1,14 +1,11 @@
 package uk.gov.register.providers;
 
-import uk.gov.register.exceptions.NoSuchItemForEntryException;
 import uk.gov.register.exceptions.OrphanItemException;
 
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import java.util.Map;
 
 @Provider
 public class OrphanItemExceptionMapper implements ExceptionMapper<OrphanItemException> {

--- a/src/main/java/uk/gov/register/providers/RootHashAssertionExceptionMapper.java
+++ b/src/main/java/uk/gov/register/providers/RootHashAssertionExceptionMapper.java
@@ -1,7 +1,6 @@
 package uk.gov.register.providers;
 
 import uk.gov.register.exceptions.RootHashAssertionException;
-import uk.gov.register.exceptions.SerializationFormatValidationException;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;

--- a/src/main/java/uk/gov/register/resources/RegisterCommandReader.java
+++ b/src/main/java/uk/gov/register/resources/RegisterCommandReader.java
@@ -1,13 +1,10 @@
 package uk.gov.register.resources;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.register.serialization.CommandParser;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.serialization.RegisterSerialisationFormat;
 import uk.gov.register.views.representations.ExtraMediaType;
 
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -26,8 +23,6 @@ import java.util.Iterator;
 @Consumes(ExtraMediaType.APPLICATION_RSF)
 public class RegisterCommandReader implements MessageBodyReader<RegisterSerialisationFormat> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RegisterCommandReader.class);
-
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return type == RegisterSerialisationFormat.class;
@@ -41,7 +36,7 @@ public class RegisterCommandReader implements MessageBodyReader<RegisterSerialis
     private RegisterSerialisationFormat parseCommands(InputStream commandStream) {
         BufferedReader buffer = new BufferedReader(new InputStreamReader(commandStream));
         final CommandParser parser = new CommandParser();
-        buffer.lines().forEach(s -> parser.addCommand(s));
+        buffer.lines().forEach(parser::addCommand);
         Iterator<RegisterCommand> commands = parser.getCommands();
         // don't close the reader as the caller will close the input stream
         return new RegisterSerialisationFormat(commands);

--- a/src/main/java/uk/gov/register/resources/RegisterCommandWriter.java
+++ b/src/main/java/uk/gov/register/resources/RegisterCommandWriter.java
@@ -4,7 +4,6 @@ import uk.gov.register.serialization.CommandParser;
 import uk.gov.register.serialization.RegisterSerialisationFormat;
 import uk.gov.register.views.representations.ExtraMediaType;
 
-import javax.inject.Inject;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;

--- a/src/main/java/uk/gov/register/store/BackingStoreDriver.java
+++ b/src/main/java/uk/gov/register/store/BackingStoreDriver.java
@@ -1,6 +1,5 @@
 package uk.gov.register.store;
 
-import com.google.common.base.Function;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
@@ -12,6 +11,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 public interface BackingStoreDriver {
 

--- a/src/main/java/uk/gov/register/store/postgres/BindEntry.java
+++ b/src/main/java/uk/gov/register/store/postgres/BindEntry.java
@@ -11,7 +11,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PARAMETER})
 public @interface BindEntry {
-    public static class EntryBinderFactory implements BinderFactory {
+    class EntryBinderFactory implements BinderFactory {
         public Binder build(Annotation annotation) {
             return (Binder<BindEntry, Entry>) (q, bind, arg) -> {
                 q.bind("entry_number", arg.getEntryNumber());

--- a/src/main/java/uk/gov/register/store/postgres/BindItem.java
+++ b/src/main/java/uk/gov/register/store/postgres/BindItem.java
@@ -12,7 +12,7 @@ import java.sql.SQLException;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PARAMETER})
 public @interface BindItem {
-    public static class ItemBinderFactory implements BinderFactory {
+    class ItemBinderFactory implements BinderFactory {
         public Binder build(Annotation annotation) {
             return (Binder<BindItem, Item>) (q, bind, arg) -> {
                 q.bind("sha256hex", arg.getSha256hex().getValue());

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
@@ -1,6 +1,5 @@
 package uk.gov.register.store.postgres;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -18,6 +17,7 @@ import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import java.time.Instant;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 
 public abstract class PostgresDriver implements BackingStoreDriver {
@@ -163,7 +163,7 @@ public abstract class PostgresDriver implements BackingStoreDriver {
         useHandle(handle -> {
             CurrentKeysUpdateDAO dao = currentKeysUpdateDAOFromHandle.apply(handle);
 
-            int[] noOfRecordsDeletedPerBatch = dao.removeRecordWithKeys(Lists.transform(currentKeys, r -> r.getKey()));
+            int[] noOfRecordsDeletedPerBatch = dao.removeRecordWithKeys(Lists.transform(currentKeys, CurrentKey::getKey));
             int noOfRecordsDeleted = IntStream.of(noOfRecordsDeletedPerBatch).sum();
             dao.writeCurrentKeys(currentKeys);
             dao.updateTotalRecords(currentKeys.size() - noOfRecordsDeleted);

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
@@ -1,6 +1,5 @@
 package uk.gov.register.store.postgres;
 
-import com.google.common.base.Function;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.tweak.HandleCallback;
@@ -12,7 +11,9 @@ import uk.gov.register.db.*;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import javax.inject.Inject;
-import java.util.Arrays;
+import java.util.function.Function;
+
+import static java.util.Collections.singletonList;
 
 public class PostgresDriverNonTransactional extends PostgresDriver {
     private DBI dbi;
@@ -33,17 +34,17 @@ public class PostgresDriverNonTransactional extends PostgresDriver {
 
     @Override
     public void insertEntry(Entry entry) {
-        super.insertEntries(Arrays.asList(entry));
+        super.insertEntries(singletonList(entry));
     }
 
     @Override
     public void insertItem(Item item) {
-        super.insertItems(Arrays.asList(item));
+        super.insertItems(singletonList(item));
     }
 
     @Override
     public void insertRecord(Record record, String registerName) {
-        super.insertCurrentKeys(Arrays.asList(new CurrentKey(record.item.getValue(registerName), record.entry.getEntryNumber())));
+        super.insertCurrentKeys(singletonList(new CurrentKey(record.item.getValue(registerName), record.entry.getEntryNumber())));
     }
 
     @Override

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverTransactional.java
@@ -1,6 +1,5 @@
 package uk.gov.register.store.postgres;
 
-import com.google.common.base.Function;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.TransactionIsolationLevel;
@@ -19,6 +18,7 @@ import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class PostgresDriverTransactional extends PostgresDriver {

--- a/src/main/java/uk/gov/register/util/HtmlViewSupport.java
+++ b/src/main/java/uk/gov/register/util/HtmlViewSupport.java
@@ -12,7 +12,7 @@ public class HtmlViewSupport {
         UriBuilder uriBuilder = UriBuilder.fromPath(requestPath);
 
         Map<String, String[]> parameterMap = httpServletRequest.getParameterMap();
-        parameterMap.keySet().stream().forEach(key ->
+        parameterMap.keySet().forEach(key ->
                         uriBuilder.queryParam(key, parameterMap.get(key)[0])
         );
 

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordListTurtleWriter.java
@@ -36,7 +36,7 @@ public class RecordListTurtleWriter extends TurtleRepresentationWriter<RecordLis
     @Override
     protected Model rdfModelFor(RecordListView view) {
         Model model = ModelFactory.createDefaultModel();
-        view.getRecords().stream().forEach(r -> model.add(new RecordTurtleWriter(requestContext, itemConverter, registerData, registerNameConfiguration, registerTrackingConfiguration, registerResolver).rdfModelFor(r)));
+        view.getRecords().forEach(r -> model.add(new RecordTurtleWriter(requestContext, itemConverter, registerData, registerNameConfiguration, registerTrackingConfiguration, registerResolver).rdfModelFor(r)));
         return model;
     }
 }

--- a/src/test/java/uk/gov/register/core/TransactionalMemoizationStoreTest.java
+++ b/src/test/java/uk/gov/register/core/TransactionalMemoizationStoreTest.java
@@ -117,7 +117,7 @@ public class TransactionalMemoizationStoreTest {
 
         verify(internalStore, never()).put(0, 1, hash);
         verify(internalStore, times(1)).put(0, 1, newHash);
-;    }
+    }
 
     @Test
     public void rollbackHashesFromStoreShouldRemoveAllStagedHashes() {

--- a/src/test/java/uk/gov/register/functional/AnalyticsFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/AnalyticsFunctionalTest.java
@@ -48,13 +48,11 @@ public class AnalyticsFunctionalTest {
     }
 
     private final String targetUrl;
-    private final String trackingId;
     private final Boolean shouldIncludeAnalytics;
 
     public AnalyticsFunctionalTest(String targetUrl, String trackingId, Boolean shouldIncludeAnalytics) {
         this.register = createRegister(trackingId);
         this.targetUrl = targetUrl;
-        this.trackingId = trackingId;
         this.shouldIncludeAnalytics = shouldIncludeAnalytics;
     }
 

--- a/src/test/java/uk/gov/register/resources/DeleteRegisterDataResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/DeleteRegisterDataResourceTest.java
@@ -1,16 +1,9 @@
 package uk.gov.register.resources;
 
 import org.flywaydb.core.Flyway;
-import org.junit.Before;
 import org.junit.Test;
-import uk.gov.register.core.RegisterReadOnly;
-import uk.gov.register.views.HomePageView;
-import uk.gov.register.views.ViewFactory;
 
 import javax.ws.rs.core.Response;
-import java.security.NoSuchAlgorithmException;
-import java.time.Instant;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/uk/gov/register/resources/RegisterCommandReaderTest.java
+++ b/src/test/java/uk/gov/register/resources/RegisterCommandReaderTest.java
@@ -6,12 +6,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.register.serialization.CommandParser;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.serialization.RegisterSerialisationFormat;
-import uk.gov.register.util.CanonicalJsonMapper;
-import uk.gov.register.util.CanonicalJsonValidator;
-import uk.gov.register.util.ObjectReconstructor;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static java.util.Collections.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -106,7 +107,7 @@ public class RegisterSerialisationFormatServiceTest {
 
     @Test
     public void createRegisterSerialisationFormat_returnsRSFFromEntireRegister() throws NoSuchAlgorithmException {
-        when(register.getItemIterator()).thenReturn(Arrays.asList(item).iterator());
+        when(register.getItemIterator()).thenReturn(singletonList(item).iterator());
         when(register.getEntryIterator()).thenReturn(Arrays.asList(entry1, entry2).iterator());
 
         RegisterProof expectedRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "1231234"));
@@ -137,8 +138,8 @@ public class RegisterSerialisationFormatServiceTest {
         RegisterCommand assertRootOneEntryInRegister = new AssertRootHashCommand(oneEntryRegisterProof);
         RegisterCommand assertRootTwoEntriesInRegister = new AssertRootHashCommand(twoEntriesRegisterProof);
 
-        when(register.getItemIterator(1, 2)).thenReturn(Arrays.asList(item).iterator());
-        when(register.getEntryIterator(1, 2)).thenReturn(Arrays.asList(entry2).iterator());
+        when(register.getItemIterator(1, 2)).thenReturn(singletonList(item).iterator());
+        when(register.getEntryIterator(1, 2)).thenReturn(singletonList(entry2).iterator());
         when(register.getRegisterProof(1)).thenReturn(oneEntryRegisterProof);
         when(register.getRegisterProof(2)).thenReturn(twoEntriesRegisterProof);
 

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDriverTransactionalTest.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -54,13 +54,13 @@ public class PostgresDriverTransactionalTest extends PostgresDriverTestBase {
 
     @Test
     public void getEntriesShouldAlwaysCommitStagedData() {
-        when(entryQueryDAO.getEntries(1, 10)).thenReturn(asList());
+        when(entryQueryDAO.getEntries(1, 10)).thenReturn(emptyList());
         assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.getEntries(1, 10));
     }
 
     @Test
     public void getAllEntriesShouldAlwaysCommitStagedData() {
-        when(entryQueryDAO.getAllEntriesNoPagination()).thenReturn(asList());
+        when(entryQueryDAO.getAllEntriesNoPagination()).thenReturn(emptyList());
         assertStagedDataIsCommittedOnAction(PostgresDriverTransactional::getAllEntries);
     }
 
@@ -110,7 +110,7 @@ public class PostgresDriverTransactionalTest extends PostgresDriverTestBase {
 
     @Test
     public void getAllItemsShouldAlwaysCommitStagedData() {
-        when(itemQueryDAO.getAllItemsNoPagination()).thenReturn(asList());
+        when(itemQueryDAO.getAllItemsNoPagination()).thenReturn(emptyList());
         assertStagedDataIsCommittedOnAction(PostgresDriverTransactional::getAllItems);
     }
 
@@ -128,20 +128,20 @@ public class PostgresDriverTransactionalTest extends PostgresDriverTestBase {
 
     @Test
     public void getRecordsShouldAlwaysCommitStagedData() {
-        when(recordQueryDAO.getRecords(10, 0)).thenReturn(asList());
+        when(recordQueryDAO.getRecords(10, 0)).thenReturn(emptyList());
         assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.getRecords(10, 0));
     }
 
     @Test
     public void findMax100RecordsByKeyValueShouldAlwaysCommitStagedData() {
-        when(recordQueryDAO.findMax100RecordsByKeyValue("name", "Germany")).thenReturn(asList());
+        when(recordQueryDAO.findMax100RecordsByKeyValue("name", "Germany")).thenReturn(emptyList());
 
         assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.findMax100RecordsByKeyValue("name", "Germany"));
     }
 
     @Test
     public void findAllEntriesOfRecordByShouldAlwaysCommitStagedData() {
-        when(recordQueryDAO.findAllEntriesOfRecordBy("country", "DE")).thenReturn(asList());
+        when(recordQueryDAO.findAllEntriesOfRecordBy("country", "DE")).thenReturn(emptyList());
         assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.findAllEntriesOfRecordBy("country", "DE"));
     }
 
@@ -152,7 +152,7 @@ public class PostgresDriverTransactionalTest extends PostgresDriverTestBase {
         assertStagedDataIsCommittedOnAction(postgresDriver -> postgresDriver.withVerifiableLog(verifiableLog -> func));
     }
 
-    @Test
+    @Test //TODO: equals problem here
     public void getItemBySha256ShouldCommitStagedDataOnlyIfItemNotStaged() {
         ArgumentCaptor<String> hashArgumentCaptor = ArgumentCaptor.forClass(String.class);
         when(itemQueryDAO.getItemBySHA256(hashArgumentCaptor.capture()))
@@ -188,7 +188,7 @@ public class PostgresDriverTransactionalTest extends PostgresDriverTestBase {
 
     @Test
     public void insertRecordWithSameKeyValueDoesNotStageBothCurrentKeys() {
-        when(entryQueryDAO.getAllEntriesNoPagination()).thenReturn(asList());
+        when(entryQueryDAO.getAllEntriesNoPagination()).thenReturn(emptyList());
         PostgresDriverTransactional postgresDriver = new PostgresDriverTransactional(
                 handle, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
 
@@ -213,7 +213,7 @@ public class PostgresDriverTransactionalTest extends PostgresDriverTestBase {
 
     @Test
     public void entryAndItemDataShouldBeCommittedInOrder() throws Exception {
-        when(entryQueryDAO.getAllEntriesNoPagination()).thenReturn(asList());
+        when(entryQueryDAO.getAllEntriesNoPagination()).thenReturn(emptyList());
         PostgresDriverTransactional postgresDriver = new PostgresDriverTransactional(
                 handle, memoizationStore, h -> entryQueryDAO, h -> entryDAO, h -> itemQueryDAO, h -> itemDAO, h -> recordQueryDAO, h -> currentKeysUpdateDAO);
 


### PR DESCRIPTION
almost entirely driven by IntelliJ code inspections:

 - remove unused imports
 - use Java 8 Function API, not guava
 - use singletonList() and emptyList() instead of Arrays.asList()
 - remove unused variables

all fairly self-explanatory.