### PR TITLE
make historyPageUrl a register-specific config item

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -90,7 +90,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(allTheRegisters);
                 bindFactory(Factories.RegisterContextProvider.class).to(RegisterContext.class)
                         .to(RegisterTrackingConfiguration.class).to(DeleteRegisterDataConfiguration.class)
-                        .to(ResourceConfiguration.class);
+                        .to(ResourceConfiguration.class).to(RegisterContentPagesConfiguration.class);
                 bindAsContract(RegisterFieldsConfiguration.class);
 
                 bind(configManager).to(ConfigManager.class);

--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -24,7 +24,6 @@ public class RegisterConfiguration extends Configuration
         implements AuthenticatorConfiguration,
         RegisterDomainConfiguration,
         RegisterConfigConfiguration,
-        RegisterContentPagesConfiguration,
         GovukClientConfiguration {
     @Valid
     @NotNull
@@ -100,7 +99,7 @@ public class RegisterConfiguration extends Configuration
     }
 
     public RegisterContextFactory getDefaultRegister() {
-        return new RegisterContextFactory(getDatabase(), trackingId, enableRegisterDataDelete, enableDownloadResource);
+        return new RegisterContextFactory(getDatabase(), trackingId, enableRegisterDataDelete, enableDownloadResource, historyPageUrl);
     }
 
     public AllTheRegistersFactory getAllTheRegisters() {
@@ -127,11 +126,6 @@ public class RegisterConfiguration extends Configuration
     @Override
     public URI getGovukEndpoint() {
         return URI.create("https://www.gov.uk");
-    }
-
-    @Override
-    public Optional<String> getRegisterHistoryPageUrl() {
-        return historyPageUrl;
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -21,12 +21,14 @@ import java.util.function.Consumer;
 public class RegisterContext implements
         RegisterTrackingConfiguration,
         DeleteRegisterDataConfiguration,
+        RegisterContentPagesConfiguration,
         ResourceConfiguration {
     private RegisterName registerName;
     private ConfigManager configManager;
     private AtomicReference<MemoizationStore> memoizationStore;
     private DBI dbi;
     private Flyway flyway;
+    private final Optional<String> historyPageUrl;
     private final Optional<String> trackingId;
     private final boolean enableRegisterDataDelete;
     private final boolean enableDownloadResource;
@@ -34,11 +36,12 @@ public class RegisterContext implements
 
     public RegisterContext(RegisterName registerName, ConfigManager configManager,
                            DBI dbi, Flyway flyway, Optional<String> trackingId, boolean enableRegisterDataDelete,
-                           boolean enableDownloadResource) {
+                           boolean enableDownloadResource, Optional<String> historyPageUrl) {
         this.registerName = registerName;
         this.configManager = configManager;
         this.dbi = dbi;
         this.flyway = flyway;
+        this.historyPageUrl = historyPageUrl;
         this.memoizationStore = new AtomicReference<>(new InMemoryPowOfTwoNoLeaves());
         this.trackingId = trackingId;
         this.enableRegisterDataDelete = enableRegisterDataDelete;
@@ -128,5 +131,10 @@ public class RegisterContext implements
     @Override
     public boolean getEnableDownloadResource() {
         return enableDownloadResource;
+    }
+
+    @Override
+    public Optional<String> getRegisterHistoryPageUrl() {
+        return historyPageUrl;
     }
 }

--- a/src/main/java/uk/gov/register/core/RegisterContextFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterContextFactory.java
@@ -33,16 +33,23 @@ public class RegisterContextFactory {
     @JsonProperty
     private boolean enableDownloadResource = false;
 
+    @SuppressWarnings("unused")
+    @Valid
+    @JsonProperty
+    private Optional<String> historyPageUrl = Optional.empty();
+
     @JsonCreator
     public RegisterContextFactory(
             @JsonProperty("database") DataSourceFactory database,
             @JsonProperty("trackingId") Optional<String> trackingId,
             @JsonProperty("enableRegisterDataDelete") boolean enableRegisterDataDelete,
-            @JsonProperty("enableDownloadResource") boolean enableDownloadResource) {
+            @JsonProperty("enableDownloadResource") boolean enableDownloadResource,
+            @JsonProperty("historyPageUrl") Optional<String> historyPageUrl) {
         this.database = database;
         this.trackingId = trackingId;
         this.enableRegisterDataDelete = enableRegisterDataDelete;
         this.enableDownloadResource = enableDownloadResource;
+        this.historyPageUrl = historyPageUrl;
     }
 
     private FlywayFactory getFlywayFactory(RegisterName registerName) {
@@ -66,6 +73,7 @@ public class RegisterContextFactory {
                 getFlywayFactory(registerName).build(managedDataSource),
                 trackingId,
                 enableRegisterDataDelete,
-                enableDownloadResource);
+                enableDownloadResource,
+                historyPageUrl);
     }
 }

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -24,17 +24,17 @@ public class ViewFactory {
     private final GovukOrganisationClient organisationClient;
     private final Provider<RegisterMetadata> registerMetadata;
     private final RegisterDomainConfiguration registerDomainConfiguration;
-    private final RegisterContentPages registerContentPages;
     private final RegisterResolver registerResolver;
     private final Provider<RegisterReadOnly> register;
     private final Provider<RegisterTrackingConfiguration> registerTrackingConfiguration;
+    private final Provider<RegisterContentPagesConfiguration> registerContentPagesConfiguration;
 
     @Inject
     public ViewFactory(RequestContext requestContext,
                        PublicBodiesConfiguration publicBodiesConfiguration,
                        GovukOrganisationClient organisationClient,
                        RegisterDomainConfiguration registerDomainConfiguration,
-                       RegisterContentPagesConfiguration registerContentPagesConfiguration,
+                       Provider<RegisterContentPagesConfiguration> registerContentPagesConfiguration,
                        Provider<RegisterMetadata> registerMetadata,
                        Provider<RegisterTrackingConfiguration> registerTrackingConfiguration,
                        RegisterResolver registerResolver,
@@ -44,7 +44,7 @@ public class ViewFactory {
         this.organisationClient = organisationClient;
         this.registerDomainConfiguration = registerDomainConfiguration;
         this.registerMetadata = registerMetadata;
-        this.registerContentPages = new RegisterContentPages(registerContentPagesConfiguration.getRegisterHistoryPageUrl());
+        this.registerContentPagesConfiguration = registerContentPagesConfiguration;
         this.registerTrackingConfiguration = registerTrackingConfiguration;
         this.registerResolver = registerResolver;
         this.register = register;
@@ -67,7 +67,7 @@ public class ViewFactory {
                 totalEntries,
                 lastUpdated,
                 register.get(),
-                registerContentPages,
+                new RegisterContentPages(registerContentPagesConfiguration.get().getRegisterHistoryPageUrl()),
                 registerTrackingConfiguration.get(),
                 registerResolver);
     }

--- a/src/test/java/uk/gov/register/core/RegisterContextTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterContextTest.java
@@ -28,7 +28,7 @@ public class RegisterContextTest {
 
     @Test
     public void resetRegister_shouldNotResetRegister_whenEnableRegisterDataDeleteIsDisabled() throws IOException, NoSuchConfigException {
-        RegisterContext context = new RegisterContext(registerName, configManager, dbi, flyway, Optional.empty(), false, false);
+        RegisterContext context = new RegisterContext(registerName, configManager, dbi, flyway, Optional.empty(), false, false, Optional.empty());
         context.resetRegister();
 
         verify(flyway, never()).clean();
@@ -38,7 +38,7 @@ public class RegisterContextTest {
 
     @Test
     public void resetRegister_shouldResetRegister_whenEnableRegisterDataDeleteIsEnabled() throws IOException, NoSuchConfigException {
-        RegisterContext context = new RegisterContext(registerName, configManager, dbi, flyway, Optional.empty(), true, false);
+        RegisterContext context = new RegisterContext(registerName, configManager, dbi, flyway, Optional.empty(), true, false, Optional.empty());
         context.resetRegister();
 
         verify(flyway, times(1)).clean();


### PR DESCRIPTION
Tested locally. The current config.yaml now means that the local
school register has a history page url, but the local register
register does not.