### PR TITLE
create RegisterName class

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -103,6 +103,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(RegisterSerialisationFormatService.class).to(RegisterSerialisationFormatService.class);
 
                 bind(RequestContext.class).to(RequestContext.class).to(SchemeContext.class);
+                bindFactory(Factories.RegisterNameProvider.class).to(RegisterName.class);
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);
                 bind(ItemConverter.class).to(ItemConverter.class).in(Singleton.class);
                 bind(GovukOrganisationClient.class).to(GovukOrganisationClient.class).in(Singleton.class);
@@ -122,7 +123,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
 
         if (configuration.cloudWatchEnvironmentName().isPresent()) {
             ScheduledExecutorService cloudwatch = environment.lifecycle().scheduledExecutorService("cloudwatch").threads(1).build();
-            cloudwatch.scheduleAtFixedRate(new CloudWatchHeartbeater(configuration.cloudWatchEnvironmentName().get(), configuration.getDefaultRegisterName()), 0, 10000, TimeUnit.MILLISECONDS);
+            cloudwatch.scheduleAtFixedRate(new CloudWatchHeartbeater(configuration.cloudWatchEnvironmentName().get(), configuration.getDefaultRegisterName().value()), 0, 10000, TimeUnit.MILLISECONDS);
         }
 
         environment.getApplicationContext().setErrorHandler(new AssetsBundleCustomErrorHandler(environment));

--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -11,11 +11,11 @@ import uk.gov.register.auth.RegisterAuthenticatorFactory;
 import uk.gov.register.configuration.*;
 import uk.gov.register.core.AllTheRegistersFactory;
 import uk.gov.register.core.RegisterContextFactory;
+import uk.gov.register.core.RegisterName;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -53,7 +53,7 @@ public class RegisterConfiguration extends Configuration
     @Valid
     @NotNull
     @JsonProperty
-    private String register;
+    private RegisterName register;
 
     @SuppressWarnings("unused")
     @Valid
@@ -96,7 +96,7 @@ public class RegisterConfiguration extends Configuration
 
     @Valid
     @JsonProperty
-    private Map<String, RegisterContextFactory> otherRegisters = new HashMap<>();
+    private Map<RegisterName, RegisterContextFactory> otherRegisters = new HashMap<>();
 
     public DataSourceFactory getDatabase() {
         return database;
@@ -110,7 +110,7 @@ public class RegisterConfiguration extends Configuration
         return new AllTheRegistersFactory(getDefaultRegister(), otherRegisters, getDefaultRegisterName());
     }
 
-    public String getDefaultRegisterName() {
+    public RegisterName getDefaultRegisterName() {
         return register;
     }
 

--- a/src/main/java/uk/gov/register/configuration/RegistersConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/RegistersConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.register.configuration;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.util.ResourceYamlFileReader;
 
 import java.util.Collection;
@@ -30,7 +31,7 @@ public class RegistersConfiguration {
         );
     }
 
