### PR TITLE
Make RSF download streaming work

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -14,6 +14,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.CommonProperties;
 import uk.gov.organisation.client.GovukOrganisationClient;
 import uk.gov.register.auth.BasicAuthFilter;
 import uk.gov.register.auth.RegisterAuthDynamicFeature;
@@ -70,6 +71,8 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         DBIFactory dbiFactory = new DBIFactory();
 
         JerseyEnvironment jersey = environment.jersey();
+        jersey.property(CommonProperties.OUTBOUND_CONTENT_LENGTH_BUFFER, 0);
+
         DropwizardResourceConfig resourceConfig = jersey.getResourceConfig();
         Client client = new JerseyClientBuilder(environment).using(configuration.getJerseyClientConfiguration()).build("http-client");
 

--- a/src/main/java/uk/gov/register/core/RegisterContextFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterContextFactory.java
@@ -70,6 +70,11 @@ public class RegisterContextFactory {
 
     public RegisterContext build(RegisterName registerName, DBIFactory dbiFactory, ConfigManager configManager, Environment environment) {
         database.getProperties().put("ApplicationName", "openregister_" + registerName);
+
+        // this is to enable JDBI Postgres @FetchSize which requires autoCommit set to false
+        // https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
+        database.setAutoCommitByDefault(false);
+
         // dbiFactory.build() will ensure that this dataSource is correctly shut down
         // it will also be shared with flyway
         ManagedDataSource managedDataSource = database.build(environment.metrics(), registerName.value());

--- a/src/main/java/uk/gov/register/db/EntryQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryQueryDAO.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 public interface EntryQueryDAO {
     @RegisterMapper(EntryMapper.class)
     @SingleValueResult(Entry.class)
-    @SqlQuery("select * from entry where entry_number=:entryNumber")
+    @SqlQuery("select entry_number, sha256hex, timestamp, key from entry where entry_number=:entryNumber")
     Optional<Entry> findByEntryNumber(@Bind("entryNumber") int entryNumber);
 
     @RegisterMapper(LongTimestampToInstantMapper.class)
@@ -31,25 +31,25 @@ public interface EntryQueryDAO {
 
     //Note: This is fine for small data registers like country
     @RegisterMapper(EntryMapper.class)
-    @SqlQuery("SELECT * from entry order by entry_number desc")
+    @SqlQuery("SELECT entry_number, sha256hex, timestamp, key from entry order by entry_number desc")
     Collection<Entry> getAllEntriesNoPagination();
 
     @RegisterMapper(EntryMapper.class)
-    @SqlQuery("select * from entry where entry_number >= :start and entry_number \\< :start + :limit order by entry_number asc")
+    @SqlQuery("select entry_number, sha256hex, timestamp, key from entry where entry_number >= :start and entry_number \\< :start + :limit order by entry_number asc")
     Collection<Entry> getEntries(@Bind("start") int start, @Bind("limit") int limit);
 
-    @SqlQuery("SELECT * FROM entry WHERE entry_number >= :entryNumber ORDER BY entry_number")
+    @SqlQuery("SELECT entry_number, sha256hex, timestamp, key FROM entry WHERE entry_number >= :entryNumber ORDER BY entry_number")
     @RegisterMapper(EntryMapper.class)
-    @FetchSize(262144) // Has to be non-zero to enable cursor mode https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
+    @FetchSize(10000) // Has to be non-zero to enable cursor mode https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
     ResultIterator<Entry> entriesIteratorFrom(@Bind("entryNumber") int entryNumber);
 
-    @SqlQuery("SELECT * FROM entry ORDER BY entry_number")
+    @SqlQuery("SELECT entry_number, sha256hex, timestamp, key FROM entry ORDER BY entry_number")
     @RegisterMapper(EntryMapper.class)
-    @FetchSize(262144)
+    @FetchSize(10000)
     Iterator<Entry> getIterator();
 
-    @SqlQuery("SELECT * FROM entry WHERE entry_number > :totalEntries1 and entry_number <= :totalEntries2 ORDER BY entry_number")
+    @SqlQuery("SELECT entry_number, sha256hex, timestamp, key FROM entry WHERE entry_number > :totalEntries1 and entry_number <= :totalEntries2 ORDER BY entry_number")
     @RegisterMapper(EntryMapper.class)
-    @FetchSize(262144)
+    @FetchSize(10000)
     Iterator<Entry> getIterator(@Bind("totalEntries1") int totalEntries1, @Bind("totalEntries2") int totalEntries2);
 }

--- a/src/main/java/uk/gov/register/db/ItemQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/ItemQueryDAO.java
@@ -14,25 +14,24 @@ import java.util.Optional;
 
 public interface ItemQueryDAO {
 
-    @SqlQuery("select * from item where sha256hex=:sha256hex order by sha256hex")
+    @SqlQuery("select sha256hex, content from item where sha256hex=:sha256hex order by sha256hex")
     @SingleValueResult(Item.class)
     @RegisterMapper(ItemMapper.class)
     Optional<Item> getItemBySHA256(@Bind("sha256hex") String sha256Hash);
 
     //Note: This is fine for small data registers like country
-    @SqlQuery("select * from item order by sha256hex")
+    @SqlQuery("select sha256hex, content from item order by sha256hex")
     @RegisterMapper(ItemMapper.class)
     Collection<Item> getAllItemsNoPagination();
 
-    @SqlQuery("select * from item where exists(select 1 from entry where item.sha256hex = entry.sha256hex) order by sha256hex")
+    @SqlQuery("select sha256hex, content from item where exists(select 1 from entry where item.sha256hex = entry.sha256hex)")
     @RegisterMapper(ItemMapper.class)
-    @FetchSize(262144)
+    @FetchSize(10000)
     Iterator<Item> getIterator();
 
-    @SqlQuery("select * from item where exists(select 1 from entry where item.sha256hex = entry.sha256hex and entry_number > :startEntryNo and entry_number <= :endEntryNo) order by sha256hex")
+    @SqlQuery("select sha256hex, content from item where exists(select 1 from entry where item.sha256hex = entry.sha256hex and entry_number > :startEntryNo and entry_number <= :endEntryNo)")
     @RegisterMapper(ItemMapper.class)
-    @FetchSize(262144)
+    @FetchSize(10000)
     Iterator<Item> getIterator(@Bind("startEntryNo") int startEntryNo, @Bind("endEntryNo") int endEntryNo);
-
 
 }

--- a/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
@@ -104,22 +104,23 @@ public class DataDownloadFunctionalTest {
         assertThat(response.getHeaderString("Content-Disposition"), startsWith("attachment; filename="));
         assertThat(response.getHeaderString("Content-Disposition"), endsWith(".rsf"));
 
-        String[] rsfLines = getRsfLinesFrom(response);
+        List<String> rsfLines = getRsfLinesFrom(response);
 
-        assertThat(rsfLines[0], equalTo("assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+        assertThat(rsfLines.get(0), equalTo("assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
 
-        assertThat(rsfLines[1], equalTo("add-item\t{\"address\":\"12345\",\"street\":\"ellis\"}"));
-        assertThat(rsfLines[2], equalTo("add-item\t{\"address\":\"145678\",\"street\":\"ellis\"}"));
-        assertThat(rsfLines[3], equalTo("add-item\t{\"address\":\"6789\",\"street\":\"presley\"}"));
-        assertThat(rsfLines[4], equalTo("add-item\t{\"address\":\"12345\",\"street\":\"foo\"}"));
+        assertThat(rsfLines, hasItems(
+                "add-item\t{\"address\":\"12345\",\"street\":\"ellis\"}",
+                "add-item\t{\"address\":\"145678\",\"street\":\"ellis\"}",
+                "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}",
+                "add-item\t{\"address\":\"12345\",\"street\":\"foo\"}"));
 
-        assertFormattedEntry(rsfLines[5], "sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\t12345");
-        assertFormattedEntry(rsfLines[6], "sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\t6789");
-        assertFormattedEntry(rsfLines[7], "sha-256:cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592\t12345");
-        assertFormattedEntry(rsfLines[8], "sha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983\t145678");
-        assertFormattedEntry(rsfLines[9], "sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\t12345");
+        assertFormattedEntry(rsfLines.get(5), "sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\t12345");
+        assertFormattedEntry(rsfLines.get(6), "sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\t6789");
+        assertFormattedEntry(rsfLines.get(7), "sha-256:cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592\t12345");
+        assertFormattedEntry(rsfLines.get(8), "sha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983\t145678");
+        assertFormattedEntry(rsfLines.get(9), "sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\t12345");
 
-        assertThat(rsfLines[10], containsString("assert-root-hash\t"));
+        assertThat(rsfLines.get(10), containsString("assert-root-hash\t"));
     }
 
     @Test
@@ -130,17 +131,18 @@ public class DataDownloadFunctionalTest {
         assertThat(response.getHeaderString("Content-Disposition"), startsWith("attachment; filename="));
         assertThat(response.getHeaderString("Content-Disposition"), endsWith(".rsf"));
 
-        String[] rsfLines = getRsfLinesFrom(response);
+        List<String> rsfLines = getRsfLinesFrom(response);
 
-        assertThat(rsfLines[0], equalTo("assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+        assertThat(rsfLines.get(0), equalTo("assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
 
-        assertThat(rsfLines[1], equalTo("add-item\t{\"address\":\"12345\",\"street\":\"ellis\"}"));
-        assertThat(rsfLines[2], equalTo("add-item\t{\"address\":\"6789\",\"street\":\"presley\"}"));
+        assertThat(rsfLines, hasItems(
+                "add-item\t{\"address\":\"12345\",\"street\":\"ellis\"}",
+                "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}"));
 
-        assertFormattedEntry(rsfLines[3], "sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\t12345");
-        assertFormattedEntry(rsfLines[4], "sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\t6789");
+        assertFormattedEntry(rsfLines.get(3), "sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\t12345");
+        assertFormattedEntry(rsfLines.get(4), "sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\t6789");
 
-        assertThat(rsfLines[5], containsString("assert-root-hash\t"));
+        assertThat(rsfLines.get(5), containsString("assert-root-hash\t"));
     }
 
     @Test
@@ -177,15 +179,15 @@ public class DataDownloadFunctionalTest {
         Response fullRsfResponse = register.getRequest(address, "/download-rsf");
         Response partialRsfResponse = register.getRequest(address, "/download-rsf/0/5");
 
-        String[] fullRsfLines = getRsfLinesFrom(fullRsfResponse);
-        String[] partialRsfLines = getRsfLinesFrom(partialRsfResponse);
+        List<String> fullRsfLines = getRsfLinesFrom(fullRsfResponse);
+        List<String> partialRsfLines = getRsfLinesFrom(partialRsfResponse);
 
         assertThat(fullRsfLines, equalTo(partialRsfLines));
     }
 
-    private String[] getRsfLinesFrom(Response response){
+    private List<String> getRsfLinesFrom(Response response){
         InputStream is = response.readEntity(InputStream.class);
-        return new BufferedReader(new InputStreamReader(is)).lines().toArray(String[]::new);
+        return new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.toList());
     }
 
     private void assertFormattedEntry(String actualEntry, String expectedLine){


### PR DESCRIPTION
Fix RSF download streaming which works like a charm.

First problem was in buffering `OutputStream` and unknown content length hence it was buffering the max length. Solution is to set `ServerProperties.OUTBOUND_CONTENT_LENGTH_BUFFER` to `false`.
http://stackoverflow.com/questions/29637151/jersey-streamingoutput-as-response-entity#answer-34358215

The other issue was that in order to create a JDBI Postgres cursor query we need to set `autoCommit` to `false`.
https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor