### PR TITLE
Introduce test register enum

### DIFF
--- a/src/test/java/uk/gov/register/functional/AnalyticsFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/AnalyticsFunctionalTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.TestRegister;
 import uk.gov.register.functional.db.TestEntry;
 
 import javax.ws.rs.core.Response;
@@ -22,9 +23,9 @@ import static uk.gov.register.views.representations.ExtraMediaType.TEXT_HTML;
 @RunWith(Parameterized.class)
 public class AnalyticsFunctionalTest {
 
-    private static final String REGISTER_WITH_MISSING_TRACKING_ID = "register";
-    private static final String REGISTER_WITH_EMPTY_TRACKING_ID = "postcode";
-    private static final String REGISTER_WITH_VALID_TRACKING_ID = "address";
+    private static final TestRegister REGISTER_WITH_MISSING_TRACKING_ID = TestRegister.register;
+    private static final TestRegister REGISTER_WITH_EMPTY_TRACKING_ID = TestRegister.postcode;
+    private static final TestRegister REGISTER_WITH_VALID_TRACKING_ID = TestRegister.address;
 
     private static final String testEntry1Key = "st1";
     private static final String testEntry2Key = "st2";
@@ -37,7 +38,9 @@ public class AnalyticsFunctionalTest {
     @Before
     public void setup() {
         register.wipe();
-        register.mintLines("address", testEntry1.itemJson, testEntry2.itemJson);
+        register.mintLines(REGISTER_WITH_MISSING_TRACKING_ID, testEntry1.itemJson, testEntry2.itemJson);
+        register.mintLines(REGISTER_WITH_EMPTY_TRACKING_ID, testEntry1.itemJson, testEntry2.itemJson);
+        register.mintLines(REGISTER_WITH_VALID_TRACKING_ID, testEntry1.itemJson, testEntry2.itemJson);
     }
 
     private final String targetUrl;
@@ -83,8 +86,8 @@ public class AnalyticsFunctionalTest {
         assertUrlHasResponseWithAppropriateAnalytics(REGISTER_WITH_VALID_TRACKING_ID, true);
     }
 
-    private void assertUrlHasResponseWithAppropriateAnalytics(String registerName, boolean shouldIncludeAnalytics) {
-        Response response = register.getRequest(registerName, targetUrl, TEXT_HTML);
+    private void assertUrlHasResponseWithAppropriateAnalytics(TestRegister testRegister, boolean shouldIncludeAnalytics) {
+        Response response = register.getRequest(testRegister, targetUrl, TEXT_HTML);
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         assertThat(response.getStatus(), lessThan(500));

--- a/src/test/java/uk/gov/register/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/functional/ApplicationTest.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.Response;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static uk.gov.register.functional.app.TestRegister.address;
 import static uk.gov.register.views.representations.ExtraMediaType.TEXT_HTML;
 
 public class ApplicationTest {
@@ -30,7 +31,7 @@ public class ApplicationTest {
     @Test
     public void appSupportsCORS() {
         String origin = "http://originfortest.com";
-        Response response = register.targetRegister("address").path("/entries")
+        Response response = register.target(address).path("/entries")
                 .request()
                 .header(HttpHeaders.ORIGIN, origin)
                 .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
@@ -49,14 +50,14 @@ public class ApplicationTest {
 
     @Test
     public void appSupportsContentSecurityPolicy() throws Exception {
-        Response response = register.getRequest("address", "/entries");
+        Response response = register.getRequest(address, "/entries");
 
         assertThat(response.getHeaders().get(HttpHeaders.CONTENT_SECURITY_POLICY), equalTo(ImmutableList.of("default-src 'self' www.google-analytics.com")));
     }
 
     @Test
     public void appExplicitlySendsHtmlCharsetInHeader() throws Exception {
-        Response response = register.getRequest("address", "/entries", TEXT_HTML);
+        Response response = register.getRequest(address, "/entries", TEXT_HTML);
 
         String contentType = (String) response.getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0);
         assertThat(contentType, containsString("text/html"));
@@ -65,21 +66,21 @@ public class ApplicationTest {
 
     @Test
     public void appSupportsContentTypeOptions() throws Exception {
-        Response response = register.getRequest("address", "/entries");
+        Response response = register.getRequest(address, "/entries");
 
         assertThat(response.getHeaders().get(HttpHeaders.X_CONTENT_TYPE_OPTIONS), equalTo(ImmutableList.of("nosniff")));
     }
 
     @Test
     public void appSupportsXssProtection() throws Exception {
-        Response response = register.getRequest("address", "/entries");
+        Response response = register.getRequest(address, "/entries");
 
         assertThat(response.getHeaders().get(HttpHeaders.X_XSS_PROTECTION), equalTo(ImmutableList.of("1; mode=block")));
     }
 
     @Test
     public void app404PageHasXhtmlLangAttributes() throws Exception {
-        Response response = register.getRequest("address", "/missing_page_to_force_a_404");
+        Response response = register.getRequest(address, "/missing_page_to_force_a_404");
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         Elements htmlElement = doc.select("html");

--- a/src/test/java/uk/gov/register/functional/AssetsBundleCustomErrorHandlerTest.java
+++ b/src/test/java/uk/gov/register/functional/AssetsBundleCustomErrorHandlerTest.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.Response;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.register.functional.app.TestRegister.address;
 
 public class AssetsBundleCustomErrorHandlerTest {
     @ClassRule
@@ -20,7 +21,7 @@ public class AssetsBundleCustomErrorHandlerTest {
 
     @Test
     public void displays404pageForNonexistentAssets() {
-        Response response = register.getRequest("address","/assets/not-an-assets");
+        Response response = register.getRequest(address, "/assets/not-an-assets");
 
         assertThat(response.getStatus(), equalTo(404));
         assertThat(response.getMediaType().isCompatible(MediaType.TEXT_HTML_TYPE), equalTo(true));

--- a/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
@@ -25,6 +25,7 @@ import java.util.zip.ZipInputStream;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static uk.gov.register.functional.app.TestRegister.address;
 
 public class DataDownloadFunctionalTest {
 
@@ -38,12 +39,12 @@ public class DataDownloadFunctionalTest {
     @Before
     public void publishTestMessages() {
         register.wipe();
-        register.mintLines("address", item1, item2, item3, item4, item1);
+        register.mintLines(address, item1, item2, item3, item4, item1);
     }
 
     @Test
     public void downloadRegister_shouldReturnAZipfile() throws IOException {
-        Response response = register.getRequest("address","/download-register");
+        Response response = register.getRequest(address, "/download-register");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo(MediaType.APPLICATION_OCTET_STREAM));
         assertThat(response.getHeaderString("Content-Disposition"), startsWith("attachment; filename="));
@@ -59,7 +60,7 @@ public class DataDownloadFunctionalTest {
 
     @Test
     public void downloadRegister_shouldUseCorrectEntryAndItemJsonFormat() throws IOException {
-        Response response = register.getRequest("address", "/download-register");
+        Response response = register.getRequest(address, "/download-register");
         InputStream is = response.readEntity(InputStream.class);
 
         List<String> itemJson = getEntries(is).entrySet().stream()
@@ -83,7 +84,7 @@ public class DataDownloadFunctionalTest {
 
     @Test
     public void downloadRegister_shouldUseCorrectRegisterJsonFormat() throws IOException {
-        Response response = register.getRequest("address", "/download-register");
+        Response response = register.getRequest(address, "/download-register");
         InputStream is = response.readEntity(InputStream.class);
 
         JsonNode registerJson = getEntries(is).get("register.json");
@@ -97,7 +98,7 @@ public class DataDownloadFunctionalTest {
 
     @Test
     public void downloadRSF_shouldReturnRegisterAsRsfStream() throws IOException {
-        Response response = register.getRequest("address", "/download-rsf");
+        Response response = register.getRequest(address, "/download-rsf");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo(ExtraMediaType.APPLICATION_RSF));
         assertThat(response.getHeaderString("Content-Disposition"), startsWith("attachment; filename="));
@@ -123,7 +124,7 @@ public class DataDownloadFunctionalTest {
 
     @Test
     public void downloadPartialRSF_shouldReturnAPartOfRegisterAsRsfStream() throws IOException {
-        Response response = register.getRequest("address", "/download-rsf/0/2");
+        Response response = register.getRequest(address, "/download-rsf/0/2");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo(ExtraMediaType.APPLICATION_RSF));
         assertThat(response.getHeaderString("Content-Disposition"), startsWith("attachment; filename="));
@@ -144,28 +145,28 @@ public class DataDownloadFunctionalTest {
 
     @Test
     public void downloadPartialRSF_shouldReturn400ForRsfBoundariesOutOfBound() throws IOException {
-        Response response = register.getRequest("address", "/download-rsf/666/1000");
+        Response response = register.getRequest(address, "/download-rsf/666/1000");
 
         assertThat(response.getStatus(), equalTo(400));
     }
 
     @Test
     public void downloadPartialRSF_shouldReturn400_whenTotalEntries1OutOfBounds() {
-        Response response = register.getRequest("address", "/download-rsf/-1/2");
+        Response response = register.getRequest(address, "/download-rsf/-1/2");
 
         assertThat(response.getStatus(), equalTo(400));
     }
 
     @Test
     public void downloadPartialRSF_shouldReturn400_whenTotalEntries2LessThanTotalEntries1() {
-        Response response = register.getRequest("address", "/download-rsf/2/1");
+        Response response = register.getRequest(address, "/download-rsf/2/1");
 
         assertThat(response.getStatus(), equalTo(400));
     }
 
     @Test
     public void downloadPartialRSF_shouldReturn400_whenRequestedTotalEntriesExceedsEntriesInRegister() {
-        Response response = register.getRequest("address", "/download-rsf/0/6");
+        Response response = register.getRequest(address, "/download-rsf/0/6");
 
         assertThat(response.getStatus(), equalTo(400));
     }
@@ -173,8 +174,8 @@ public class DataDownloadFunctionalTest {
 
     @Test
     public void downloadPartialRSF_shouldReturnSameRSFAsFullDownload() {
-        Response fullRsfResponse = register.getRequest("address", "/download-rsf");
-        Response partialRsfResponse = register.getRequest("address", "/download-rsf/0/5");
+        Response fullRsfResponse = register.getRequest(address, "/download-rsf");
+        Response partialRsfResponse = register.getRequest(address, "/download-rsf/0/5");
 
         String[] fullRsfLines = getRsfLinesFrom(fullRsfResponse);
         String[] partialRsfLines = getRsfLinesFrom(partialRsfResponse);

--- a/src/test/java/uk/gov/register/functional/DataDownloadResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadResourceFunctionalTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.TestRegister;
 
 import javax.ws.rs.core.Response;
 import java.util.Arrays;
@@ -16,8 +17,8 @@ import static org.junit.Assert.assertThat;
 @RunWith(Parameterized.class)
 public class DataDownloadResourceFunctionalTest {
 
-    public static final String REGISTER_WITH_DOWNLOAD_ENABLED = "address";
-    public static final String REGISTER_WITH_DOWNLOAD_DISABLED = "register";
+    public static final TestRegister REGISTER_WITH_DOWNLOAD_ENABLED = TestRegister.address;
+    public static final TestRegister REGISTER_WITH_DOWNLOAD_DISABLED = TestRegister.register;
     @ClassRule
     public static RegisterRule register = new RegisterRule();
 
@@ -43,9 +44,9 @@ public class DataDownloadResourceFunctionalTest {
 
     @Test
     public void checkDownloadResourceStatusCode() throws Exception {
-        String registerName = enableDownload ? REGISTER_WITH_DOWNLOAD_ENABLED : REGISTER_WITH_DOWNLOAD_DISABLED;
+        TestRegister testRegister = enableDownload ? REGISTER_WITH_DOWNLOAD_ENABLED : REGISTER_WITH_DOWNLOAD_DISABLED;
 
-        Response response = register.getRequest(registerName, targetUrl);
+        Response response = register.getRequest(testRegister, targetUrl);
         
         assertThat(response.getStatus(), equalTo(expectedStatusCode));
     }

--- a/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
@@ -10,6 +10,7 @@ import org.skife.jdbi.v2.Handle;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.TestRegister;
 import uk.gov.register.functional.db.TestDBItem;
 import uk.gov.register.functional.db.TestEntryDAO;
 import uk.gov.register.functional.db.TestItemCommandDAO;
@@ -39,7 +40,7 @@ public class DataUploadFunctionalTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
-        Handle handle = register.handleFor("register");
+        Handle handle = register.handleFor(TestRegister.register);
         testRecordDAO = handle.attach(TestRecordDAO.class);
         testEntryDAO = handle.attach(TestEntryDAO.class);
         testItemDAO = handle.attach(TestItemCommandDAO.class);
@@ -53,7 +54,7 @@ public class DataUploadFunctionalTest {
     @Test
     public void checkMessageIsConsumedAndStoredInDatabase() throws Exception {
         JsonNode inputItem = canonicalJsonMapper.readFromBytes("{\"register\":\"ft_openregister_test\",\"text\":\"SomeText\"}".getBytes());
-        Response r = register.mintLines("register", inputItem.toString());
+        Response r = register.mintLines(TestRegister.register, inputItem.toString());
         assertThat(r.getStatus(), equalTo(204));
 
         TestDBItem storedItem = testItemDAO.getItems().get(0);
@@ -67,7 +68,7 @@ public class DataUploadFunctionalTest {
         assertThat(record.getEntryNumber(), equalTo(1));
         assertThat(record.getPrimaryKey(), equalTo("ft_openregister_test"));
 
-        Response response = register.getRequest("register", "/record/ft_openregister_test.json");
+        Response response = register.getRequest(TestRegister.register, "/record/ft_openregister_test.json");
 
         assertThat(response.getStatus(), equalTo(200));
         Map actualJson = response.readEntity(Map.class);
@@ -85,7 +86,7 @@ public class DataUploadFunctionalTest {
         String item1 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
         String item2 = "{\"register\":\"register2\",\"text\":\"Register2 Text\", \"phase\":\"alpha\"}";
 
-        Response r = register.mintLines("register", item1 + "\n" + item2);
+        Response r = register.mintLines(TestRegister.register, item1, item2);
 
         assertThat(r.getStatus(), equalTo(204));
 
@@ -122,7 +123,7 @@ public class DataUploadFunctionalTest {
         String item1 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
         String item2 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
 
-        Response r = register.mintLines("register",item1 + "\n" + item2);
+        Response r = register.mintLines(TestRegister.register,item1 + "\n" + item2);
 
         assertThat(r.getStatus(), equalTo(204));
 
@@ -152,12 +153,12 @@ public class DataUploadFunctionalTest {
     @Test
     public void loadTwoNewItems_withOneItemPreexistsInDatabase_addsTwoRowsInEntryAndOnlyOneRowInItemTable() {
         String item1 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
-        Response r = register.mintLines("register", item1);
+        Response r = register.mintLines(TestRegister.register, item1);
         assertThat(r.getStatus(), equalTo(204));
 
         String item2 = "{\"register\":\"register2\",\"text\":\"Register2 Text\", \"phase\":\"alpha\"}";
 
-        r = register.mintLines("register", item1 + "\n" + item2);
+        r = register.mintLines(TestRegister.register, item1 + "\n" + item2);
 
         assertThat(r.getStatus(), equalTo(204));
 
@@ -193,18 +194,18 @@ public class DataUploadFunctionalTest {
 
     @Test
     public void validation_FailsToLoadEntryWhenNonEmptyPrimaryKeyFieldIsNotExist() {
-        Response response = register.mintLines("register", "{}");
+        Response response = register.mintLines(TestRegister.register, "{}");
         assertThat(response.getStatus(), equalTo(400));
         assertThat(response.readEntity(String.class), equalTo("Entry does not contain primary key field 'register'. Error entry: '{}'"));
 
-        response = register.mintLines("register", "{\"register\":\"  \"}");
+        response = register.mintLines(TestRegister.register, "{\"register\":\"  \"}");
         assertThat(response.getStatus(), equalTo(400));
         assertThat(response.readEntity(String.class), equalTo("Primary key field 'register' must have a valid value. Error entry: '{\"register\":\"  \"}'"));
     }
 
     @Test
     public void validation_FailsToLoadEntryWhenEntryContainsInvalidFields() {
-        Response response = register.mintLines("register", "{\"foo\":\"bar\",\"foo1\":\"bar1\"}");
+        Response response = register.mintLines(TestRegister.register, "{\"foo\":\"bar\",\"foo1\":\"bar1\"}");
         assertThat(response.getStatus(), equalTo(400));
         assertThat(response.readEntity(String.class), equalTo("Entry contains invalid fields: [foo, foo1]. Error entry: '{\"foo\":\"bar\",\"foo1\":\"bar1\"}'"));
     }
@@ -212,7 +213,7 @@ public class DataUploadFunctionalTest {
     @Test
     public void validation_FailsToLoadEntryWhenFieldWithCardinalityManyIsNotAJsonArray() {
         String entry = "{\"register\":\"someregister\",\"fields\":\"value\"}";
-        Response response = register.mintLines("register", entry);
+        Response response = register.mintLines(TestRegister.register, entry);
         assertThat(response.getStatus(), equalTo(400));
         assertThat(response.readEntity(String.class), equalTo("Field 'fields' has cardinality 'n' so the value must be an array of 'string'. Error entry: '" + entry + "'"));
     }
@@ -220,7 +221,7 @@ public class DataUploadFunctionalTest {
     @Test
     public void requestWithoutCredentials_isRejectedAsUnauthorized() throws Exception {
         // register.target() is unauthenticated
-        Response response = register.targetRegister("register").path("/load")
+        Response response = register.target(TestRegister.register).path("/load")
                 .request()
                 .post(entity("{}", APPLICATION_JSON_TYPE));
         assertThat(response.getStatus(), equalTo(401));

--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataAvailabilityFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataAvailabilityFunctionalTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.TestRegister;
 
 import javax.ws.rs.core.Response;
 import java.util.Arrays;
@@ -12,12 +13,14 @@ import java.util.Collection;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static uk.gov.register.functional.app.TestRegister.address;
+import static uk.gov.register.functional.app.TestRegister.postcode;
 
 @RunWith(Parameterized.class)
 public class DeleteRegisterDataAvailabilityFunctionalTest {
 
-    private static final String REGISTER_WHICH_ALLOWS_DELETE = "postcode";
-    private static final String REGISTER_WHICH_DENIES_DELETE = "address";
+    private static final TestRegister REGISTER_WHICH_ALLOWS_DELETE = postcode;
+    private static final TestRegister REGISTER_WHICH_DENIES_DELETE = address;
     private static final String DELETE_ENDPOINT = "/delete-register-data";
     private final Boolean enableRegisterDataDelete;
 
@@ -45,14 +48,14 @@ public class DeleteRegisterDataAvailabilityFunctionalTest {
 
     @Test
     public void checkDeleteRegisterDataStatusCode() throws Exception {
-        String registerName = enableRegisterDataDelete ? REGISTER_WHICH_ALLOWS_DELETE : REGISTER_WHICH_DENIES_DELETE;
-        Response response = isAuthenticated ? register.deleteRegisterData(registerName) : makeUnauthenticatedDeleteCallTo(registerName, DELETE_ENDPOINT);
+        TestRegister testRegister = enableRegisterDataDelete ? REGISTER_WHICH_ALLOWS_DELETE : REGISTER_WHICH_DENIES_DELETE;
+        Response response = isAuthenticated ? register.deleteRegisterData(testRegister) : makeUnauthenticatedDeleteCallTo(testRegister, DELETE_ENDPOINT);
 
         assertThat(response.getStatus(), equalTo(expectedStatusCode));
     }
 
-    private Response makeUnauthenticatedDeleteCallTo(String registerName, String endpoint) {
-        // register.targetRegister() is unauthenticated
-        return register.targetRegister(registerName).path(endpoint).request().delete();
+    private Response makeUnauthenticatedDeleteCallTo(TestRegister testRegister, String endpoint) {
+        // register.target() is unauthenticated
+        return register.target(testRegister).path(endpoint).request().delete();
     }
 }

--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
@@ -4,6 +4,7 @@ import io.dropwizard.testing.ConfigOverride;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.TestRegister;
 
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -12,9 +13,10 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static uk.gov.register.functional.app.TestRegister.postcode;
 
 public class DeleteRegisterDataFunctionalTest {
-    public static final String REGISTER_WHICH_ALLOWS_DELETING = "postcode";
+    public static final TestRegister REGISTER_WHICH_ALLOWS_DELETING = postcode;
     @ClassRule
     public static final RegisterRule register = new RegisterRule(
             ConfigOverride.config("enableRegisterDataDelete", "true"));

--- a/src/test/java/uk/gov/register/functional/EntriesResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntriesResourceFunctionalTest.java
@@ -22,12 +22,13 @@ import java.time.format.DateTimeFormatter;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.register.functional.app.TestRegister.address;
 import static uk.gov.register.views.representations.ExtraMediaType.TEXT_HTML;
 
 public class EntriesResourceFunctionalTest {
     @ClassRule
     public static RegisterRule register = new RegisterRule();
-    private final WebTarget addressTarget = register.targetRegister("address");
+    private final WebTarget addressTarget = register.target(address);
 
     @Before
     public void setup() {
@@ -36,21 +37,21 @@ public class EntriesResourceFunctionalTest {
 
     @Test
     public void entries_returnsEmptyResultJsonWhenNoEntryIsAvailable() {
-        Response response = register.getRequest("address", "/entries.json");
+        Response response = register.getRequest(address, "/entries.json");
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.readEntity(ArrayNode.class).size(), equalTo(0));
     }
 
     @Test
     public void entries_setsAppropriateFilenameForDownload() {
-        Response response = register.getRequest("address", "/entries.json");
+        Response response = register.getRequest(address, "/entries.json");
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString(HttpHeaders.CONTENT_DISPOSITION), containsString("filename=\"address-entries.json\""));
     }
 
     @Test
     public void entriesPageHasXhtmlLangAttributes() throws Throwable {
-        Response response = register.getRequest("address", "/entries", TEXT_HTML);
+        Response response = register.getRequest(address, "/entries", TEXT_HTML);
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         Elements htmlElement = doc.select("html");
@@ -64,9 +65,9 @@ public class EntriesResourceFunctionalTest {
         String item1 = "{\"address\":\"1234\",\"street\":\"elvis\"}";
         String item2 = "{\"address\":\"6789\",\"street\":\"presley\"}";
 
-        register.mintLines("address", item1, item2);
+        register.mintLines(address, item1, item2);
 
-        Response response = register.getRequest("address","/entries.json");
+        Response response = register.getRequest(address, "/entries.json");
         assertThat(response.getStatus(), equalTo(200));
         ArrayNode jsonNodes = response.readEntity(ArrayNode.class);
         assertThat(jsonNodes.size(), equalTo(2));
@@ -93,7 +94,7 @@ public class EntriesResourceFunctionalTest {
         String item2 = "{\"address\":\"6789\",\"street\":\"presley\"}";
         String item3 = "{\"address\":\"567\",\"street\":\"john\"}";
 
-        register.mintLines("address", item1, item2, item3);
+        register.mintLines(address, item1, item2, item3);
 
         Response response = addressTarget.path("/entries.json").queryParam("start",1).queryParam("limit",2)
                 .request().get();

--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertTrue;
+import static uk.gov.register.functional.app.TestRegister.address;
 import static uk.gov.register.views.representations.ExtraMediaType.TEXT_HTML;
 
 public class EntryResourceFunctionalTest {
@@ -35,17 +36,17 @@ public class EntryResourceFunctionalTest {
     private final String item2 = "{\"address\":\"6790\",\"street\":\"presley\"}";
     private final String item1Hash = "sha-256:" + DigestUtils.sha256Hex(item1);
     private final String item2Hash = "sha-256:" + DigestUtils.sha256Hex(item2);
-    private final WebTarget addressTarget = register.targetRegister("address");
+    private final WebTarget addressTarget = register.target(address);
 
     @Before
     public void publishTestMessages() throws Throwable {
         register.wipe();
-        register.mintLines("address", item1, item2);
+        register.mintLines(address, item1, item2);
     }
 
     @Test
     public void getEntriesView_itemHashesAreRenderedAsLinks() {
-        Response response = register.getRequest("address", "/entries", TEXT_HTML);
+        Response response = register.getRequest(address, "/entries", TEXT_HTML);
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -77,7 +78,7 @@ public class EntryResourceFunctionalTest {
 
     @Test
     public void getEntriesAsJson() throws JSONException, IOException {
-        Response response = register.getRequest("address", "/entries.json");
+        Response response = register.getRequest(address, "/entries.json");
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -89,7 +90,7 @@ public class EntryResourceFunctionalTest {
 
     @Test
     public void getEntryByEntryNumber() throws JSONException, IOException {
-        Response response = register.getRequest("address", "/entry/1.json");
+        Response response = register.getRequest(address, "/entry/1.json");
 
         assertThat(response.getStatus(), equalTo(200));
         JsonNode res = Jackson.newObjectMapper().readValue(response.readEntity(String.class), JsonNode.class);
@@ -98,7 +99,7 @@ public class EntryResourceFunctionalTest {
 
     @Test
     public void entryView_itemHashIsRenderedAsALink() {
-        Response response = register.getRequest("address", "/entry/1", TEXT_HTML);
+        Response response = register.getRequest(address, "/entry/1", TEXT_HTML);
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         String text = doc.getElementsByTag("table").select("a[href=/item/" + item1Hash + "]").first().text();
@@ -107,24 +108,24 @@ public class EntryResourceFunctionalTest {
 
     @Test
     public void return200ResponseForTextHtmlMediaTypeWhenItemExists() {
-        assertThat(register.getRequest("address", "/entry/1", MediaType.TEXT_HTML).getStatus(), equalTo(200));
+        assertThat(register.getRequest(address, "/entry/1", MediaType.TEXT_HTML).getStatus(), equalTo(200));
     }
 
     @Test
     public void return404ResponseWhenEntryNotExist() {
-        assertThat(register.getRequest("address", "/entry/5001").getStatus(), equalTo(404));
+        assertThat(register.getRequest(address, "/entry/5001").getStatus(), equalTo(404));
     }
 
     @Test
     public void return404ResponseWhenEntryNumberIsNotAnIntegerValue() {
-        assertThat(register.getRequest("address", "/entry/a2").getStatus(), equalTo(404));
+        assertThat(register.getRequest(address, "/entry/a2").getStatus(), equalTo(404));
     }
 
     @Test
     public void entryResource_retrievesTimestampsInUTC() throws IOException {
         Instant now = Instant.now();
 
-        Response response = register.getRequest("address", "/entry/1.json");
+        Response response = register.getRequest(address, "/entry/1.json");
         Map<String, String> responseData = response.readEntity(Map.class);
         Instant entryTimestamp = Instant.parse(responseData.get("entry-timestamp"));
 

--- a/src/test/java/uk/gov/register/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/functional/FindEntityTest.java
@@ -14,6 +14,7 @@ import java.net.URI;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.register.functional.app.TestRegister.address;
 
 public class FindEntityTest {
 
@@ -23,12 +24,12 @@ public class FindEntityTest {
     @Before
     public void publishTestMessages() {
         register.wipe();
-        register.mintLines("address", "{\"street\":\"ellis\",\"address\":\"12345\"}", "{\"street\":\"presley\",\"address\":\"6789\"}", "{\"street\":\"ellis\",\"address\":\"145678\"}");
+        register.mintLines(address, "{\"street\":\"ellis\",\"address\":\"12345\"}", "{\"street\":\"presley\",\"address\":\"6789\"}", "{\"street\":\"ellis\",\"address\":\"145678\"}");
     }
 
     @Test
     public void shouldRedirectCorrectly_whenUsingOldUrlForFindByPrimaryKey() throws JSONException {
-        WebTarget target = register.targetRegister("address");
+        WebTarget target = register.target(address);
         target.property("jersey.config.client.followRedirects",false);
         Response response = target.path("/address/12345.json").request().get();
 
@@ -40,7 +41,7 @@ public class FindEntityTest {
 
     @Test
     public void find_returnsTheCorrectTotalRecordsInPaginationHeader() {
-        Response response = register.getRequest("address", "/records/street/ellis");
+        Response response = register.getRequest(address, "/records/street/ellis");
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
 

--- a/src/test/java/uk/gov/register/functional/HomePageFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/HomePageFunctionalTest.java
@@ -6,16 +6,18 @@ import org.jsoup.select.Elements;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.TestRegister;
 
 import javax.ws.rs.core.Response;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
+import static uk.gov.register.functional.app.TestRegister.postcode;
 
 public class HomePageFunctionalTest {
 
-    private static final String REGISTER_WITH_COPYRIGHT_FIELD = "postcode";
+    private static final TestRegister REGISTER_WITH_COPYRIGHT_FIELD = postcode;
 
     @ClassRule
     public static final RegisterRule register = new RegisterRule();

--- a/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.Response;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.register.functional.app.TestRegister.address;
 
 public class ItemResourceFunctionalTest {
     @ClassRule
@@ -23,14 +24,14 @@ public class ItemResourceFunctionalTest {
     @Before
     public void publishTestMessages() throws Throwable {
         register.wipe();
-        register.mintLines("address", item1, item2);
+        register.mintLines(address, item1, item2);
     }
 
     @Test
     public void jsonRepresentationOfAnItem() throws JSONException {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 
-        Response response = register.getRequest("address", String.format("/item/sha-256:%s.json", sha256Hex));
+        Response response = register.getRequest(address, String.format("/item/sha-256:%s.json", sha256Hex));
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -41,21 +42,21 @@ public class ItemResourceFunctionalTest {
     public void return200ResponseForTextHtmlMediaTypeWhenItemExists() {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 
-        Response response = register.getRequest("address", String.format("/item/sha-256:%s", sha256Hex), MediaType.TEXT_HTML);
+        Response response = register.getRequest(address, String.format("/item/sha-256:%s", sha256Hex), MediaType.TEXT_HTML);
 
         assertThat(response.getStatus(), equalTo(200));
     }
 
     @Test
     public void return404ResponseWhenItemNotExist() throws JSONException {
-        Response response = register.getRequest("address", "/item/sha-256:notExistHexValue");
+        Response response = register.getRequest(address, "/item/sha-256:notExistHexValue");
 
         assertThat(response.getStatus(), equalTo(404));
     }
 
     @Test
     public void return404ResponseWhenItemHexIsNotInProperFormat() throws JSONException {
-        Response response = register.getRequest("address", "/item/notExistHexValue");
+        Response response = register.getRequest(address, "/item/notExistHexValue");
 
         assertThat(response.getStatus(), equalTo(404));
     }

--- a/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
@@ -8,6 +8,7 @@ import org.junit.rules.TestRule;
 import org.skife.jdbi.v2.Handle;
 import uk.gov.register.core.Entry;
 import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.TestRegister;
 import uk.gov.register.functional.app.WipeDatabaseRule;
 import uk.gov.register.functional.db.TestDBItem;
 import uk.gov.register.functional.db.TestEntryDAO;
@@ -27,7 +28,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class LoadSerializedFunctionalTest {
-    private static final String registerName = "register";
+    private static final TestRegister testRegister = TestRegister.register;
 
     @Rule
     public TestRule wipe = new WipeDatabaseRule();
@@ -40,7 +41,7 @@ public class LoadSerializedFunctionalTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        Handle handle = register.handleFor(registerName);
+        Handle handle = register.handleFor(testRegister);
         testItemDAO = handle.attach(TestItemCommandDAO.class);
         testEntryDAO = handle.attach(TestEntryDAO.class);
         testRecordDAO = handle.attach(TestRecordDAO.class);
@@ -111,6 +112,6 @@ public class LoadSerializedFunctionalTest {
     }
 
     private Response send(String payload) {
-        return register.loadRsf(registerName, payload);
+        return register.loadRsf(testRegister, payload);
     }
 }

--- a/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
@@ -20,23 +20,24 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.register.functional.app.TestRegister.address;
 import static uk.gov.register.views.representations.ExtraMediaType.TEXT_HTML;
 
 public class RecordListResourceFunctionalTest {
     @ClassRule
     public static RegisterRule register = new RegisterRule();
-    private final WebTarget addressTarget = register.targetRegister("address");
+    private final WebTarget addressTarget = register.target(address);
 
     @Before
     public void publishTestMessages() {
         register.wipe();
-        register.mintLines("address", "{\"street\":\"ellis\",\"address\":\"12345\"}", "{\"street\":\"presley\",\"address\":\"6789\"}", "{\"street\":\"ellis\",\"address\":\"145678\"}", "{\"street\":\"updatedEllisName\",\"address\":\"145678\"}", "{\"street\":\"ellis\",\"address\":\"6789\"}");
+        register.mintLines(address, "{\"street\":\"ellis\",\"address\":\"12345\"}", "{\"street\":\"presley\",\"address\":\"6789\"}", "{\"street\":\"ellis\",\"address\":\"145678\"}", "{\"street\":\"updatedEllisName\",\"address\":\"145678\"}", "{\"street\":\"ellis\",\"address\":\"6789\"}");
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void newRecords_shouldReturnAllCurrentVersionsOnly() throws Exception {
-        Response response = register.getRequest("address", "/records.json");
+        Response response = register.getRequest(address, "/records.json");
 
         Map<String, Map<String, String>> responseMap = response.readEntity(Map.class);
 
@@ -67,7 +68,7 @@ public class RecordListResourceFunctionalTest {
 
     @Test
     public void newRecords_setsAppropriateFilenameForDownload() {
-        Response response = register.getRequest("address", "/records.json");
+        Response response = register.getRequest(address, "/records.json");
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString(HttpHeaders.CONTENT_DISPOSITION), containsString("filename=\"address-records.json\""));
     }
@@ -89,7 +90,7 @@ public class RecordListResourceFunctionalTest {
 
     @Test
     public void newRecordsPageHasXhtmlLangAttributes() {
-        Response response = register.getRequest("address", "/records", TEXT_HTML);
+        Response response = register.getRequest(address, "/records", TEXT_HTML);
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
         Elements htmlElement = doc.select("html");
@@ -101,7 +102,7 @@ public class RecordListResourceFunctionalTest {
     @SuppressWarnings("unchecked")
     @Test
     public void fetchAllRecordsForAKeyValueCombination() throws JSONException {
-        Response response = register.getRequest("address","/records/street/ellis.json");
+        Response response = register.getRequest(address, "/records/street/ellis.json");
         Map<String, Map<String, String>> responseMap = response.readEntity(Map.class);
 
         assertThat(responseMap.size(), equalTo(2));

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static uk.gov.register.functional.app.TestRegister.address;
 
 public class RecordResourceFunctionalTest {
     private final static String item0 = "{\"address\":\"6789\",\"street\":\"elvis\"}";
@@ -26,14 +27,14 @@ public class RecordResourceFunctionalTest {
     @Before
     public void publishTestMessages() throws Throwable {
         register.wipe();
-        register.mintLines("address", item0, item1, "{\"address\":\"145678\",\"street\":\"ellis\"}");
+        register.mintLines(address, item0, item1, "{\"address\":\"145678\",\"street\":\"ellis\"}");
     }
 
     @Test
     public void getRecordByKey() throws JSONException, IOException {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 
-        Response response = register.getRequest("address","/record/6789.json");
+        Response response = register.getRequest(address, "/record/6789.json");
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -49,12 +50,12 @@ public class RecordResourceFunctionalTest {
 
     @Test
     public void recordResource_return404ResponseWhenRecordNotExist() {
-        assertThat(register.getRequest("address","/record/5001.json").getStatus(), equalTo(404));
+        assertThat(register.getRequest(address, "/record/5001.json").getStatus(), equalTo(404));
     }
 
     @Test
     public void recordResource_return400ResponseWhenPageSizeIsNotANumber() {
-        Response response = register.targetRegister("address").path("/records").queryParam("page-size", "not-a-number").request().get();
+        Response response = register.target(address).path("/records").queryParam("page-size", "not-a-number").request().get();
 
         assertThat(response.getMediaType().getType(), equalTo("text"));
         assertThat(response.getMediaType().getSubtype(), equalTo("html"));
@@ -63,7 +64,7 @@ public class RecordResourceFunctionalTest {
 
     @Test
     public void recordResource_return400ResponseWhenPageIndexIsNotANumber() {
-        Response response = register.targetRegister("address").path("/records").queryParam("page-index", "not-a-number").request().get();
+        Response response = register.target(address).path("/records").queryParam("page-index", "not-a-number").request().get();
 
         assertThat(response.getMediaType().getType(), equalTo("text"));
         assertThat(response.getMediaType().getSubtype(), equalTo("html"));
@@ -72,14 +73,14 @@ public class RecordResourceFunctionalTest {
 
     @Test
     public void recordResource_return200ResponseForTextHtmlMediaTypeWhenRecordExists() {
-        Response response = register.getRequest("address", "/record/6789", MediaType.TEXT_HTML);
+        Response response = register.getRequest(address, "/record/6789", MediaType.TEXT_HTML);
 
         assertThat(response.getStatus(), equalTo(200));
     }
 
     @Test
     public void historyResource_returnsHistoryOfARecord() throws IOException {
-        Response response = register.getRequest("address","/record/6789/entries.json");
+        Response response = register.getRequest(address, "/record/6789/entries.json");
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -101,6 +102,6 @@ public class RecordResourceFunctionalTest {
 
     @Test
     public void historyResource_return404ResponseWhenRecordNotExist() {
-        assertThat(register.getRequest("address","/record/5001/entries.json").getStatus(), equalTo(404));
+        assertThat(register.getRequest(address, "/record/5001/entries.json").getStatus(), equalTo(404));
     }
 }

--- a/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.core.IsNot.not;
+import static uk.gov.register.functional.app.TestRegister.address;
 
 public class RegisterResourceFunctionalTest {
 
@@ -32,13 +33,13 @@ public class RegisterResourceFunctionalTest {
 
     @Test
     public void registerJsonShouldContainEntryViewRegisterRegister() throws Throwable {
-        register.mintLines("address", "{\"address\":\"12345\"}",
+        register.mintLines(address, "{\"address\":\"12345\"}",
                 "{\"address\":\"6789\"}",
                 "{\"address\":\"145678\"}",
                 "{\"address\":\"145678\"}",
                 "{\"address\":\"6789\"}");
 
-        Response registerResourceFromAddressRegisterResponse = register.getRequest("address","/register.json");
+        Response registerResourceFromAddressRegisterResponse = register.getRequest(address, "/register.json");
         assertThat(registerResourceFromAddressRegisterResponse.getStatus(), equalTo(200));
 
         Map registerResourceMapFromAddressRegister = registerResourceFromAddressRegisterResponse.readEntity(Map.class);
@@ -55,7 +56,7 @@ public class RegisterResourceFunctionalTest {
 
     @Test
     public void registerJsonShouldGenerateValidResponseForEmptyDB(){
-        Response registerResourceFromAddressRegisterResponse = register.getRequest("address","/register.json");
+        Response registerResourceFromAddressRegisterResponse = register.getRequest(address, "/register.json");
         assertThat(registerResourceFromAddressRegisterResponse.getStatus(), equalTo(200));
 
         Map<String,?> registerResourceMapFromAddressRegister = registerResourceFromAddressRegisterResponse.readEntity(new GenericType<Map<String, ?>>(){});

--- a/src/test/java/uk/gov/register/functional/RepresentationsFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RepresentationsFunctionalTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.TestRegister;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -37,7 +38,7 @@ public class RepresentationsFunctionalTest {
     @Before
     public void publishTestMessages() {
         register.wipe();
-        register.loadRsf("register", "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+        register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
                 "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
                 "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
@@ -69,7 +70,7 @@ public class RepresentationsFunctionalTest {
     public void representationIsSupportedForEntryResource() {
         assumeThat(expectedEntryValue, notNullValue());
 
-        Response response = register.getRequest("register", "/entry/1." + extension);
+        Response response = register.getRequest(TestRegister.register, "/entry/1." + extension);
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));
@@ -80,7 +81,7 @@ public class RepresentationsFunctionalTest {
     public void representationIsSupportedForItemResource() {
         assumeThat(expectedItemValue, notNullValue());
 
-        Response response = register.getRequest("register","/item/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18." + extension);
+        Response response = register.getRequest(TestRegister.register, "/item/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18." + extension);
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));
@@ -91,7 +92,7 @@ public class RepresentationsFunctionalTest {
     public void representationIsSupportedForRecordResource() {
         assumeThat(expectedRecordValue, notNullValue());
 
-        Response response = register.getRequest("register", "/record/value1." + extension);
+        Response response = register.getRequest(TestRegister.register, "/record/value1." + extension);
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));
@@ -102,7 +103,7 @@ public class RepresentationsFunctionalTest {
     public void representationIsSupportedForRecordsResource() {
         assumeThat(expectedRecordsValue, notNullValue());
 
-        Response response = register.getRequest("register", "/records." + extension);
+        Response response = register.getRequest(TestRegister.register, "/records." + extension);
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));
@@ -113,7 +114,7 @@ public class RepresentationsFunctionalTest {
     public void representationIsSupportedForEntriesResource() {
         assumeThat(expectedEntriesValue, notNullValue());
 
-        Response response = register.getRequest("register", "/entries." + extension);
+        Response response = register.getRequest(TestRegister.register, "/entries." + extension);
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));
@@ -124,7 +125,7 @@ public class RepresentationsFunctionalTest {
     public void representationIsSupportedForRecordEntriesResource(){
         assumeThat(expectedRecordEntriesValue, notNullValue());
 
-        Response response = register.getRequest("register", "/record/value1/entries." + extension);
+        Response response = register.getRequest(TestRegister.register, "/record/value1/entries." + extension);
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));

--- a/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static uk.gov.register.functional.app.TestRegister.address;
 
 public class VerifiableLogResourceFunctionalTest {
 
@@ -24,12 +25,12 @@ public class VerifiableLogResourceFunctionalTest {
     @Before
     public void publishTestMessages() throws Throwable {
         register.wipe();
-        register.mintLines("address", "{\"address\":\"1111\",\"street\":\"elvis\"}", "{\"address\":\"2222\",\"street\":\"presley\"}", "{\"address\":\"3333\",\"street\":\"ellis\"}", "{\"address\":\"4444\",\"street\":\"pretzel\"}", "{\"address\":\"5555\",\"street\":\"elfsley\"}");
+        register.mintLines(address, "{\"address\":\"1111\",\"street\":\"elvis\"}", "{\"address\":\"2222\",\"street\":\"presley\"}", "{\"address\":\"3333\",\"street\":\"ellis\"}", "{\"address\":\"4444\",\"street\":\"pretzel\"}", "{\"address\":\"5555\",\"street\":\"elfsley\"}");
     }
 
     @Test
     public void getRegisterProof() {
-        Response response = register.getRequest("address", "/proof/register/" + proofIdentifier);
+        Response response = register.getRequest(address, "/proof/register/" + proofIdentifier);
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -40,7 +41,7 @@ public class VerifiableLogResourceFunctionalTest {
 
     @Test
     public void getEntryProof() {
-        Response response = register.getRequest("address", "/proof/entry/1/5/" + proofIdentifier);
+        Response response = register.getRequest(address, "/proof/entry/1/5/" + proofIdentifier);
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -54,7 +55,7 @@ public class VerifiableLogResourceFunctionalTest {
 
     @Test
     public void getConsistencyProof() {
-        Response response = register.getRequest("address","/proof/consistency/2/5/" + proofIdentifier);
+        Response response = register.getRequest(address, "/proof/consistency/2/5/" + proofIdentifier);
 
         assertThat(response.getStatus(), equalTo(200));
 

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -30,16 +30,6 @@ import static javax.ws.rs.client.Entity.entity;
 import static uk.gov.register.views.representations.ExtraMediaType.APPLICATION_RSF_TYPE;
 
 public class RegisterRule implements TestRule {
-    public enum TestRegister {
-        address, postcode, register;
-
-        private static final String REGISTER_DOMAIN = "test.register.gov.uk";
-        private final String hostname = name() + "." + REGISTER_DOMAIN;
-
-        public String getHostname() {
-            return hostname;
-        }
-    }
     private final WipeDatabaseRule wipeRule;
     private DropwizardAppRule<RegisterConfiguration> appRule;
 
@@ -74,48 +64,40 @@ public class RegisterRule implements TestRule {
         return wholeRule.apply(me, description);
     }
 
-    private WebTarget authenticatedTarget(String registerName) {
-        WebTarget authenticatedTarget = targetRegister(registerName);
-        authenticatedTarget.register(HttpAuthenticationFeature.basicBuilder().credentials("foo", "bar").build());
-        return authenticatedTarget;
+    private WebTarget authenticatedTarget(TestRegister register) {
+        return target(register).register(HttpAuthenticationFeature.basicBuilder().credentials("foo", "bar").build());
     }
 
     private WebTarget target(String targetHost) {
         return client.target("http://" + targetHost + ":" + appRule.getLocalPort());
     }
 
-    /**
-     * get a WebTarget pointing at a particular register.
-     * if the registerName is recognized, the Host: will be set appropriately for that register
-     * if not, it will default to a Host: of localhost (which will hit the default register)
-     */
-    public WebTarget targetRegister(String registerName) {
-        TestRegister register = TestRegister.valueOf(registerName);
+    public WebTarget target(TestRegister register) {
         return target(register.getHostname());
     }
 
-    public Response loadRsf(String registerName, String rsf) {
-        return authenticatedTarget(registerName).path("/load-rsf")
+    public Response loadRsf(TestRegister register, String rsf) {
+        return authenticatedTarget(register).path("/load-rsf")
                 .request()
                 .post(entity(rsf, APPLICATION_RSF_TYPE));
     }
 
-    public Response mintLines(String registerName, String... payload) {
-        return authenticatedTarget(registerName).path("/load")
+    public Response mintLines(TestRegister register, String... payload) {
+        return authenticatedTarget(register).path("/load")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .post(Entity.json(String.join("\n", payload)));
     }
 
-    public Response getRequest(String registerName, String path) {
-        return targetRegister(registerName).path(path).request().get();
+    public Response getRequest(TestRegister register, String path) {
+        return target(register).path(path).request().get();
     }
 
-    public Response getRequest(String registerName, String path, String acceptedResponseType) {
-        return targetRegister(registerName).path(path).request(acceptedResponseType).get();
+    public Response getRequest(TestRegister register, String path, String acceptedResponseType) {
+        return target(register).path(path).request(acceptedResponseType).get();
     }
 
-    public Response deleteRegisterData(String registerName) {
-        return authenticatedTarget(registerName).path("/delete-register-data").request().delete();
+    public Response deleteRegisterData(TestRegister register) {
+        return authenticatedTarget(register).path("/delete-register-data").request().delete();
     }
 
     public void wipe() {
@@ -137,13 +119,13 @@ public class RegisterRule implements TestRule {
      * provides a DBI Handle for the given register
      * the handle will automatically be closed by the RegisterRule
      */
-    public Handle handleFor(String register) {
+    public Handle handleFor(TestRegister register) {
         Handle handle = new DBI(postgresConnectionString(register)).open();
         handles.add(handle);
         return handle;
     }
 
-    private String postgresConnectionString(String register) {
-        return String.format("jdbc:postgresql://localhost:5432/ft_openregister_java_%s?user=postgres&ApplicationName=RegisterRule", register);
+    private String postgresConnectionString(TestRegister register) {
+        return String.format("jdbc:postgresql://localhost:5432/ft_openregister_java_%s?user=postgres&ApplicationName=RegisterRule", register.name());
     }
 }

--- a/src/test/java/uk/gov/register/functional/app/TestRegister.java
+++ b/src/test/java/uk/gov/register/functional/app/TestRegister.java
@@ -1,0 +1,12 @@
+package uk.gov.register.functional.app;
+
+public enum TestRegister {
+    address, postcode, register;
+
+    private static final String REGISTER_DOMAIN = "test.register.gov.uk";
+    private final String hostname = name() + "." + REGISTER_DOMAIN;
+
+    public String getHostname() {
+        return hostname;
+    }
+}

--- a/src/test/java/uk/gov/register/functional/db/EntryIteratorDAOFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/db/EntryIteratorDAOFunctionalTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import uk.gov.register.db.EntryIteratorDAO;
 import uk.gov.register.db.EntryQueryDAO;
 import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.TestRegister;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -19,7 +20,7 @@ public class EntryIteratorDAOFunctionalTest {
 
     @ClassRule
     public static final RegisterRule register = new RegisterRule();
-    private static final TestEntryDAO testEntryDAO = register.handleFor("register").attach(TestEntryDAO.class);
+    private static final TestEntryDAO testEntryDAO = register.handleFor(TestRegister.register).attach(TestEntryDAO.class);
 
     @Before
     public void publishTestMessages() {
@@ -34,7 +35,7 @@ public class EntryIteratorDAOFunctionalTest {
 
     @Test
     public void testCanIterateInOrder() {
-        register.loadRsf("register", "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+        register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
                 "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
                 "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
@@ -45,7 +46,7 @@ public class EntryIteratorDAOFunctionalTest {
 
     @Test
     public void testCanIterateNotInOrder() {
-        register.loadRsf("register", "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+        register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
                 "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
                 "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
@@ -56,12 +57,12 @@ public class EntryIteratorDAOFunctionalTest {
 
     @Test
     public void testCanStillIterateAfterIteratorEndsThenNewEntriesAdded() {
-        register.loadRsf("register", "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+        register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n");
 
         assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
 
-        register.loadRsf("register", "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
+        register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
                 "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
 
         assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));
@@ -69,14 +70,14 @@ public class EntryIteratorDAOFunctionalTest {
 
     @Test
     public void testCanStillIterateAfterIteratorDoesNotThenNewEntriesAddedd() {
-        register.loadRsf("register", "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+        register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
                 "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
                 "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
 
         assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
 
-        register.loadRsf("register", "add-item\t{\"fields\":[\"field1\",\"field2\",\"field3\"],\"register\":\"value3\",\"text\":\"The Entry 3\"}\n" +
+        register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\",\"field2\",\"field3\"],\"register\":\"value3\",\"text\":\"The Entry 3\"}\n" +
                 "append-entry\t2016-03-01T01:02:03Z\tsha-256:8d5c2ed1e59f8871dff6e2132171008f12f43aa37e70ab158d598bc6b6db848f\tvalue1\n");
 
         assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));


### PR DESCRIPTION
This introduces an enum `TestRegister`, to capture configuration information about the registers defined in `test-app-config.yaml` and for use with `RegisterRule`.  It means we can pass in an enum value to `getRequest()` and similar methods, rather than passing in a String representing a register.

This will also be useful for my next PR, where I intend to make different register have different basic auth credentials, and TestRegister will be able to hold that data.