### PR TITLE
ensure we create the `register` db

### DIFF
--- a/go
+++ b/go
@@ -12,6 +12,7 @@ function ensure_user_exists {
 
 # Set up postgres
 ensure_db_exists openregister_java
+ensure_db_exists register
 ensure_db_exists ft_openregister_java
 ensure_user_exists postgres
 


### PR DESCRIPTION
In 70291f6f, I added a dependency in `config.yaml` (the local dev
config file) on a new database called `register`, but forgot to update
the `go` script to ensure that it actually exists.