### PR TITLE
Fail to start if we're missing required RegisterData

### DIFF
--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -23,6 +23,7 @@ public class RegisterContext {
     private MemoizationStore memoizationStore;
     private DBI dbi;
     private Flyway flyway;
+    private RegisterData registerData;
 
     public RegisterContext(String registerName, RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, MemoizationStore memoizationStore, DBI dbi, Flyway flyway) {
         this.registerName = registerName;
@@ -31,6 +32,7 @@ public class RegisterContext {
         this.memoizationStore = memoizationStore;
         this.dbi = dbi;
         this.flyway = flyway;
+        this.registerData = registersConfiguration.getRegisterData(registerName);
     }
 
     public String getRegisterName() {
@@ -42,7 +44,7 @@ public class RegisterContext {
     }
 
     public RegisterData getRegisterData() {
-        return registersConfiguration.getRegisterData(registerName);
+        return registerData;
     }
 
     public MemoizationStore getMemoizationStore() {


### PR DESCRIPTION
Currently, on startup we create all the RegisterContext instances we
need, but we don't check that RegistersConfiguration has the required
RegisterData until the first request is routed to that register.

This changes RegisterContext to pull out the needed RegisterData in
its constructor, which will force the app to fail startup if the
RegisterData can't be found.