### PR TITLE
Move table spacing to wrapper

### DIFF
--- a/src/main/resources/assets/sass/main.scss
+++ b/src/main/resources/assets/sass/main.scss
@@ -150,6 +150,8 @@ $table-header: #f5f5f5;
 $table-row: #f9f9f9;
 
 .table-wrapper {
+  margin-top: $gutter;
+  margin-bottom: $gutter;
   overflow-x: scroll;
 }
 
@@ -158,9 +160,6 @@ table {
   border-collapse: collapse;
   border: 1px solid $border-colour;
   width: 100%;
-
-  margin-top: $gutter;
-  margin-bottom: $gutter;
 
   td, th {
     vertical-align: top;


### PR DESCRIPTION
Moving the margin to the wrapper to remove the margin above the scroll
bar

## Before
<img width="1392" alt="screen shot 2016-12-22 at 11 14 19" src="https://cloud.githubusercontent.com/assets/3071606/21423989/d781c08a-c837-11e6-89dc-85f5527948c8.png">

## After
<img width="1392" alt="screen shot 2016-12-22 at 11 15 52" src="https://cloud.githubusercontent.com/assets/3071606/21424022/03469ace-c838-11e6-9af2-00a480743ea6.png">

