### PR TITLE
Demonstrate delete data problem

### DIFF
--- a/src/main/java/uk/gov/register/core/RegisterContextFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterContextFactory.java
@@ -8,7 +8,6 @@ import io.dropwizard.flyway.FlywayFactory;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.register.configuration.ConfigManager;
-import uk.gov.verifiablelog.store.memoization.InMemoryPowOfTwoNoLeaves;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -63,7 +62,6 @@ public class RegisterContextFactory {
         return new RegisterContext(
                 registerName,
                 configManager,
-                new InMemoryPowOfTwoNoLeaves(),
                 dbiFactory.build(environment, database, managedDataSource, registerName.value()),
                 getFlywayFactory(registerName).build(managedDataSource),
                 trackingId,

--- a/src/main/java/uk/gov/register/resources/DeleteRegisterDataResource.java
+++ b/src/main/java/uk/gov/register/resources/DeleteRegisterDataResource.java
@@ -1,7 +1,5 @@
 package uk.gov.register.resources;
 
-import org.flywaydb.core.Flyway;
-import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.core.RegisterContext;
 import uk.gov.register.exceptions.NoSuchConfigException;
 
@@ -14,13 +12,11 @@ import java.io.IOException;
 
 @Path("/")
 public class DeleteRegisterDataResource {
-    private Flyway flyway;
-    private ConfigManager configManager;
+    private RegisterContext registerContext;
 
     @Inject
-    public DeleteRegisterDataResource(RegisterContext registerContext, ConfigManager configManager) {
-        this.flyway = registerContext.getFlyway();
-        this.configManager = configManager;
+    public DeleteRegisterDataResource(RegisterContext registerContext) {
+        this.registerContext = registerContext;
     }
 
     @DELETE
@@ -28,9 +24,7 @@ public class DeleteRegisterDataResource {
     @Path("/delete-register-data")
     @DataDeleteNotAllowed
     public Response deleteRegisterData() throws NoSuchConfigException, IOException {
-        flyway.clean();
-        configManager.refreshConfig();
-        flyway.migrate();
+        registerContext.resetRegister();
 
         return Response.status(200).entity("Data has been deleted").build();
     }

--- a/src/test/java/uk/gov/register/core/RegisterContextTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterContextTest.java
@@ -1,0 +1,48 @@
+package uk.gov.register.core;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.exceptions.NoSuchConfigException;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+public class RegisterContextTest {
+    private RegisterName registerName;
+    private ConfigManager configManager;
+    private DBI dbi;
+    private Flyway flyway;
+
+    @Before
+    public void setup() {
+        registerName = new RegisterName("register");
+        configManager = mock(ConfigManager.class, RETURNS_DEEP_STUBS);
+        dbi = mock(DBI.class);
+        flyway = mock(Flyway.class);
+    }
+
+    @Test
+    public void resetRegister_shouldNotResetRegister_whenEnableRegisterDataDeleteIsDisabled() throws IOException, NoSuchConfigException {
+        RegisterContext context = new RegisterContext(registerName, configManager, dbi, flyway, Optional.empty(), false, false);
+        context.resetRegister();
+
+        verify(flyway, never()).clean();
+        verify(configManager, never()).refreshConfig();
+        verify(flyway, never()).migrate();
+    }
+
+    @Test
+    public void resetRegister_shouldResetRegister_whenEnableRegisterDataDeleteIsEnabled() throws IOException, NoSuchConfigException {
+        RegisterContext context = new RegisterContext(registerName, configManager, dbi, flyway, Optional.empty(), true, false);
+        context.resetRegister();
+
+        verify(flyway, times(1)).clean();
+        verify(configManager, times(1)).refreshConfig();
+        verify(flyway, times(1)).migrate();
+    }
+}

--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
@@ -43,20 +43,20 @@ public class DeleteRegisterDataFunctionalTest {
 
     @Test
     public void deleteRegisterData_deletesProofCache() throws Exception {
-        String item1 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
-        String item2 = "{\"register\":\"register2\",\"text\":\"Register2 Text\", \"phase\":\"alpha\"}";
+        String item1 = "{\"postcode\":\"P1\"}";
+        String item2 = "{\"postcode\":\"P2\"}";
 
-        register.deleteRegisterData();
-        register.mintLines(item1, item2);
+        register.deleteRegisterData(REGISTER_WHICH_ALLOWS_DELETING);
+        register.mintLines(REGISTER_WHICH_ALLOWS_DELETING, item1, item2);
 
-        Response proof1Response = register.getRequest("/proof/register/merkle:sha-256");
+        Response proof1Response = register.getRequest(REGISTER_WHICH_ALLOWS_DELETING, "/proof/register/merkle:sha-256");
         assertThat(proof1Response.getStatus(), equalTo(200));
         String proof1 = proof1Response.readEntity(String.class);
 
-        register.deleteRegisterData();
-        register.mintLines(item2, item1);
+        register.deleteRegisterData(REGISTER_WHICH_ALLOWS_DELETING);
+        register.mintLines(REGISTER_WHICH_ALLOWS_DELETING, item2, item1);
 
-        Response proof2Response = register.getRequest("/proof/register/merkle:sha-256");
+        Response proof2Response = register.getRequest(REGISTER_WHICH_ALLOWS_DELETING, "/proof/register/merkle:sha-256");
         assertThat(proof2Response.getStatus(), equalTo(200));
         String proof2 = proof2Response.readEntity(String.class);
 

--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -38,5 +39,27 @@ public class DeleteRegisterDataFunctionalTest {
         String entriesRawJSON = entriesResponse2.readEntity(String.class);
 
         assertThat(entriesRawJSON, is("[]"));
+    }
+
+    @Test
+    public void deleteRegisterData_deletesProofCache() throws Exception {
+        String item1 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
+        String item2 = "{\"register\":\"register2\",\"text\":\"Register2 Text\", \"phase\":\"alpha\"}";
+
+        register.deleteRegisterData();
+        register.mintLines(item1, item2);
+
+        Response proof1Response = register.getRequest("/proof/register/merkle:sha-256");
+        assertThat(proof1Response.getStatus(), equalTo(200));
+        String proof1 = proof1Response.readEntity(String.class);
+
+        register.deleteRegisterData();
+        register.mintLines(item2, item1);
+
+        Response proof2Response = register.getRequest("/proof/register/merkle:sha-256");
+        assertThat(proof2Response.getStatus(), equalTo(200));
+        String proof2 = proof2Response.readEntity(String.class);
+
+        assertThat(proof2, not(equalTo(proof1)));
     }
 }

--- a/src/test/java/uk/gov/register/resources/DeleteRegisterDataResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/DeleteRegisterDataResourceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.register.resources;
 
 import org.junit.Test;
-import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.core.RegisterContext;
 
 import javax.ws.rs.core.Response;
@@ -11,18 +10,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class DeleteRegisterDataResourceTest {
-
     @Test
     public void shouldUseFlywayToDeleteData() throws Exception {
         RegisterContext registerMock = mock(RegisterContext.class, RETURNS_DEEP_STUBS);
-        ConfigManager configManager = mock(ConfigManager.class);
-        DeleteRegisterDataResource sutResource = new DeleteRegisterDataResource(registerMock, configManager);
+        DeleteRegisterDataResource sutResource = new DeleteRegisterDataResource(registerMock);
 
         Response response = sutResource.deleteRegisterData();
 
         assertThat(response.getStatus(), equalTo(200));
-        verify(registerMock.getFlyway(), times(1)).clean();
-        verify(registerMock.getFlyway(), times(1)).migrate();
+        verify(registerMock, times(1)).resetRegister();
     }
 }
 


### PR DESCRIPTION
A few notes about this pull request:
- In `RegisterMemoizationStoreFactory` it would be great if we didn't have to specify the types of `MemoizationStore` that we care about - is it overkill to add a new service which would take these types when the application is registered and loop through this in the factory to create a new store?
- Assumption has been made that we will always be returning an `InMemory` store if the requested type isn't found, but because the factory specifies `<T extends MemoizationStore>` then this should never be the case.