### PR TITLE
Rsf performance

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,3 +34,4 @@ logging:
   # Logger-specific levels.
   loggers:
     "uk.gov": DEBUG
+    "org.skife.jdbi.v2": TRACE

--- a/src/main/java/uk/gov/register/db/CurrentKeysUpdateDAO.java
+++ b/src/main/java/uk/gov/register/db/CurrentKeysUpdateDAO.java
@@ -4,6 +4,7 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 import org.skife.jdbi.v2.unstable.BindIn;
 
@@ -12,9 +13,11 @@ public interface CurrentKeysUpdateDAO {
     String CURRENT_KEYS_TABLE = "current_keys";
 
     @SqlBatch("delete from " + CURRENT_KEYS_TABLE + " where key = :key")
+    @BatchChunkSize(1000)
     int[] removeRecordWithKeys(@Bind("key") Iterable<String> allKeys);
 
     @SqlBatch("insert into " + CURRENT_KEYS_TABLE + "(entry_number, key) values(:entry_number, :key)")
+    @BatchChunkSize(1000)
     void writeCurrentKeys(@BindBean Iterable<CurrentKey> values);
 
     @SqlUpdate("update total_records set count=count+:noOfNewRecords")

--- a/src/main/java/uk/gov/register/db/EntryDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryDAO.java
@@ -1,11 +1,13 @@
 package uk.gov.register.db;
 
 import org.skife.jdbi.v2.sqlobject.*;
+import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 import uk.gov.register.core.Entry;
 import uk.gov.register.store.postgres.BindEntry;
 
 public interface EntryDAO {
     @SqlBatch("insert into entry(entry_number, sha256hex, timestamp, key) values(:entry_number, :sha256hex, :timestampAsLong, :key)")
+    @BatchChunkSize(1000)
     void insertInBatch(@BindEntry Iterable<Entry> entries);
 
     @SqlQuery("select value from current_entry_number")

--- a/src/main/java/uk/gov/register/db/ItemDAO.java
+++ b/src/main/java/uk/gov/register/db/ItemDAO.java
@@ -1,10 +1,12 @@
 package uk.gov.register.db;
 
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
+import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 import uk.gov.register.core.Item;
 import uk.gov.register.store.postgres.BindItem;
 
 public interface ItemDAO {
     @SqlBatch("insert into item(sha256hex, content) values(:sha256hex, :content) on conflict do nothing")
+    @BatchChunkSize(1000)
     void insertInBatch(@BindItem Iterable<Item> items);
 }

--- a/src/main/java/uk/gov/register/resources/RegisterCommandReader.java
+++ b/src/main/java/uk/gov/register/resources/RegisterCommandReader.java
@@ -39,10 +39,12 @@ public class RegisterCommandReader implements MessageBodyReader<RegisterSerialis
     }
 
     private RegisterSerialisationFormat parseCommands(InputStream commandStream) {
+        LOG.debug("reading commands");
         BufferedReader buffer = new BufferedReader(new InputStreamReader(commandStream));
         final CommandParser parser = new CommandParser();
         buffer.lines().forEach(s -> parser.addCommand(s));
         Iterator<RegisterCommand> commands = parser.getCommands();
+        LOG.debug("finished reading commands");
         // don't close the reader as the caller will close the input stream
         return new RegisterSerialisationFormat(commands);
 

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
@@ -99,7 +99,7 @@ public abstract class PostgresDriver implements BackingStoreDriver {
 
     @Override
     public int getTotalEntries() {
-        return withHandleRead(handle -> entryQueryDAOFromHandle.apply(handle).getTotalEntries());
+        return withHandle(handle -> entryQueryDAOFromHandle.apply(handle).getTotalEntries());
     }
 
     @Override
@@ -178,8 +178,6 @@ public abstract class PostgresDriver implements BackingStoreDriver {
     protected abstract void useHandle(HandleConsumer callback);
 
     protected abstract <ReturnType> ReturnType withHandle(HandleCallback<ReturnType> callback);
-
-    protected abstract <ReturnType> ReturnType withHandleRead(HandleCallback<ReturnType> callback);
 
     protected abstract <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback);
 }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriver.java
@@ -99,7 +99,7 @@ public abstract class PostgresDriver implements BackingStoreDriver {
 
     @Override
     public int getTotalEntries() {
-        return withHandle(handle -> entryQueryDAOFromHandle.apply(handle).getTotalEntries());
+        return withHandleRead(handle -> entryQueryDAOFromHandle.apply(handle).getTotalEntries());
     }
 
     @Override
@@ -178,6 +178,8 @@ public abstract class PostgresDriver implements BackingStoreDriver {
     protected abstract void useHandle(HandleConsumer callback);
 
     protected abstract <ReturnType> ReturnType withHandle(HandleCallback<ReturnType> callback);
+
+    protected abstract <ReturnType> ReturnType withHandleRead(HandleCallback<ReturnType> callback);
 
     protected abstract <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback);
 }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
@@ -57,11 +57,6 @@ public class PostgresDriverNonTransactional extends PostgresDriver {
     }
 
     @Override
-    protected <ReturnType> ReturnType withHandleRead(HandleCallback<ReturnType> callback) {
-        return dbi.withHandle(callback);
-    }
-
-    @Override
     protected <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback) {
         return dbi.inTransaction((handle, status) -> callback.withHandle(handle));
     }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDriverNonTransactional.java
@@ -57,6 +57,11 @@ public class PostgresDriverNonTransactional extends PostgresDriver {
     }
 
     @Override
+    protected <ReturnType> ReturnType withHandleRead(HandleCallback<ReturnType> callback) {
+        return dbi.withHandle(callback);
+    }
+
+    @Override
     protected <ReturnType> ReturnType inTransaction(HandleCallback<ReturnType> callback) {
         return dbi.inTransaction((handle, status) -> callback.withHandle(handle));
     }


### PR DESCRIPTION
I've removed the readOnly methods from PostgresDriver as suggested and just read the max entry at the start of the transaction. I'm still puzzled by the PostgresDriverTransactional as I had though that all changes should be isolated from the database until the transaction comes to be committed.