### PR TITLE
Bugfix: stop leaking flyway db connections

### DIFF
--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -99,6 +99,7 @@ public class RegisterConfiguration extends Configuration
     private Map<RegisterName, RegisterContextFactory> otherRegisters = new HashMap<>();
 
     public DataSourceFactory getDatabase() {
+        database.getProperties().put("ApplicationName", "openregister");
         return database;
     }
 

--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -99,7 +99,6 @@ public class RegisterConfiguration extends Configuration
     private Map<RegisterName, RegisterContextFactory> otherRegisters = new HashMap<>();
 
     public DataSourceFactory getDatabase() {
-        database.getProperties().put("ApplicationName", "openregister");
         return database;
     }
 

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -97,9 +97,10 @@ public class RegisterContext {
 
     public static void useTransaction(DBI dbi, Consumer<Handle> callback) {
         try {
-            dbi.useTransaction(TransactionIsolationLevel.SERIALIZABLE, (handle, status) ->
-                    callback.accept(handle)
-            );
+            dbi.useTransaction(TransactionIsolationLevel.SERIALIZABLE, (handle, status) -> {
+                handle.getConnection().setClientInfo("ApplicationName", "openregister_transactional");
+                callback.accept(handle);
+            });
         } catch (CallbackFailedException e) {
             throw Throwables.propagate(e.getCause());
         }

--- a/src/main/java/uk/gov/register/core/RegisterContextFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterContextFactory.java
@@ -36,6 +36,7 @@ public class RegisterContextFactory {
     }
 
     public RegisterContext build(RegisterName registerName, DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, Environment environment) {
+        database.getProperties().put("ApplicationName", "openregister");
         return new RegisterContext(
                 registerName,
                 registersConfiguration,

--- a/src/main/java/uk/gov/register/core/RegisterContextFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterContextFactory.java
@@ -2,6 +2,7 @@ package uk.gov.register.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.flyway.FlywayFactory;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.setup.Environment;
@@ -36,13 +37,17 @@ public class RegisterContextFactory {
     }
 
     public RegisterContext build(RegisterName registerName, DBIFactory dbiFactory, RegistersConfiguration registersConfiguration, FieldsConfiguration fieldsConfiguration, Environment environment) {
-        database.getProperties().put("ApplicationName", "openregister");
+        database.getProperties().put("ApplicationName", "openregister_" + registerName);
+        // dbiFactory.build() will ensure that this dataSource is correctly shut down
+        // it will also be shared with flyway
+        ManagedDataSource managedDataSource = database.build(environment.metrics(), registerName.value());
+
         return new RegisterContext(
                 registerName,
                 registersConfiguration,
                 fieldsConfiguration,
                 new InMemoryPowOfTwoNoLeaves(),
-                dbiFactory.build(environment, database, registerName.value()),
-                getFlywayFactory(registerName).build(database.build(environment.metrics(), registerName + "_flyway")));
+                dbiFactory.build(environment, database, managedDataSource, registerName.value()),
+                getFlywayFactory(registerName).build(managedDataSource));
     }
 }

--- a/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
+++ b/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
@@ -23,7 +23,7 @@ public class EntryMapperTest {
         String expected = "2016-07-15T10:00:00Z";
         Instant expectedInstant = Instant.parse(expected);
 
-        DBI dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java?user=postgres");
+        DBI dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java?user=postgres&ApplicationName=EntryMapperTest");
         Handle h = dbi.open();
         EntryQueryDAO entryQueryDAO = dbi.onDemand(EntryQueryDAO.class);
 

--- a/src/test/java/uk/gov/register/functional/db/TestDBSupport.java
+++ b/src/test/java/uk/gov/register/functional/db/TestDBSupport.java
@@ -4,7 +4,7 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 
 public class TestDBSupport {
-    public static String postgresConnectionString = "jdbc:postgresql://localhost:5432/ft_openregister_java?user=postgres";
+    public static String postgresConnectionString = "jdbc:postgresql://localhost:5432/ft_openregister_java?user=postgres&ApplicationName=TestDBSupport";
     public static final TestEntryDAO testEntryDAO;
     public static final TestItemCommandDAO testItemDAO;
     public static final TestRecordDAO testRecordDAO;


### PR DESCRIPTION
We used to create two separate DataSources per register: one for the
app to use, and a separate one for flyway.  The one created for the
app was created by dbiFactory.build(), which ensures that the
ManagedDataSource instance is correctly registered with the app
lifecycle hooks so that it is shut down when the app shuts down.

The flyway datasource, however, was created manually by us, and we
never register it in the lifecycle hooks.  This means that the app
leaks connections when shut down.  This causes problems when running a
lot of tests, because the collective leaked connections can exhaust
available DB connections and cause test failures.

There are two ways to fix this:

  1. register flyway's datasource with the app lifecycle so it gets
     closed
  2. get flyway to use the same datasource as the rest of the app

I went with option 2 in this commit.  With two separate DataSources,
we have two separate pools, each of which has the same minimum and
maximum sizes taken from the app configuration.  This means that when
you specify `maxSize: 4` in your configuration, you might actually
consume as many as 8 connections.  By using a single shared
DataSource, `maxSize: 4` means that only 4 connections will ever be
used.