-    public RegisterMetadata getRegisterMetadata(String registerName) {
+    public RegisterMetadata getRegisterMetadata(RegisterName registerName) {
         try {
             return registers.stream().filter(f -> Objects.equals(f.getRegisterName(), registerName)).findFirst().get();
         } catch (RuntimeException e) {

--- a/src/main/java/uk/gov/register/core/AllTheRegisters.java
+++ b/src/main/java/uk/gov/register/core/AllTheRegisters.java
@@ -5,14 +5,14 @@ import java.util.stream.Stream;
 
 public class AllTheRegisters {
     private RegisterContext defaultRegister;
-    private final Map<String, RegisterContext> otherRegisters;
+    private final Map<RegisterName, RegisterContext> otherRegisters;
 
-    public AllTheRegisters(RegisterContext defaultRegister, Map<String, RegisterContext> otherRegisters) {
+    public AllTheRegisters(RegisterContext defaultRegister, Map<RegisterName, RegisterContext> otherRegisters) {
         this.defaultRegister = defaultRegister;
         this.otherRegisters = otherRegisters;
     }
 
-    public RegisterContext getRegisterByName(String name) {
+    public RegisterContext getRegisterByName(RegisterName name) {
         return otherRegisters.getOrDefault(name, defaultRegister);
     }
 

--- a/src/main/java/uk/gov/register/core/AllTheRegistersFactory.java
+++ b/src/main/java/uk/gov/register/core/AllTheRegistersFactory.java
@@ -11,17 +11,17 @@ import static java.util.stream.Collectors.toMap;
 
 public class AllTheRegistersFactory {
     private RegisterContextFactory defaultRegisterFactory;
-    private final Map<String, RegisterContextFactory> otherRegisters;
-    private final String defaultRegisterName;
+    private final Map<RegisterName, RegisterContextFactory> otherRegisters;
+    private final RegisterName defaultRegisterName;
 
-    public AllTheRegistersFactory(RegisterContextFactory defaultRegisterFactory, Map<String, RegisterContextFactory> otherRegisters, String defaultRegisterName) {
+    public AllTheRegistersFactory(RegisterContextFactory defaultRegisterFactory, Map<RegisterName, RegisterContextFactory> otherRegisters, RegisterName defaultRegisterName) {
         this.defaultRegisterFactory = defaultRegisterFactory;
         this.otherRegisters = otherRegisters;
         this.defaultRegisterName = defaultRegisterName;
     }
 
     public AllTheRegisters build(DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, Environment environment) {
-        Map<String, RegisterContext> builtRegisters = otherRegisters.entrySet().stream().collect(toMap(Map.Entry::getKey,
+        Map<RegisterName, RegisterContext> builtRegisters = otherRegisters.entrySet().stream().collect(toMap(Map.Entry::getKey,
                 e -> buildRegister(e.getKey(), e.getValue(), dbiFactory, registersConfiguration, fieldsConfiguration, environment)));
         return new AllTheRegisters(
                 defaultRegisterFactory.build(defaultRegisterName, dbiFactory, registersConfiguration, fieldsConfiguration, environment),
@@ -29,7 +29,7 @@ public class AllTheRegistersFactory {
         );
     }
 
-    private RegisterContext buildRegister(String registerName, RegisterContextFactory registerFactory, DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, Environment environment) {
+    private RegisterContext buildRegister(RegisterName registerName, RegisterContextFactory registerFactory, DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, Environment environment) {
         return registerFactory.build(registerName, dbiFactory, registersConfiguration, fieldsConfiguration, environment);
     }
 }

--- a/src/main/java/uk/gov/register/core/Field.java
+++ b/src/main/java/uk/gov/register/core/Field.java
@@ -3,7 +3,6 @@ package uk.gov.register.core;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang3.StringUtils;
 import uk.gov.register.core.datatype.Datatype;
 import uk.gov.register.core.datatype.DatatypeFactory;
 
@@ -13,24 +12,24 @@ import java.util.Optional;
 public class Field {
     public final String fieldName;
     final Datatype datatype;
-    final Optional<String> register;
+    final Optional<RegisterName> register;
     final Cardinality cardinality;
     final String text;
 
     @JsonCreator
     public Field(@JsonProperty("field") String fieldName,
                  @JsonProperty("datatype") String datatype,
-                 @JsonProperty("register") String register,
+                 @JsonProperty("register") RegisterName register,
                  @JsonProperty("cardinality") Cardinality cardinality,
                  @JsonProperty("text") String text) {
         this.fieldName = fieldName;
         this.text = text;
-        this.register = StringUtils.isNotEmpty(register) ? Optional.of(register) : Optional.empty();
+        this.register = Optional.ofNullable(register);
         this.cardinality = cardinality;
         this.datatype = DatatypeFactory.get(datatype);
     }
 
-    public Optional<String> getRegister() {
+    public Optional<RegisterName> getRegister() {
         return register;
     }
 

--- a/src/main/java/uk/gov/register/core/LinkResolver.java
+++ b/src/main/java/uk/gov/register/core/LinkResolver.java
@@ -6,5 +6,5 @@ public interface LinkResolver {
     default URI resolve(LinkValue linkValue) {
         return resolve(linkValue.getTargetRegister(), linkValue.getLinkKey());
     }
-    URI resolve(String register, String linkKey);
+    URI resolve(RegisterName register, String linkKey);
 }

--- a/src/main/java/uk/gov/register/core/LinkValue.java
+++ b/src/main/java/uk/gov/register/core/LinkValue.java
@@ -10,15 +10,15 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * is the Curie as a string, while the "linkKey" is the second half of the Curie (after the colon).
  */
 public class LinkValue implements FieldValue {
-    private final String targetRegister;
+    private final RegisterName targetRegister;
     private final String value;
     private final String linkKey;
 
-    public LinkValue(String registerName, String value) {
+    public LinkValue(RegisterName registerName, String value) {
         this(registerName, value, value);
     }
 
-    private LinkValue(String registerName, String value, String linkKey){
+    private LinkValue(RegisterName registerName, String value, String linkKey){
         this.targetRegister = registerName;
         this.value = value;
         this.linkKey = linkKey;
@@ -39,7 +39,7 @@ public class LinkValue implements FieldValue {
         return false;
     }
 
-    public String getTargetRegister() {
+    public RegisterName getTargetRegister() {
         return targetRegister;
     }
 
@@ -49,7 +49,7 @@ public class LinkValue implements FieldValue {
 
     public static class CurieValue extends LinkValue {
         public CurieValue(String curieValue) {
-            super(curieValue.split(":")[0], curieValue, curieValue.split(":")[1]);
+            super(new RegisterName(curieValue.split(":")[0]), curieValue, curieValue.split(":")[1]);
         }
     }
 }

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 public class PostgresRegister implements Register {
     private final RecordIndex recordIndex;
 
-    private final String registerName;
+    private final RegisterName registerName;
     private final EntryLog entryLog;
     private final ItemStore itemStore;
     private final RegisterFieldsConfiguration registerFieldsConfiguration;
@@ -167,7 +167,7 @@ public class PostgresRegister implements Register {
     }
 
     @Override
-    public String getRegisterName() {
+    public RegisterName getRegisterName() {
         return registerName;
     }
 

--- a/src/main/java/uk/gov/register/core/RecordIndex.java
+++ b/src/main/java/uk/gov/register/core/RecordIndex.java
@@ -15,7 +15,7 @@ public interface RecordIndex {
 
     List<Record> findMax100RecordsByKeyValue(String key, String value);
 
-    Collection<Entry> findAllEntriesOfRecordBy(String registerName, String key);
+    Collection<Entry> findAllEntriesOfRecordBy(RegisterName registerName, String key);
 
     void checkpoint();
 }

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -16,7 +16,7 @@ import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 import java.util.function.Consumer;
 
 public class RegisterContext {
-    private String registerName;
+    private RegisterName registerName;
 
     private RegistersConfiguration registersConfiguration;
     private FieldsConfiguration fieldsConfiguration;
@@ -25,7 +25,7 @@ public class RegisterContext {
     private Flyway flyway;
     private RegisterMetadata registerMetadata;
 
-    public RegisterContext(String registerName, RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, MemoizationStore memoizationStore, DBI dbi, Flyway flyway) {
+    public RegisterContext(RegisterName registerName, RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, MemoizationStore memoizationStore, DBI dbi, Flyway flyway) {
         this.registerName = registerName;
         this.registersConfiguration = registersConfiguration;
         this.fieldsConfiguration = fieldsConfiguration;
@@ -35,7 +35,7 @@ public class RegisterContext {
         this.registerMetadata = registersConfiguration.getRegisterMetadata(registerName);
     }
 
-    public String getRegisterName() {
+    public RegisterName getRegisterName() {
         return registerName;
     }
 
@@ -77,7 +77,7 @@ public class RegisterContext {
                 new TransactionalItemStore(
                         handle.attach(ItemDAO.class),
                         handle.attach(ItemQueryDAO.class),
-                        new ItemValidator(registersConfiguration, fieldsConfiguration, this)),
+                        new ItemValidator(registersConfiguration, fieldsConfiguration, registerName)),
                 new TransactionalRecordIndex(
                         handle.attach(RecordQueryDAO.class),
                         handle.attach(CurrentKeysUpdateDAO.class)

--- a/src/main/java/uk/gov/register/core/RegisterContextFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterContextFactory.java
@@ -27,21 +27,21 @@ public class RegisterContextFactory {
         this.database = database;
     }
 
-    private FlywayFactory getFlywayFactory(String registerName) {
+    private FlywayFactory getFlywayFactory(RegisterName registerName) {
         FlywayFactory flywayFactory = new FlywayFactory();
         flywayFactory.setLocations(Collections.singletonList("/sql"));
-        flywayFactory.setPlaceholders(Collections.singletonMap("registerName", registerName));
+        flywayFactory.setPlaceholders(Collections.singletonMap("registerName", registerName.value()));
         flywayFactory.setOutOfOrder(true);
         return flywayFactory;
     }
 
-    public RegisterContext build(String registerName, DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, Environment environment) {
+    public RegisterContext build(RegisterName registerName, DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, Environment environment) {
         return new RegisterContext(
                 registerName,
                 registersConfiguration,
                 fieldsConfiguration,
                 new InMemoryPowOfTwoNoLeaves(),
-                dbiFactory.build(environment, database, registerName),
+                dbiFactory.build(environment, database, registerName.value()),
                 getFlywayFactory(registerName).build(database.build(environment.metrics(), registerName + "_flyway")));
     }
 }

--- a/src/main/java/uk/gov/register/core/RegisterMetadata.java
+++ b/src/main/java/uk/gov/register/core/RegisterMetadata.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Predicates.not;
 @JsonInclude(NON_NULL)
 public class RegisterMetadata {
     @JsonProperty("register")
-    private String registerName;
+    private RegisterName registerName;
     @JsonProperty
     private List<String> fields;
     @JsonProperty
@@ -50,7 +50,7 @@ public class RegisterMetadata {
     public RegisterMetadata() {
     }
 
-    public RegisterMetadata(String registerName,
+    public RegisterMetadata(RegisterName registerName,
                             List<String> fields,
                             String copyright,
                             String registry,
@@ -64,7 +64,7 @@ public class RegisterMetadata {
         this.text = text;
     }
 
-    public String getRegisterName() {
+    public RegisterName getRegisterName() {
         return registerName;
     }
 
@@ -74,7 +74,7 @@ public class RegisterMetadata {
 
     @JsonIgnore
     public Iterable<String> getNonPrimaryFields() {
-        return Iterables.filter(fields, not(equalTo(registerName)));
+        return Iterables.filter(fields, not(equalTo(registerName.value())));
     }
 
     public Iterable<String> getFields() {

--- a/src/main/java/uk/gov/register/core/RegisterName.java
+++ b/src/main/java/uk/gov/register/core/RegisterName.java
@@ -1,0 +1,47 @@
+package uk.gov.register.core;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.commons.lang3.StringUtils;
+
+/* dumb wrapper around String to give a type to a register's name */
+public class RegisterName {
+    private final String name;
+
+    @JsonCreator
+    public RegisterName(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name cannot be null");
+        }
+        this.name = name;
+    }
+
+    @JsonValue
+    public String value() {
+        return name;
+    }
+
+    public String getFriendlyRegisterName() {
+        return StringUtils.capitalize(name.replace('-', ' '));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RegisterName that = (RegisterName) o;
+
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/java/uk/gov/register/core/RegisterReadOnly.java
+++ b/src/main/java/uk/gov/register/core/RegisterReadOnly.java
@@ -42,7 +42,7 @@ public interface RegisterReadOnly {
     Iterator<Item> getItemIterator();
     Iterator<Item> getItemIterator(int start, int end);
 
-    String getRegisterName();
+    RegisterName getRegisterName();
 
     RegisterMetadata getRegisterMetadata();
 }

--- a/src/main/java/uk/gov/register/core/RegisterResolver.java
+++ b/src/main/java/uk/gov/register/core/RegisterResolver.java
@@ -3,7 +3,7 @@ package uk.gov.register.core;
 import java.net.URI;
 
 public interface RegisterResolver {
-    URI baseUriFor(String name);
+    URI baseUriFor(RegisterName name);
 
     default LinkResolver getLinkResolver() {
         return new UriTemplateLinkResolver(this);

--- a/src/main/java/uk/gov/register/core/UriTemplateLinkResolver.java
+++ b/src/main/java/uk/gov/register/core/UriTemplateLinkResolver.java
@@ -17,7 +17,7 @@ public class UriTemplateLinkResolver implements LinkResolver {
     }
 
     @Override
-    public URI resolve(String register, String linkKey) {
+    public URI resolve(RegisterName register, String linkKey) {
         URI baseUri = registerResolver.baseUriFor(register);
 
         return UriBuilder.fromUri(baseUri).path("record").path(linkKey).build();

--- a/src/main/java/uk/gov/register/core/UriTemplateRegisterResolver.java
+++ b/src/main/java/uk/gov/register/core/UriTemplateRegisterResolver.java
@@ -18,7 +18,7 @@ public class UriTemplateRegisterResolver implements RegisterResolver {
     }
 
     @Override
-    public URI baseUriFor(String name) {
+    public URI baseUriFor(RegisterName name) {
         return URI.create(String.format(template, schemeContext.getScheme(), name, registerDomain));
     }
 }

--- a/src/main/java/uk/gov/register/db/AbstractRecordIndex.java
+++ b/src/main/java/uk/gov/register/db/AbstractRecordIndex.java
@@ -3,6 +3,7 @@ package uk.gov.register.db;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Record;
 import uk.gov.register.core.RecordIndex;
+import uk.gov.register.core.RegisterName;
 
 import java.util.Collection;
 import java.util.List;
@@ -40,8 +41,8 @@ public abstract class AbstractRecordIndex implements RecordIndex {
     }
 
     @Override
-    public Collection<Entry> findAllEntriesOfRecordBy(String registerName, String key) {
+    public Collection<Entry> findAllEntriesOfRecordBy(RegisterName registerName, String key) {
         checkpoint();
-        return recordQueryDAO.findAllEntriesOfRecordBy(registerName, key);
+        return recordQueryDAO.findAllEntriesOfRecordBy(registerName.value(), key);
     }
 }

--- a/src/main/java/uk/gov/register/exceptions/NoSuchFieldException.java
+++ b/src/main/java/uk/gov/register/exceptions/NoSuchFieldException.java
@@ -1,9 +1,11 @@
 package uk.gov.register.exceptions;
 
+import uk.gov.register.core.RegisterName;
+
 import javax.ws.rs.NotFoundException;
 
 public class NoSuchFieldException extends NotFoundException {
-    public NoSuchFieldException(String registerName, String fieldName) {
+    public NoSuchFieldException(RegisterName registerName, String fieldName) {
         super("No field found matching " + fieldName + " in register " + registerName);
     }
 }

--- a/src/main/java/uk/gov/register/resources/DataDownload.java
+++ b/src/main/java/uk/gov/register/resources/DataDownload.java
@@ -5,6 +5,7 @@ import uk.gov.register.configuration.ResourceConfiguration;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.RegisterDetail;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.serialization.RegisterSerialisationFormat;
 import uk.gov.register.service.RegisterSerialisationFormatService;
@@ -24,7 +25,7 @@ public class DataDownload {
 
     private final RegisterReadOnly register;
     protected final ViewFactory viewFactory;
-    private String registerPrimaryKey;
+    private RegisterName registerPrimaryKey;
     private final ResourceConfiguration resourceConfiguration;
     private RegisterSerialisationFormatService rsfService;
 

--- a/src/main/java/uk/gov/register/resources/DataUpload.java
+++ b/src/main/java/uk/gov/register/resources/DataUpload.java
@@ -74,7 +74,7 @@ public class DataUpload {
 
     private void mintItem(Register register, AtomicInteger currentEntryNumber, Item item) {
         register.putItem(item);
-        register.appendEntry(new Entry(currentEntryNumber.incrementAndGet(), item.getSha256hex(), Instant.now(), item.getValue(this.registerContext.getRegisterName())));
+        register.appendEntry(new Entry(currentEntryNumber.incrementAndGet(), item.getSha256hex(), Instant.now(), item.getValue(this.registerContext.getRegisterName().value())));
     }
 }
 

--- a/src/main/java/uk/gov/register/resources/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/EntryResource.java
@@ -2,6 +2,7 @@ package uk.gov.register.resources;
 
 import io.dropwizard.jersey.params.IntParam;
 import uk.gov.register.core.Entry;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.providers.params.IntegerParam;
 import uk.gov.register.views.AttributionView;
@@ -23,7 +24,7 @@ public class EntryResource {
     private final ViewFactory viewFactory;
     private final RequestContext requestContext;
     private final HttpServletResponseAdapter httpServletResponseAdapter;
-    private final String registerPrimaryKey;
+    private final RegisterName registerPrimaryKey;
 
     @Inject
     public EntryResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext) {

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -5,6 +5,7 @@ import uk.gov.register.core.Entry;
 import uk.gov.register.core.FieldValue;
 import uk.gov.register.core.Record;
 import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.providers.params.IntegerParam;
 import uk.gov.register.service.ItemConverter;
@@ -34,7 +35,7 @@ public class RecordResource {
     private final RequestContext requestContext;
     private final RegisterReadOnly register;
     private final ViewFactory viewFactory;
-    private final String registerPrimaryKey;
+    private final RegisterName registerPrimaryKey;
     private final ItemConverter itemConverter;
     private Iterable<String> fields;
 

--- a/src/main/java/uk/gov/register/resources/SearchResource.java
+++ b/src/main/java/uk/gov/register/resources/SearchResource.java
@@ -1,7 +1,7 @@
 package uk.gov.register.resources;
 
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.inject.Inject;
@@ -17,12 +17,12 @@ import java.nio.charset.StandardCharsets;
 @Path("/")
 public class SearchResource {
 
-    private final String registerPrimaryKey;
+    private final RegisterName registerPrimaryKey;
     private final RegisterFieldsConfiguration registerFieldsConfiguration;
 
     @Inject
-    public SearchResource(RegisterReadOnly register, RegisterFieldsConfiguration registerFieldsConfiguration) {
-        registerPrimaryKey = register.getRegisterName();
+    public SearchResource(RegisterName registerName, RegisterFieldsConfiguration registerFieldsConfiguration) {
+        registerPrimaryKey = registerName;
         this.registerFieldsConfiguration = registerFieldsConfiguration;
     }
 
@@ -30,11 +30,11 @@ public class SearchResource {
     @Path("/{key}/{value}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public Object find(@PathParam("key") String key, @PathParam("value") String value) throws Exception {
-        if (!key.equals(registerPrimaryKey) && !registerFieldsConfiguration.containsField(key)) {
+        if (!key.equals(registerPrimaryKey.value()) && !registerFieldsConfiguration.containsField(key)) {
             throw new NotFoundException();
         }
 
-        String redirectUrl = key.equals(registerPrimaryKey) ?
+        String redirectUrl = key.equals(registerPrimaryKey.value()) ?
                 String.format("/record/%s", encodeUrlValue(value)) :
                 String.format("/records/%s/%s", key, encodeUrlValue(value));
 

--- a/src/main/java/uk/gov/register/service/ItemValidator.java
+++ b/src/main/java/uk/gov/register/service/ItemValidator.java
@@ -7,8 +7,8 @@ import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.core.Cardinality;
 import uk.gov.register.core.Field;
-import uk.gov.register.core.RegisterContext;
 import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.datatype.Datatype;
 import uk.gov.register.exceptions.ItemValidationException;
 
@@ -18,12 +18,12 @@ public class ItemValidator {
 
     private final FieldsConfiguration fieldsConfiguration;
     private final RegistersConfiguration registersConfiguration;
-    private final String registerName;
+    private final RegisterName registerName;
 
-    public ItemValidator(RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, RegisterContext registerContext) {
+    public ItemValidator(RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, RegisterName registerName) {
         this.fieldsConfiguration = fieldsConfiguration;
         this.registersConfiguration = registersConfiguration;
-        this.registerName = registerContext.getRegisterName();
+        this.registerName = registerName;
     }
 
     public void validateItem(JsonNode inputEntry) throws ItemValidationException {
@@ -37,7 +37,7 @@ public class ItemValidator {
     }
 
     private void validatePrimaryKeyExists(JsonNode inputEntry) throws ItemValidationException {
-        JsonNode primaryKeyNode = inputEntry.get(registerName);
+        JsonNode primaryKeyNode = inputEntry.get(registerName.value());
         throwEntryValidationExceptionIfConditionIsFalse(primaryKeyNode == null, inputEntry, "Entry does not contain primary key field '" + registerName + "'");
         validatePrimaryKeyIsNotBlankAssumingItWillAlwaysBeAStringNode(StringUtils.isBlank(primaryKeyNode.textValue()), inputEntry, "Primary key field '" + registerName + "' must have a valid value");
     }

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
@@ -1,11 +1,11 @@
 package uk.gov.register.thymeleaf;
 
 import io.dropwizard.views.View;
-import org.apache.commons.lang3.StringUtils;
 import org.markdownj.MarkdownProcessor;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.LinkResolver;
 import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
@@ -50,12 +50,11 @@ public class ThymeleafView extends View {
 
     @SuppressWarnings("unused, used by templates")
     public String getFriendlyRegisterName() {
-        String registerId = getRegisterId();
-        String registerName = registerId.replace('-',' ');
-        return StringUtils.capitalize(registerName) + " register";
+        // FIXME: this string concat should be in the template?
+        return getRegisterId().getFriendlyRegisterName() + " register";
     }
 
-    public String getRegisterId() {
+    public RegisterName getRegisterId() {
         return register.getRegisterName();
     }
 

--- a/src/main/java/uk/gov/register/views/HomePageView.java
+++ b/src/main/java/uk/gov/register/views/HomePageView.java
@@ -4,6 +4,7 @@ import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.configuration.RegisterContentPages;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.PublicBody;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
@@ -65,7 +66,7 @@ public class HomePageView extends AttributionView<Object> {
 
     @SuppressWarnings("unused, used from template")
     public URI getLinkToRegisterRegister() {
-        return getLinkResolver().resolve("register", getRegisterId());
+        return getLinkResolver().resolve(new RegisterName("register"), getRegisterId().value());
     }
 
     @SuppressWarnings("unused, used from template")

--- a/src/main/java/uk/gov/register/views/representations/turtle/EntryListTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/EntryListTurtleWriter.java
@@ -3,7 +3,7 @@ package uk.gov.register.views.representations.turtle;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import uk.gov.register.core.Entry;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.views.EntryListView;
 import uk.gov.register.views.representations.ExtraMediaType;
@@ -17,15 +17,15 @@ import javax.ws.rs.ext.Provider;
 public class EntryListTurtleWriter extends TurtleRepresentationWriter<EntryListView> {
 
     @Inject
-    public EntryListTurtleWriter(javax.inject.Provider<RegisterReadOnly> registerProvider, RegisterResolver registerResolver) {
-        super(registerProvider, registerResolver);
+    public EntryListTurtleWriter(javax.inject.Provider<RegisterName> registerNameProvider, RegisterResolver registerResolver) {
+        super(registerNameProvider, registerResolver);
     }
 
     @Override
     protected Model rdfModelFor(EntryListView view) {
         Model model = ModelFactory.createDefaultModel();
         for (Entry entry : view.getEntries()) {
-            model.add(new EntryTurtleWriter(registerProvider, registerResolver).rdfModelFor(entry));
+            model.add(new EntryTurtleWriter(registerNameProvider, registerResolver).rdfModelFor(entry));
         }
         return model;
     }

--- a/src/main/java/uk/gov/register/views/representations/turtle/EntryTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/EntryTurtleWriter.java
@@ -5,7 +5,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import uk.gov.register.core.Entry;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.views.representations.ExtraMediaType;
 
@@ -18,8 +18,8 @@ import javax.ws.rs.ext.Provider;
 public class EntryTurtleWriter extends TurtleRepresentationWriter<Entry> {
 
     @Inject
-    public EntryTurtleWriter(javax.inject.Provider<RegisterReadOnly> registerProvider, RegisterResolver registerResolver) {
-        super(registerProvider, registerResolver);
+    public EntryTurtleWriter(javax.inject.Provider<RegisterName> registerNameProvider, RegisterResolver registerResolver) {
+        super(registerNameProvider, registerResolver);
     }
 
     @Override

--- a/src/main/java/uk/gov/register/views/representations/turtle/ItemTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/ItemTurtleWriter.java
@@ -7,7 +7,7 @@ import org.apache.jena.rdf.model.Resource;
 import uk.gov.register.core.FieldValue;
 import uk.gov.register.core.LinkValue;
 import uk.gov.register.core.ListValue;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.views.ItemView;
 import uk.gov.register.views.representations.ExtraMediaType;
@@ -24,8 +24,8 @@ import java.util.Map;
 public class ItemTurtleWriter extends TurtleRepresentationWriter<ItemView> {
 
     @Inject
-    public ItemTurtleWriter(javax.inject.Provider<RegisterReadOnly> registerProvider, RegisterResolver registerResolver) {
-        super(registerProvider, registerResolver);
+    public ItemTurtleWriter(javax.inject.Provider<RegisterName> registerNameProvider, RegisterResolver registerResolver) {
+        super(registerNameProvider, registerResolver);
     }
 
     @Override
@@ -42,7 +42,7 @@ public class ItemTurtleWriter extends TurtleRepresentationWriter<ItemView> {
     }
 
     private String fieldUri(String key) {
-        URI fieldBaseUri = registerResolver.baseUriFor("field");
+        URI fieldBaseUri = registerResolver.baseUriFor(new RegisterName("field"));
         return UriBuilder.fromUri(fieldBaseUri).path("record").path(key).build().toString();
     }
 

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
@@ -6,7 +6,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import uk.gov.register.core.Entry;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.views.ItemView;
 import uk.gov.register.views.RecordView;
@@ -24,8 +24,8 @@ import java.util.Map;
 public class RecordTurtleWriter extends TurtleRepresentationWriter<RecordView> {
 
     @Inject
-    public RecordTurtleWriter(javax.inject.Provider<RegisterReadOnly> registerProvider, RegisterResolver registerResolver) {
-        super(registerProvider, registerResolver);
+    public RecordTurtleWriter(javax.inject.Provider<RegisterName> registerNameProvider, RegisterResolver registerResolver) {
+        super(registerNameProvider, registerResolver);
     }
 
     @Override
@@ -34,8 +34,8 @@ public class RecordTurtleWriter extends TurtleRepresentationWriter<RecordView> {
         ItemView itemView = view.getItemView();
 
         Model recordModel = ModelFactory.createDefaultModel();
-        Model entryModel = new EntryTurtleWriter(registerProvider, registerResolver).rdfModelFor(entry, false);
-        Model itemModel = new ItemTurtleWriter(registerProvider, registerResolver).rdfModelFor(itemView);
+        Model entryModel = new EntryTurtleWriter(registerNameProvider, registerResolver).rdfModelFor(entry, false);
+        Model itemModel = new ItemTurtleWriter(registerNameProvider, registerResolver).rdfModelFor(itemView);
 
         Resource recordResource = recordModel.createResource(recordUri(view.getPrimaryKey()).toString());
         addPropertiesToResource(recordResource, entryModel.getResource(entryUri(Integer.toString(entry.getEntryNumber())).toString()));

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordsTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordsTurtleWriter.java
@@ -2,7 +2,7 @@ package uk.gov.register.views.representations.turtle;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.views.RecordsView;
 import uk.gov.register.views.representations.ExtraMediaType;
@@ -16,14 +16,14 @@ import javax.ws.rs.ext.Provider;
 public class RecordsTurtleWriter extends TurtleRepresentationWriter<RecordsView> {
 
     @Inject
-    public RecordsTurtleWriter(javax.inject.Provider<RegisterReadOnly> registerProvider, RegisterResolver registerResolver) {
-        super(registerProvider, registerResolver);
+    public RecordsTurtleWriter(javax.inject.Provider<RegisterName> registerNameProvider, RegisterResolver registerResolver) {
+        super(registerNameProvider, registerResolver);
     }
 
     @Override
     protected Model rdfModelFor(RecordsView view) {
         Model model = ModelFactory.createDefaultModel();
-        RecordTurtleWriter recordTurtleWriter = new RecordTurtleWriter(registerProvider, registerResolver);
+        RecordTurtleWriter recordTurtleWriter = new RecordTurtleWriter(registerNameProvider, registerResolver);
         view.getRecords().forEach(r -> model.add(recordTurtleWriter.rdfModelFor(r)));
         return model;
     }

--- a/src/main/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriter.java
@@ -1,7 +1,7 @@
 package uk.gov.register.views.representations.turtle;
 
 import org.apache.jena.rdf.model.Model;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.views.representations.RepresentationWriter;
 
@@ -19,10 +19,10 @@ import java.net.URI;
 public abstract class TurtleRepresentationWriter<T> extends RepresentationWriter<T> {
     protected static final String SPEC_PREFIX = "https://openregister.github.io/specification/#";
     protected final RegisterResolver registerResolver;
-    protected final Provider<RegisterReadOnly> registerProvider;
+    protected final Provider<RegisterName> registerNameProvider;
 
-    protected TurtleRepresentationWriter(javax.inject.Provider<RegisterReadOnly> registerProvider, RegisterResolver registerResolver) {
-        this.registerProvider = registerProvider;
+    protected TurtleRepresentationWriter(javax.inject.Provider<RegisterName> registerNameProvider, RegisterResolver registerResolver) {
+        this.registerNameProvider = registerNameProvider;
         this.registerResolver = registerResolver;
     }
 
@@ -38,7 +38,7 @@ public abstract class TurtleRepresentationWriter<T> extends RepresentationWriter
     }
 
     protected URI ourBaseUri() {
-        return registerResolver.baseUriFor(registerProvider.get().getRegisterName());
+        return registerResolver.baseUriFor(registerNameProvider.get());
     }
 
     protected URI itemUri(String itemHash) {

--- a/src/main/resources/templates/records.html
+++ b/src/main/resources/templates/records.html
@@ -13,9 +13,9 @@
     <table th:if="${!content.records.isEmpty()}">
         <thead>
         <tr>
-            <th scope="col"><a th:href="${linkResolver.resolve('field', registerId)}" th:text="${registerId}"></a></th>
+            <th scope="col"><a th:href="${linkResolver.resolve(new uk.gov.register.core.RegisterName('field'), registerId)}" th:text="${registerId}"></a></th>
             <th:block th:each="fieldName : ${register.nonPrimaryFields}">
-                <th scope="col"><a th:href="${linkResolver.resolve('field', fieldName)}" th:text="${fieldName}"></a></th>
+                <th scope="col"><a th:href="${linkResolver.resolve(new uk.gov.register.core.RegisterName('field'), fieldName)}" th:text="${fieldName}"></a></th>
             </th:block>
         </tr>
         </thead>

--- a/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
+++ b/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
@@ -83,7 +83,7 @@ public class PostgresRegisterTest {
         Entry entryDangling = new Entry(106, new HashValue(HashingAlgorithm.SHA256, "item-hash-2"), Instant.now(), "key-2");
 
         RegisterMetadata registerMetadata = mock(RegisterMetadata.class);
-        when(registerMetadata.getRegisterName()).thenReturn("country");
+        when(registerMetadata.getRegisterName()).thenReturn(new RegisterName("country"));
 
         PostgresRegister register = new PostgresRegister(registerMetadata("country"), registerFieldsConfiguration, inMemoryEntryLog(entryDAO), inMemoryItemStore(itemValidator, entryDAO), recordIndex);
 
@@ -99,7 +99,7 @@ public class PostgresRegisterTest {
 
     private RegisterMetadata registerMetadata(String registerName) {
         RegisterMetadata mock = mock(RegisterMetadata.class);
-        when(mock.getRegisterName()).thenReturn(registerName);
+        when(mock.getRegisterName()).thenReturn(new RegisterName(registerName));
         return mock;
     }
 }

--- a/src/test/java/uk/gov/register/core/RegisterMetadataTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterMetadataTest.java
@@ -21,7 +21,7 @@ public class RegisterMetadataTest {
 
     @Test
     public void getFields_returnsFieldsInConfiguredOrder() throws Exception {
-        RegisterMetadata registerMetadata = new RegisterMetadata("address", ImmutableList.of("address", "street", "postcode", "area", "property"), "", "", "", "alpha");
+        RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("address"), ImmutableList.of("address", "street", "postcode", "area", "property"), "", "", "", "alpha");
 
         Iterable<String> fields = registerMetadata.getFields();
 
@@ -30,7 +30,7 @@ public class RegisterMetadataTest {
 
     @Test
     public void getNonPrimaryFields_returnsFieldsOtherThanPrimaryInConfiguredOrder() throws Exception {
-        RegisterMetadata registerMetadata = new RegisterMetadata("company", ImmutableList.of("address", "company", "secretary", "company-status", "company-accounts-category"), "", "", "", "alpha");
+        RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("company"), ImmutableList.of("address", "company", "secretary", "company-status", "company-accounts-category"), "", "", "", "alpha");
 
         Iterable<String> fields = registerMetadata.getNonPrimaryFields();
 
@@ -50,7 +50,7 @@ public class RegisterMetadataTest {
 
     @Test
     public void shouldSerializeUndeclaredFields() throws Exception {
-        RegisterMetadata registerMetadata = new RegisterMetadata("test-register", emptyList(), null, null, "a test register", "discovery");
+        RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("test-register"), emptyList(), null, null, "a test register", "discovery");
         registerMetadata.setOtherProperty("foo", new TextNode("bar"));
 
         String output = YAML_MAPPER.writeValueAsString(registerMetadata);
@@ -61,19 +61,19 @@ public class RegisterMetadataTest {
 
     @Test
     public void shouldRoundTripUndeclaredFields() throws Exception {
-        RegisterMetadata registerMetadata = new RegisterMetadata("test-register", emptyList(), null, null, "a test register", "discovery");
+        RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("test-register"), emptyList(), null, null, "a test register", "discovery");
         registerMetadata.setOtherProperty("foo", new TextNode("bar"));
 
         String output = YAML_MAPPER.writeValueAsString(registerMetadata);
         RegisterMetadata roundTripped = YAML_MAPPER.readValue(output, RegisterMetadata.class);
 
-        assertThat(roundTripped.getRegisterName(), is("test-register"));
+        assertThat(roundTripped.getRegisterName(), is(new RegisterName("test-register")));
         assertThat(roundTripped.getOtherProperties().get("foo"), is(new TextNode("bar")));
     }
 
     @Test
     public void shouldNotSerializeNullFields() throws Exception {
-        RegisterMetadata registerMetadata = new RegisterMetadata("test-register", emptyList(), null, null, "a test register", "discovery");
+        RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("test-register"), emptyList(), null, null, "a test register", "discovery");
 
         String output = YAML_MAPPER.writeValueAsString(registerMetadata);
 

--- a/src/test/java/uk/gov/register/core/UriTemplateLinkResolverTest.java
+++ b/src/test/java/uk/gov/register/core/UriTemplateLinkResolverTest.java
@@ -14,7 +14,7 @@ public class UriTemplateLinkResolverTest {
 
     @Test
     public void linkValueReturnsLink() {
-        LinkValue linkValue = new LinkValue("address", "1111112");
+        LinkValue linkValue = new LinkValue(new RegisterName("address"), "1111112");
 
         assertThat(localResolver.resolve(linkValue), is(URI.create("http://address.openregister.dev:8080/record/1111112")));
         assertThat(prodResolver.resolve(linkValue), is(URI.create("https://address.register.gov.uk/record/1111112")));
@@ -31,6 +31,6 @@ public class UriTemplateLinkResolverTest {
 
     @Test
     public void separateRegisterAndValueReturnsCorrectLink() throws Exception {
-        assertThat(localResolver.resolve("country","CZ"), is(URI.create("http://country.openregister.dev:8080/record/CZ")));
+        assertThat(localResolver.resolve(new RegisterName("country"),"CZ"), is(URI.create("http://country.openregister.dev:8080/record/CZ")));
     }
 }

--- a/src/test/java/uk/gov/register/core/UriTemplateRegisterResolverTest.java
+++ b/src/test/java/uk/gov/register/core/UriTemplateRegisterResolverTest.java
@@ -13,7 +13,7 @@ public class UriTemplateRegisterResolverTest {
 
     @Test
     public void linkValueReturnsLink() {
-        assertThat(localResolver.baseUriFor("address"), is(URI.create("http://address.openregister.dev:8080")));
-        assertThat(prodResolver.baseUriFor("address"), is(URI.create("https://address.register.gov.uk")));
+        assertThat(localResolver.baseUriFor(new RegisterName("address")), is(URI.create("http://address.openregister.dev:8080")));
+        assertThat(prodResolver.baseUriFor(new RegisterName("address")), is(URI.create("https://address.register.gov.uk")));
     }
 }

--- a/src/test/java/uk/gov/register/db/TransactionalRecordIndexTest.java
+++ b/src/test/java/uk/gov/register/db/TransactionalRecordIndexTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Record;
+import uk.gov.register.core.RegisterName;
 
 import java.util.*;
 
@@ -70,7 +71,7 @@ public class TransactionalRecordIndexTest {
     public void findAllEntriesOfRecordBy_shouldCauseCheckpoint() {
         recordIndex.updateRecordIndex("foo", 5);
 
-        Collection<Entry> ignored = recordIndex.findAllEntriesOfRecordBy("foo", "bar");
+        Collection<Entry> ignored = recordIndex.findAllEntriesOfRecordBy(new RegisterName("foo"), "bar");
 
         // ignore the result, but check that we flushed out to currentKeys
         assertThat(currentKeys.get("foo"), is(5));

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -135,7 +135,7 @@ public class PostgresRegisterTransactionalFunctionalTest extends TestDBSupport {
         TransactionalItemStore itemStore = new TransactionalItemStore(handle.attach(ItemDAO.class), handle.attach(ItemQueryDAO.class),
                 mock(ItemValidator.class));
         RegisterMetadata registerData = mock(RegisterMetadata.class);
-        when(registerData.getRegisterName()).thenReturn("address");
+        when(registerData.getRegisterName()).thenReturn(new RegisterName("address"));
         return new PostgresRegister(registerData, new RegisterFieldsConfiguration(emptyList()), entryLog, itemStore, new TransactionalRecordIndex(handle.attach(RecordQueryDAO.class), handle.attach(CurrentKeysUpdateDAO.class)));
     }
 }

--- a/src/test/java/uk/gov/register/resources/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/SearchResourceTest.java
@@ -3,7 +3,7 @@ package uk.gov.register.resources;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.ws.rs.NotFoundException;
@@ -23,12 +23,9 @@ import static org.mockito.Mockito.when;
 public class SearchResourceTest {
     SearchResource resource;
     RegisterFieldsConfiguration registerFieldsConfiguration;
-    RegisterReadOnly thisRegister;
 
     @Before
     public void setUp() throws Exception {
-        thisRegister = mock(RegisterReadOnly.class);
-        when(thisRegister.getRegisterName()).thenReturn("school");
         registerFieldsConfiguration = mock(RegisterFieldsConfiguration.class);
     }
 
@@ -44,14 +41,14 @@ public class SearchResourceTest {
 
     @Test(expected = NotFoundException.class)
     public void find_doesNotRedirect_whenKeyDoesNotExistAsFieldInRegister() throws Exception {
-        resource = new SearchResource(thisRegister, registerFieldsConfiguration);
+        resource = new SearchResource(new RegisterName("school"), registerFieldsConfiguration);
         resource.find("country-name", "United Kingdom");
     }
 
     @Test
     public void find_returns301_whenKeyExistsAsFieldInRegister() throws Exception {
         when(registerFieldsConfiguration.containsField("country-name")).thenReturn(true);
-        resource = new SearchResource(thisRegister, registerFieldsConfiguration);
+        resource = new SearchResource(new RegisterName("school"), registerFieldsConfiguration);
 
         Response r = (Response) resource.find("country-name", "United Kingdom");
         assertThat(r.getStatus(), equalTo(301));

--- a/src/test/java/uk/gov/register/service/ItemValidatorTest.java
+++ b/src/test/java/uk/gov/register/service/ItemValidatorTest.java
@@ -2,11 +2,10 @@ package uk.gov.register.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
 import org.junit.Test;
 import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.RegistersConfiguration;
-import uk.gov.register.core.RegisterContext;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.exceptions.ItemValidationException;
 
 import java.io.IOException;
@@ -15,8 +14,6 @@ import java.util.Optional;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ItemValidatorTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -24,14 +21,7 @@ public class ItemValidatorTest {
     private FieldsConfiguration fieldsConfiguration = new FieldsConfiguration(Optional.empty());
     private RegistersConfiguration registerConfiguration = new RegistersConfiguration(Optional.empty());
 
-    private ItemValidator itemValidator;
-
-    @Before
-    public void setUp() throws Exception {
-        RegisterContext registerContext = mock(RegisterContext.class);
-        when(registerContext.getRegisterName()).thenReturn("register");
-        itemValidator = new ItemValidator(registerConfiguration, fieldsConfiguration, registerContext);
-    }
+    private ItemValidator itemValidator = new ItemValidator(registerConfiguration, fieldsConfiguration, new RegisterName("register"));
 
     @Test
     public void validateItem_throwsValidationException_givenPrimaryKeyOfRegisterNotExists() throws IOException {

--- a/src/test/java/uk/gov/register/thymeleaf/ThymeleafViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/ThymeleafViewTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.resources.RequestContext;
 
@@ -26,9 +27,9 @@ public class ThymeleafViewTest {
 
     @Before
     public void setUp() throws Exception {
-        RegisterMetadata metadata = new RegisterMetadata("company-limited-by-guarantee", null, "Copyright text [with link](http://www.example.com/copyright)", null, null, null);
+        RegisterMetadata metadata = new RegisterMetadata(new RegisterName("company-limited-by-guarantee"), null, "Copyright text [with link](http://www.example.com/copyright)", null, null, null);
         RegisterReadOnly register = mock(RegisterReadOnly.class);
-        when(register.getRegisterName()).thenReturn("company-limited-by-guarantee");
+        when(register.getRegisterName()).thenReturn(new RegisterName("company-limited-by-guarantee"));
         when(register.getRegisterMetadata()).thenReturn(metadata);
 
         thymeleafView = new ThymeleafView(requestContext, "don't care", () -> Optional.empty(), registerName -> URI.create("http://" + registerName + ".test.register.gov.uk"), register);

--- a/src/test/java/uk/gov/register/util/ArchiveCreatorTest.java
+++ b/src/test/java/uk/gov/register/util/ArchiveCreatorTest.java
@@ -46,7 +46,7 @@ public class ArchiveCreatorTest {
             .add("field-2");
 
         RegisterMetadata registerMetadata = new RegisterMetadata(
-                "test-register",
+                new RegisterName("test-register"),
                 ImmutableList.of("field-1","field-2"),
                 null,
                 null,

--- a/src/test/java/uk/gov/register/views/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/views/HomePageViewTest.java
@@ -6,6 +6,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.configuration.RegisterContentPages;
 import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.resources.RequestContext;
@@ -36,8 +37,8 @@ public class HomePageViewTest {
         String registerText = "foo *bar* [baz](/quux)";
 
         RegisterReadOnly register = mock(RegisterReadOnly.class);
-        when(register.getRegisterName()).thenReturn("widget");
-        when(register.getRegisterMetadata()).thenReturn(new RegisterMetadata("widget", null, null, null, registerText, "alpha"));
+        when(register.getRegisterName()).thenReturn(new RegisterName("widget"));
+        when(register.getRegisterMetadata()).thenReturn(new RegisterMetadata(new RegisterName("widget"), null, null, null, registerText, "alpha"));
 
         HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, register, registerContentPages, () -> Optional.empty(), registerResolver);
 
@@ -69,7 +70,7 @@ public class HomePageViewTest {
         when(mockRequestContext.getScheme()).thenReturn("https");
 
         RegisterReadOnly register = mock(RegisterReadOnly.class);
-        when(register.getRegisterName()).thenReturn("school");
+        when(register.getRegisterName()).thenReturn(new RegisterName("school"));
         HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), register, registerContentPages, () -> Optional.empty(), registerResolver);
 
         assertThat(homePageView.getLinkToRegisterRegister(), equalTo(URI.create("http://register.test.register.gov.uk/record/school")));

--- a/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
@@ -2,7 +2,6 @@ package uk.gov.register.views.representations.turtle;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Before;
 import org.junit.Test;
 import uk.gov.register.core.*;
 import uk.gov.register.util.HashValue;
@@ -18,20 +17,11 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TurtleRepresentationWriterTest {
     private final RegisterResolver registerResolver = register -> URI.create("http://" + register + ".test.register.gov.uk");
 
     private final Set<String> fields = ImmutableSet.of("address", "location", "link-values", "string-values");
-    private RegisterReadOnly register;
-
-    @Before
-    public void setUp() throws Exception {
-        register = mock(RegisterReadOnly.class);
-        when(register.getRegisterName()).thenReturn("address");
-    }
 
     @Test
     public void rendersFieldPrefixFromConfiguration() throws Exception {
@@ -45,7 +35,7 @@ public class TurtleRepresentationWriterTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        ItemTurtleWriter writer = new ItemTurtleWriter(() -> register, registerResolver);
+        ItemTurtleWriter writer = new ItemTurtleWriter(() -> new RegisterName("address"), registerResolver);
         writer.writeTo(itemView, itemView.getClass(), null, null, null, null, outputStream);
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);
@@ -58,7 +48,7 @@ public class TurtleRepresentationWriterTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        EntryTurtleWriter writer = new EntryTurtleWriter(() -> register, registerResolver);
+        EntryTurtleWriter writer = new EntryTurtleWriter(() -> new RegisterName("address"), registerResolver);
         writer.writeTo(entry, entry.getClass(), null, null, null, null, outputStream);
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);
@@ -69,8 +59,8 @@ public class TurtleRepresentationWriterTest {
     public void rendersLinksCorrectlyAsUrls() throws Exception {
         Map<String, FieldValue> map =
                 ImmutableMap.of(
-                        "address", new LinkValue("address", "1111111"),
-                        "location", new LinkValue("address", "location-value"),
+                        "address", new LinkValue(new RegisterName("address"), "1111111"),
+                        "location", new LinkValue(new RegisterName( "address"), "location-value"),
                         "name", new StringValue("foo")
                 );
 
@@ -78,7 +68,7 @@ public class TurtleRepresentationWriterTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        ItemTurtleWriter writer = new ItemTurtleWriter(() -> register, registerResolver);
+        ItemTurtleWriter writer = new ItemTurtleWriter(() -> new RegisterName("address"), registerResolver);
         writer.writeTo(itemView, itemView.getClass(), null, null, null, null, outputStream);
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);
@@ -92,7 +82,7 @@ public class TurtleRepresentationWriterTest {
     public void rendersLists() throws Exception {
         Map<String, FieldValue> map =
                 ImmutableMap.of(
-                        "link-values", new ListValue(asList(new LinkValue("address", "1111111"), new LinkValue("address", "2222222"))),
+                        "link-values", new ListValue(asList(new LinkValue(new RegisterName("address"), "1111111"), new LinkValue(new RegisterName("address"), "2222222"))),
                         "string-values", new ListValue(asList(new StringValue("value1"), new StringValue("value2"))),
                         "name", new StringValue("foo")
                 );
@@ -101,7 +91,7 @@ public class TurtleRepresentationWriterTest {
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        ItemTurtleWriter writer = new ItemTurtleWriter(() -> register, registerResolver);
+        ItemTurtleWriter writer = new ItemTurtleWriter(() -> new RegisterName("address"), registerResolver);
         writer.writeTo(itemView, itemView.getClass(), null, null, null, null, outputStream);
 
         byte[] bytes = outputStream.toByteArray();


### PR DESCRIPTION
This creates a RegisterName class, which is mostly a thin wrapper
around String for those Strings which specifically name registers.
This achieves a couple of things:

 - a RegisterName can more easily be injected on its own
 - a String can't be passed where a RegisterName is expected, and vice
   versa

This also reduces some duplications: for example, between
AssetsBundleCustomErrorHandler and ThymeleafView (which were both
constructing friendly names) and between
AssetsBundleCustomErrorHandler and RequestContext (which were both
extracting register names from the Host/X-Forwarded-Host header).