### PR TITLE
Set batch chunk size for inserts.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,3 +34,4 @@ logging:
   # Logger-specific levels.
   loggers:
     "uk.gov": DEBUG
+    "org.skife.jdbi.v2": TRACE

--- a/src/main/java/uk/gov/register/db/CurrentKeysUpdateDAO.java
+++ b/src/main/java/uk/gov/register/db/CurrentKeysUpdateDAO.java
@@ -4,6 +4,7 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 
 @UseStringTemplate3StatementLocator
@@ -11,9 +12,11 @@ public interface CurrentKeysUpdateDAO {
     String CURRENT_KEYS_TABLE = "current_keys";
 
     @SqlBatch("delete from " + CURRENT_KEYS_TABLE + " where key = :key")
+    @BatchChunkSize(1000)
     int[] removeRecordWithKeys(@Bind("key") Iterable<String> allKeys);
 
     @SqlBatch("insert into " + CURRENT_KEYS_TABLE + "(entry_number, key) values(:entry_number, :key)")
+    @BatchChunkSize(1000)
     void writeCurrentKeys(@BindBean Iterable<CurrentKey> values);
 
     @SqlUpdate("update total_records set count=count+:noOfNewRecords")

--- a/src/main/java/uk/gov/register/db/EntryDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryDAO.java
@@ -1,11 +1,13 @@
 package uk.gov.register.db;
 
 import org.skife.jdbi.v2.sqlobject.*;
+import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 import uk.gov.register.core.Entry;
 import uk.gov.register.store.postgres.BindEntry;
 
 public interface EntryDAO {
     @SqlBatch("insert into entry(entry_number, sha256hex, timestamp, key) values(:entry_number, :sha256hex, :timestampAsLong, :key)")
+    @BatchChunkSize(1000)
     void insertInBatch(@BindEntry Iterable<Entry> entries);
 
     @SqlQuery("select value from current_entry_number")

--- a/src/main/java/uk/gov/register/db/ItemDAO.java
+++ b/src/main/java/uk/gov/register/db/ItemDAO.java
@@ -1,10 +1,12 @@
 package uk.gov.register.db;
 
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
+import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 import uk.gov.register.core.Item;
 import uk.gov.register.store.postgres.BindItem;
 
 public interface ItemDAO {
     @SqlBatch("insert into item(sha256hex, content) values(:sha256hex, :content) on conflict do nothing")
+    @BatchChunkSize(1000)
     void insertInBatch(@BindItem Iterable<Item> items);
 }

--- a/src/main/java/uk/gov/register/resources/RegisterCommandReader.java
+++ b/src/main/java/uk/gov/register/resources/RegisterCommandReader.java
@@ -1,5 +1,7 @@
 package uk.gov.register.resources;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.register.serialization.CommandParser;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.serialization.RegisterSerialisationFormat;
@@ -23,6 +25,8 @@ import java.util.Iterator;
 @Consumes(ExtraMediaType.APPLICATION_RSF)
 public class RegisterCommandReader implements MessageBodyReader<RegisterSerialisationFormat> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(RegisterCommandReader.class);
+
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return type == RegisterSerialisationFormat.class;
@@ -34,10 +38,12 @@ public class RegisterCommandReader implements MessageBodyReader<RegisterSerialis
     }
 
     private RegisterSerialisationFormat parseCommands(InputStream commandStream) {
+        LOG.debug("reading commands");
         BufferedReader buffer = new BufferedReader(new InputStreamReader(commandStream));
         final CommandParser parser = new CommandParser();
         buffer.lines().forEach(parser::addCommand);
         Iterator<RegisterCommand> commands = parser.getCommands();
+        LOG.debug("finished reading commands");
         // don't close the reader as the caller will close the input stream
         return new RegisterSerialisationFormat(commands);
 


### PR DESCRIPTION
Using the BatchChunkSize annotation seems to avoid memory issues when loading large registers up to and including food-premises-ratings. When doing development its useful to see the sql statements being created by jdbi. 