### PR TITLE
Add standardjs badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A java implementation of a register
 
 # Working on the frontend
 
+[![Standard - JavaScript Style Guide](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
+
 ## Updating the styles
 
 Recompile the `.scss` files to `.css` via Gradle task:


### PR DESCRIPTION
We use StandardJS to lint our JS so adding this to make it more obvious

<img width="889" alt="screen shot 2016-12-30 at 10 30 31" src="https://cloud.githubusercontent.com/assets/3071606/21563678/55c6ce1e-ce7c-11e6-9299-cca48598da82.png">
