### PR TITLE
Fix iterator closed bug

### DIFF
--- a/src/main/java/uk/gov/register/db/EntryIteratorDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryIteratorDAO.java
@@ -15,7 +15,7 @@ public class EntryIteratorDAO {
     }
 
     public Entry findByEntryNumber(int entryNumber) {
-        if (iterator == null || entryNumber != nextValidEntryNumber) {
+        if (iterator == null || !iterator.hasNext() || entryNumber != nextValidEntryNumber) {
             if (iterator != null) {
                 iterator.close();
             }

--- a/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
@@ -20,6 +20,7 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
@@ -43,17 +44,24 @@ public class LoadSerializedFunctionalTest {
         Response r = send(input);
         assertThat(r.getStatus(), equalTo(204));
 
-        TestDBItem storedItem = testItemDAO.getItems().get(0);
-        assertThat(storedItem.contents.toString(), equalTo("{\"text\":\"SomeText\",\"register\":\"ft_openregister_test\"}"));
-        assertThat(storedItem.hashValue.getValue(), equalTo("3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254"));
+        List<TestDBItem> storedItems = testItemDAO.getItems();
+        assertThat(storedItems.get(0).contents.toString(), equalTo("{\"text\":\"SomeText\",\"register\":\"ft_openregister_test\"}"));
+        assertThat(storedItems.get(0).hashValue.getValue(), equalTo("3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254"));
+        assertThat(storedItems.get(1).contents.toString(), equalTo("{\"text\":\"SomeText\",\"register\":\"ft_openregister_test2\"}"));
+        assertThat(storedItems.get(1).hashValue.getValue(), equalTo("b8b56d0329b4a82ce55217cfbb3803c322bf43711f82649757e9c2df5f5b8371"));
 
-        Entry entry = testEntryDAO.getAllEntries().get(0);
-        assertThat(entry.getEntryNumber(), is(1));
-        assertThat(entry.getSha256hex().getValue(), is("3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254"));
+        List<Entry> entries = testEntryDAO.getAllEntries();
+        assertThat(entries.get(0).getEntryNumber(), is(1));
+        assertThat(entries.get(0).getSha256hex().getValue(), is("3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254"));
+        assertThat(entries.get(1).getEntryNumber(), is(2));
+        assertThat(entries.get(1).getSha256hex().getValue(), is("b8b56d0329b4a82ce55217cfbb3803c322bf43711f82649757e9c2df5f5b8371"));
 
-        TestRecord record = testRecordDAO.getRecord("ft_openregister_test");
-        assertThat(record.getEntryNumber(), equalTo(1));
-        assertThat(record.getPrimaryKey(), equalTo("ft_openregister_test"));
+        TestRecord record1 = testRecordDAO.getRecord("ft_openregister_test");
+        assertThat(record1.getEntryNumber(), equalTo(1));
+        assertThat(record1.getPrimaryKey(), equalTo("ft_openregister_test"));
+        TestRecord record2 = testRecordDAO.getRecord("ft_openregister_test2");
+        assertThat(record2.getEntryNumber(), equalTo(2));
+        assertThat(record2.getPrimaryKey(), equalTo("ft_openregister_test2"));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/db/EntryIteratorDAOFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/db/EntryIteratorDAOFunctionalTest.java
@@ -1,0 +1,93 @@
+package uk.gov.register.functional.db;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.skife.jdbi.v2.ResultIterator;
+import uk.gov.register.core.Entry;
+import uk.gov.register.db.EntryIteratorDAO;
+import uk.gov.register.db.EntryQueryDAO;
+import uk.gov.register.functional.app.RegisterRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.register.functional.db.TestDBSupport.*;
+
+public class EntryIteratorDAOFunctionalTest {
+
+    private EntryIteratorDAO entryIteratorDAO;
+
+    @ClassRule
+    public static final RegisterRule register = new RegisterRule("register");
+
+    @Before
+    public void publishTestMessages() {
+        register.wipe();
+
+        EntryQueryDAO entryQueryDAO = mock(EntryQueryDAO.class);
+        when(entryQueryDAO.entriesIteratorFrom(anyInt())).thenAnswer(new Answer<ResultIterator<Entry>>() {
+            @Override
+            public ResultIterator<Entry> answer(InvocationOnMock invocation) throws Throwable {
+                return testEntryDAO.entriesIteratorFrom(invocation.getArgument(0));
+            }
+        });
+
+        entryIteratorDAO = new EntryIteratorDAO(entryQueryDAO);
+    }
+
+    @Test
+    public void testCanIterateInOrder() {
+        register.loadRsf("add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+                "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
+                "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
+                "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
+
+        assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
+        assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));
+    }
+
+    @Test
+    public void testCanIterateNotInOrder() {
+        register.loadRsf("add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+                "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
+                "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
+                "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
+
+        assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));
+        assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
+    }
+
+    @Test
+    public void testCanStillIterateAfterIteratorEndsThenNewEntriesAdded() {
+        register.loadRsf("add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+                "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n");
+
+        assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
+
+        register.loadRsf("add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
+                "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
+
+        assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));
+    }
+
+    @Test
+    public void testCanStillIterateAfterIteratorDoesNotThenNewEntriesAddedd() {
+        register.loadRsf("add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+                "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
+                "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
+                "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
+
+        assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
+
+        register.loadRsf("add-item\t{\"fields\":[\"field1\",\"field2\",\"field3\"],\"register\":\"value3\",\"text\":\"The Entry 3\"}\n" +
+                "append-entry\t2016-03-01T01:02:03Z\tsha-256:8d5c2ed1e59f8871dff6e2132171008f12f43aa37e70ab158d598bc6b6db848f\tvalue1\n");
+
+        assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));
+        assertThat(entryIteratorDAO.findByEntryNumber(3).getEntryNumber(), equalTo(3));
+    }
+}

--- a/src/test/java/uk/gov/register/functional/db/TestEntryDAO.java
+++ b/src/test/java/uk/gov/register/functional/db/TestEntryDAO.java
@@ -1,12 +1,16 @@
 package uk.gov.register.functional.db;
 
+import org.skife.jdbi.v2.ResultIterator;
 import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.FetchSize;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.db.mappers.EntryMapper;
 import uk.gov.register.util.HashValue;
 
 import java.sql.ResultSet;
@@ -23,6 +27,11 @@ public interface TestEntryDAO {
     @RegisterMapper(EntryMapper.class)
     @SqlQuery("select entry_number, sha256hex, timestamp, key from entry")
     List<Entry> getAllEntries();
+
+    @SqlQuery("SELECT * FROM entry WHERE entry_number >= :entryNumber ORDER BY entry_number")
+    @RegisterMapper(EntryMapper.class)
+    @FetchSize(262144) // Has to be non-zero to enable cursor mode https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
+    ResultIterator<Entry> entriesIteratorFrom(@Bind("entryNumber") int entryNumber);
 
     class EntryMapper implements ResultSetMapper<Entry> {
         @Override

--- a/src/test/java/uk/gov/register/resources/RegisterCommandReaderTest.java
+++ b/src/test/java/uk/gov/register/resources/RegisterCommandReaderTest.java
@@ -49,7 +49,7 @@ public class RegisterCommandReaderTest {
             RegisterSerialisationFormat registerSerialisationFormat = registerCommandReader.readFrom(type, genericType, annotations, mediaType, httpHeaders, serializerRegisterStream);
             RegisterCommand[] registerCommands = Iterators.toArray(registerSerialisationFormat.getCommands(), RegisterCommand.class);
 
-            assertThat(registerCommands.length, is(4));
+            assertThat(registerCommands.length, is(7));
         }
     }
 

--- a/src/test/resources/fixtures/serialized/register-register-rsf.tsv
+++ b/src/test/resources/fixtures/serialized/register-register-rsf.tsv
@@ -2,3 +2,6 @@ assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991
 add-item	{"register":"ft_openregister_test","text":"SomeText"}
 append-entry	2016-11-02T14:45:54Z	sha-256:3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254	ft_openregister_test
 assert-root-hash	sha-256:73c630e876cceeffa993aa9b68eb8448c2dddb42665627b3c4e579a7d5018908
+add-item	{"register":"ft_openregister_test2","text":"SomeText"}
+append-entry	2016-11-02T14:45:54Z	sha-256:b8b56d0329b4a82ce55217cfbb3803c322bf43711f82649757e9c2df5f5b8371	ft_openregister_test2
+assert-root-hash	sha-256:e32a78a66e26fc0b15db224ea72b847ccb4bef9154f24096edc5f1819b67350f


### PR DESCRIPTION
Sometimes the iterator may not be null but may be already closed. This occurs because we have used the EntryIteratorDAO previously to read up to the end of the iterator (which will close it). This now checks for the closed iterator and recreates it if necessary.