### PR TITLE
Add functional tests for entry, item and record

### DIFF
--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -50,8 +50,8 @@ public class EntryResourceFunctionalTest {
         assertThat(response.getStatus(), equalTo(200));
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
-        String entry1Text = doc.getElementsByTag("table").select("a[href=/item/"+ item1Hash + "]").first().text();
-        String entry2Text = doc.getElementsByTag("table").select("a[href=/item/"+ item2Hash + "]").first().text();
+        String entry1Text = doc.getElementsByTag("table").select("a[href=/item/" + item1Hash + "]").first().text();
+        String entry2Text = doc.getElementsByTag("table").select("a[href=/item/" + item2Hash + "]").first().text();
 
         assertThat(entry1Text, equalTo(item1Hash));
         assertThat(entry2Text, equalTo(item2Hash));
@@ -89,7 +89,7 @@ public class EntryResourceFunctionalTest {
 
     @Test
     public void getEntryByEntryNumber() throws JSONException, IOException {
-        Response response = register.getRequest("address","/entry/1.json");
+        Response response = register.getRequest("address", "/entry/1.json");
 
         assertThat(response.getStatus(), equalTo(200));
         JsonNode res = Jackson.newObjectMapper().readValue(response.readEntity(String.class), JsonNode.class);
@@ -107,7 +107,7 @@ public class EntryResourceFunctionalTest {
 
     @Test
     public void return200ResponseForTextHtmlMediaTypeWhenItemExists() {
-        assertThat(register.getRequest("/entry/1", MediaType.TEXT_HTML).getStatus(), equalTo(200));
+        assertThat(register.getRequest("address", "/entry/1", MediaType.TEXT_HTML).getStatus(), equalTo(200));
     }
 
     @Test
@@ -131,7 +131,7 @@ public class EntryResourceFunctionalTest {
         assertThat(entryTimestamp, between(now.minus(30, SECONDS), now.plus(30, SECONDS)));
     }
 
-    private void assertEntryInJsonNode(JsonNode actualJsonNode, int expectedEntryNumber, String expectedHash){
+    private void assertEntryInJsonNode(JsonNode actualJsonNode, int expectedEntryNumber, String expectedHash) {
         assertThat(actualJsonNode.get("entry-number").asInt(), equalTo(expectedEntryNumber));
         assertThat(actualJsonNode.get("item-hash").textValue(), equalTo(expectedHash));
         assertTrue(actualJsonNode.get("entry-timestamp").textValue().matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"));

--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import uk.gov.register.functional.app.RegisterRule;
 
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.time.Instant;
@@ -102,6 +103,11 @@ public class EntryResourceFunctionalTest {
         Document doc = Jsoup.parse(response.readEntity(String.class));
         String text = doc.getElementsByTag("table").select("a[href=/item/" + item1Hash + "]").first().text();
         assertThat(text, equalTo(item1Hash));
+    }
+
+    @Test
+    public void return200ResponseForTextHtmlMediaTypeWhenItemExists() {
+        assertThat(register.getRequest("/entry/1", MediaType.TEXT_HTML).getStatus(), equalTo(200));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
@@ -41,7 +41,7 @@ public class ItemResourceFunctionalTest {
     public void return200ResponseForTextHtmlMediaTypeWhenItemExists() {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 
-        Response response = register.getRequest("address", String.format("/item/sha-256:%s.json", sha256Hex), MediaType.TEXT_HTML);
+        Response response = register.getRequest("address", String.format("/item/sha-256:%s", sha256Hex), MediaType.TEXT_HTML);
 
         assertThat(response.getStatus(), equalTo(200));
     }

--- a/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import uk.gov.register.functional.app.RegisterRule;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -34,6 +35,15 @@ public class ItemResourceFunctionalTest {
         assertThat(response.getStatus(), equalTo(200));
 
         JSONAssert.assertEquals(item1, response.readEntity(String.class), false);
+    }
+
+    @Test
+    public void return200ResponseForTextHtmlMediaTypeWhenItemExists() {
+        String sha256Hex = DigestUtils.sha256Hex(item1);
+
+        Response response = register.getRequest(String.format("/item/sha-256:%s.json", sha256Hex), MediaType.TEXT_HTML);
+
+        assertThat(response.getStatus(), equalTo(200));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
@@ -41,7 +41,7 @@ public class ItemResourceFunctionalTest {
     public void return200ResponseForTextHtmlMediaTypeWhenItemExists() {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 
-        Response response = register.getRequest(String.format("/item/sha-256:%s.json", sha256Hex), MediaType.TEXT_HTML);
+        Response response = register.getRequest("address", String.format("/item/sha-256:%s.json", sha256Hex), MediaType.TEXT_HTML);
 
         assertThat(response.getStatus(), equalTo(200));
     }

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -9,6 +9,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.register.functional.app.RegisterRule;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 
@@ -67,6 +68,13 @@ public class RecordResourceFunctionalTest {
         assertThat(response.getMediaType().getType(), equalTo("text"));
         assertThat(response.getMediaType().getSubtype(), equalTo("html"));
         assertThat(response.getStatus(), equalTo(400));
+    }
+
+    @Test
+    public void recordResource_return200ResponseForTextHtmlMediaTypeWhenRecordExists() {
+        Response response = register.getRequest("/record/6789", MediaType.TEXT_HTML);
+
+        assertThat(response.getStatus(), equalTo(200));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -72,7 +72,7 @@ public class RecordResourceFunctionalTest {
 
     @Test
     public void recordResource_return200ResponseForTextHtmlMediaTypeWhenRecordExists() {
-        Response response = register.getRequest("/record/6789", MediaType.TEXT_HTML);
+        Response response = register.getRequest("address", "/record/6789", MediaType.TEXT_HTML);
 
         assertThat(response.getStatus(), equalTo(200));
     }


### PR DESCRIPTION
Adding tests to ensure that entry, item and record pages return a 200 status code when we expect the thing to exist.