### PR TITLE
test independence of MemoizationStores

### DIFF
--- a/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
@@ -12,9 +12,12 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.isIn;
 import static uk.gov.register.functional.app.TestRegister.address;
+import static uk.gov.register.functional.app.TestRegister.postcode;
 
 public class VerifiableLogResourceFunctionalTest {
 
@@ -26,6 +29,7 @@ public class VerifiableLogResourceFunctionalTest {
     public void publishTestMessages() throws Throwable {
         register.wipe();
         register.mintLines(address, "{\"address\":\"1111\",\"street\":\"elvis\"}", "{\"address\":\"2222\",\"street\":\"presley\"}", "{\"address\":\"3333\",\"street\":\"ellis\"}", "{\"address\":\"4444\",\"street\":\"pretzel\"}", "{\"address\":\"5555\",\"street\":\"elfsley\"}");
+        register.mintLines(postcode, "{\"postcode\":\"P1\"}", "{\"postcode\":\"P2\"}", "{\"postcode\":\"P3\"}", "{\"postcode\":\"P4\"}", "{\"postcode\":\"P5\"}");
     }
 
     @Test
@@ -64,5 +68,21 @@ public class VerifiableLogResourceFunctionalTest {
 
         List<?> auditPath = (List)(responseData.get("merkle-consistency-nodes"));
         assertThat(auditPath, hasSize(2));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void registerProofsForDifferentRegistersAreIndependent() {
+        // This test exists to ensure that we aren't accidentally sharing the same MemoizationStore between
+        // two different register instances.
+        // We get a proof of the same shape from two different registers, and verify that there are no
+        // hashes that exist in both proofs.
+
+        List<String> addressAuditPath = (List<String>) register.getRequest(address, "/proof/entry/3/5/" + proofIdentifier)
+                .readEntity(Map.class).get("merkle-audit-path");
+        List<String> postcodeAuditPath = (List<String>) register.getRequest(postcode, "/proof/entry/3/5/" + proofIdentifier)
+                .readEntity(Map.class).get("merkle-audit-path");
+
+        assertThat(addressAuditPath, everyItem(not(isIn(postcodeAuditPath))));
     }
 }


### PR DESCRIPTION
This adds a test to verify that we don't accidentally share a
MemoizationStore between two different registers -- ie, when we get
proofs from one register, its hashes should be completely different
from the proofs in a different register.