### PR TITLE
remove last use of ConfigOverride

### DIFF
--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
@@ -1,6 +1,5 @@
 package uk.gov.register.functional;
 
-import io.dropwizard.testing.ConfigOverride;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.register.functional.app.RegisterRule;
@@ -19,8 +18,7 @@ import static uk.gov.register.functional.app.TestRegister.postcode;
 public class DeleteRegisterDataFunctionalTest {
     public static final TestRegister REGISTER_WHICH_ALLOWS_DELETING = postcode;
     @ClassRule
-    public static final RegisterRule register = new RegisterRule(
-            ConfigOverride.config("enableRegisterDataDelete", "true"));
+    public static final RegisterRule register = new RegisterRule();
 
     @Test
     public void deleteRegisterData_deletesAllDataFromDb() throws Exception {

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -1,7 +1,6 @@
 package uk.gov.register.functional.app;
 
 import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.apache.http.impl.conn.InMemoryDnsResolver;
@@ -38,10 +37,9 @@ public class RegisterRule implements TestRule {
     private Client client;
     private List<Handle> handles = new ArrayList<>();
 
-    public RegisterRule(ConfigOverride... overrides) {
+    public RegisterRule() {
         this.appRule = new DropwizardAppRule<>(RegisterApplication.class,
-                ResourceHelpers.resourceFilePath("test-app-config.yaml"),
-                overrides);
+                ResourceHelpers.resourceFilePath("test-app-config.yaml"));
         String[] registers = Arrays.stream(TestRegister.values())
                 .map(TestRegister::name)
                 .toArray(String[]::new);


### PR DESCRIPTION
This was dead code -- the DeleteRegisterDataFunctionalTest didn't need
the ConfigOverride at all.  We can now get rid of the
ConfigOverride... constructor from RegisterRule.