### PR TITLE
Fix bug where we accidentally use zero-indexed entry-numbers for entry proofs

### DIFF
--- a/src/main/java/uk/gov/register/db/AbstractEntryLog.java
+++ b/src/main/java/uk/gov/register/db/AbstractEntryLog.java
@@ -91,7 +91,7 @@ public abstract class AbstractEntryLog implements EntryLog {
     public EntryProof getEntryProof(int entryNumber, int totalEntries) {
         checkpoint();
         List<HashValue> auditProof = withVerifiableLog(verifiableLog ->
-                verifiableLog.auditProof(entryNumber, totalEntries)
+                verifiableLog.auditProof(entryNumber - 1, totalEntries)
                         .stream()
                         .map(hashBytes -> new HashValue(HashingAlgorithm.SHA256, bytesToString(hashBytes)))
                         .collect(Collectors.toList()));

--- a/src/main/java/uk/gov/register/resources/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/VerifiableLogResource.java
@@ -6,10 +6,7 @@ import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
 
 import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.security.NoSuchAlgorithmException;
 
@@ -33,6 +30,7 @@ public class VerifiableLogResource {
     @Path("/entry/{entry-number}/{total-entries}/merkle:sha-256")
     @Produces(MediaType.APPLICATION_JSON)
     public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) throws NoSuchAlgorithmException {
+        validateEntryProofParams(entryNumber, totalEntries);
         return register.getEntryProof(entryNumber, totalEntries);
     }
 
@@ -40,6 +38,23 @@ public class VerifiableLogResource {
     @Path("/consistency/{total-entries-1}/{total-entries-2}/merkle:sha-256")
     @Produces(MediaType.APPLICATION_JSON)
     public ConsistencyProof consistencyProof(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) throws NoSuchAlgorithmException {
+        validateConsistencyProofParams(totalEntries1, totalEntries2);
         return register.getConsistencyProof(totalEntries1, totalEntries2);
+    }
+
+    private void validateEntryProofParams(int entryNumber, int totalEntries) {
+        if (entryNumber < 1 ||
+                entryNumber > totalEntries ||
+                totalEntries > register.getTotalEntries()) {
+            throw new BadRequestException("Invalid parameters");
+        }
+    }
+
+    private void validateConsistencyProofParams(int totalEntries1, int totalEntries2) {
+        if (totalEntries1 < 1 ||
+                totalEntries1 > totalEntries2 ||
+                totalEntries2 > register.getTotalEntries()) {
+            throw new BadRequestException("Invalid parameters");
+        }
     }
 }

--- a/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
@@ -12,10 +12,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.*;
 import static uk.gov.register.functional.app.TestRegister.address;
 import static uk.gov.register.functional.app.TestRegister.postcode;
 
@@ -68,6 +65,25 @@ public class VerifiableLogResourceFunctionalTest {
 
         List<?> auditPath = (List)(responseData.get("merkle-consistency-nodes"));
         assertThat(auditPath, hasSize(2));
+    }
+
+    @Test
+    public void entryProofsAreDifferentForEntriesInSameSubtree() {
+        Response entry1Proof = register.getRequest(address, "/proof/entry/1/2/" + proofIdentifier);
+        Response entry2Proof = register.getRequest(address, "/proof/entry/2/2/" + proofIdentifier);
+
+        assertThat(entry1Proof.getStatus(), equalTo(200));
+        assertThat(entry2Proof.getStatus(), equalTo(200));
+
+        Map<?,?> entry1ProofData = entry1Proof.readEntity(Map.class);
+        Map<?,?> entry2ProofData = entry2Proof.readEntity(Map.class);
+
+        List<?> entry1Path = (List)(entry1ProofData.get("merkle-audit-path"));
+        List<?> entry2Path = (List)(entry2ProofData.get("merkle-audit-path"));
+
+        assertThat(entry1Path, hasSize(1));
+        assertThat(entry2Path, hasSize(1));
+        assertThat(entry1Path, not(contains(entry2Path)));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
@@ -69,6 +69,9 @@ public class VerifiableLogResourceFunctionalTest {
 
     @Test
     public void entryProofsAreDifferentForEntriesInSameSubtree() {
+        // This tests that we are mapping entry numbers (one-indexed) to leaf indexes correctly (zero-indexed).
+        // In the case that we accidentally map to zero-indexed entry nubers this test would fail
+
         Response entry1Proof = register.getRequest(address, "/proof/entry/1/2/" + proofIdentifier);
         Response entry2Proof = register.getRequest(address, "/proof/entry/2/2/" + proofIdentifier);
 
@@ -83,7 +86,7 @@ public class VerifiableLogResourceFunctionalTest {
 
         assertThat(entry1Path, hasSize(1));
         assertThat(entry2Path, hasSize(1));
-        assertThat(entry1Path, not(contains(entry2Path)));
+        assertThat(entry1Path, not(equalTo(entry2Path)));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
@@ -9,6 +9,7 @@ import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
 
+import javax.ws.rs.BadRequestException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
@@ -45,6 +46,7 @@ public class VerifiableLogResourceTest {
 
         EntryProof expectedProof = new EntryProof("3", expectedAuditPath);
         RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        when(registerMock.getTotalEntries()).thenReturn(8);
         when(registerMock.getEntryProof(entryNumber, totalEntries)).thenReturn(expectedProof);
 
         VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
@@ -66,6 +68,7 @@ public class VerifiableLogResourceTest {
 
         ConsistencyProof expectedProof = new ConsistencyProof(expectedConsistencyNodes);
         RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        when(registerMock.getTotalEntries()).thenReturn(8);
         when(registerMock.getConsistencyProof(totalEntries1, totalEntries2)).thenReturn(expectedProof);
 
         VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
@@ -75,6 +78,69 @@ public class VerifiableLogResourceTest {
         assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
 
         assertThat(actualProof.getConsistencyNodes(), IsIterableContainingInOrder.contains(expectedHash1, expectedHash2));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void entryProofShouldThrowBadRequestExceptionIfTotalEntriesTooSmall() throws NoSuchAlgorithmException {
+        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        when(registerMock.getTotalEntries()).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+
+        vlResource.entryProof(0, 5);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void entryProofShouldThrowBadRequestExceptionIfEntryNumberTooSmall() throws NoSuchAlgorithmException {
+        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        when(registerMock.getTotalEntries()).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+
+        vlResource.entryProof(0, 5);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void entryProofShouldThrowBadRequestExceptionIfEntryNumberGreaterThanTotalEntries() throws NoSuchAlgorithmException {
+        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        when(registerMock.getTotalEntries()).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+
+        vlResource.entryProof(5, 3);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void entryProofShouldThrowBadRequestExceptionIfTotalEntriesGreaterThanSizeOfRegister() throws NoSuchAlgorithmException {
+        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        when(registerMock.getTotalEntries()).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+
+        vlResource.entryProof(5, 10);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries1TooSmall() throws NoSuchAlgorithmException {
+        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        when(registerMock.getTotalEntries()).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+
+        vlResource.consistencyProof(0, 5);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void consistencyProofshouldThrowBadRequestExceptionIfTotalEntries2SmallerThanTotalEntries1() throws NoSuchAlgorithmException {
+        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        when(registerMock.getTotalEntries()).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+
+        vlResource.consistencyProof(5, 3);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries2GreaterThanSizeOfRegister() throws NoSuchAlgorithmException {
+        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
+        when(registerMock.getTotalEntries()).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+
+        vlResource.consistencyProof(5, 10);
     }
 }
 

--- a/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
@@ -81,15 +81,6 @@ public class VerifiableLogResourceTest {
     }
 
     @Test(expected = BadRequestException.class)
-    public void entryProofShouldThrowBadRequestExceptionIfTotalEntriesTooSmall() throws NoSuchAlgorithmException {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries()).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
-
-        vlResource.entryProof(0, 5);
-    }
-
-    @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfEntryNumberTooSmall() throws NoSuchAlgorithmException {
         RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
         when(registerMock.getTotalEntries()).thenReturn(8);


### PR DESCRIPTION
This meant that we were calculating incorrect entry proofs. In the app entry-numbers are one-indexed, but the VerifiableLog library assumes Merkle Tree leaves are zero-indexed. The bug existed because we were not correctly mapping between the two indexed.

It resulted in /proof/entry/1/2/merkle:sha-256 and /proof/entry/2/2/merkle:sha-256 returning the same result.

There was also a problem where we allow /proof/entry/0/2/merkle:sha-256 and /proof/entry/3/2/merkle:sha-256 to be called and they return results (which it shouldn't because these requests do not make sense). We now return a BadRequestException for parameter combinations like this.