### PR TITLE
rename `otherRegisters` to `registers`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ database:
   properties:
     charSet: UTF-8
 
-otherRegisters:
+registers:
   register:
     database:
       driverClass: org.postgresql.Driver

--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -93,7 +93,7 @@ public class RegisterConfiguration extends Configuration
 
     @Valid
     @JsonProperty
-    private Map<RegisterName, RegisterContextFactory> otherRegisters = new HashMap<>();
+    private Map<RegisterName, RegisterContextFactory> registers = new HashMap<>();
 
     public DataSourceFactory getDatabase() {
         return database;
@@ -104,7 +104,7 @@ public class RegisterConfiguration extends Configuration
     }
 
     public AllTheRegistersFactory getAllTheRegisters() {
-        return new AllTheRegistersFactory(getDefaultRegister(), otherRegisters, getDefaultRegisterName());
+        return new AllTheRegistersFactory(getDefaultRegister(), registers, getDefaultRegisterName());
     }
 
     public RegisterName getDefaultRegisterName() {

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -19,7 +19,7 @@ jerseyClient:
 
 trackingId: "UA-12345678-1"
 
-otherRegisters:
+registers:
   postcode:
     database:
       driverClass: org.postgresql.Driver


### PR DESCRIPTION
Longer-term, I think we're likely to get rid of the default register
configuration items (the top-level things like `database`, `register`,
`enableRegisterDataDelete` etc).  At that point, the name
`otherRegisters` won't make sense any more.

This renames it to plain `registers`.

Nothing is yet consuming this configuration item except the config
files in this repo, so it's a safe rename to do.