### PR TITLE
Make field text available to homepage

### DIFF
--- a/src/main/java/uk/gov/register/core/Field.java
+++ b/src/main/java/uk/gov/register/core/Field.java
@@ -42,6 +42,10 @@ public class Field {
         return datatype;
     }
 
+    public String getText() {
+        return text;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/uk/gov/register/views/HomePageView.java
+++ b/src/main/java/uk/gov/register/views/HomePageView.java
@@ -1,12 +1,11 @@
 package uk.gov.register.views;
 
+import com.google.common.collect.Iterables;
 import uk.gov.organisation.client.GovukOrganisation;
+import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.RegisterContentPages;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
-import uk.gov.register.core.PublicBody;
-import uk.gov.register.core.RegisterName;
-import uk.gov.register.core.RegisterReadOnly;
-import uk.gov.register.core.RegisterResolver;
+import uk.gov.register.core.*;
 import uk.gov.register.resources.RequestContext;
 
 import java.net.URI;
@@ -25,6 +24,7 @@ public class HomePageView extends AttributionView<Object> {
     private final int totalRecords;
     private final int totalEntries;
     private final RegisterContentPages registerContentPages;
+    private final Iterable<Field> fields;
 
     public HomePageView(
             PublicBody registry,
@@ -36,12 +36,14 @@ public class HomePageView extends AttributionView<Object> {
             RegisterReadOnly register,
             RegisterContentPages registerContentPages,
             RegisterTrackingConfiguration registerTrackingConfiguration,
-            RegisterResolver registerResolver) {
+            RegisterResolver registerResolver,
+            FieldsConfiguration fieldsConfiguration) {
         super("home.html", requestContext, registry, registryBranding, register, registerTrackingConfiguration, registerResolver, null);
         this.totalRecords = totalRecords;
         this.totalEntries = totalEntries;
         this.lastUpdated = lastUpdated;
         this.registerContentPages = registerContentPages;
+        this.fields = Iterables.transform(getRegister().getFields(), f -> fieldsConfiguration.getField(f));
     }
 
     @SuppressWarnings("unused, used from template")
@@ -72,5 +74,9 @@ public class HomePageView extends AttributionView<Object> {
     @SuppressWarnings("unused, used from template")
     public RegisterContentPages getContentPages() {
         return registerContentPages;
+    }
+
+    public Iterable<Field> getFields() {
+        return fields;
     }
 }

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -28,6 +28,7 @@ public class ViewFactory {
     private final Provider<RegisterReadOnly> register;
     private final Provider<RegisterTrackingConfiguration> registerTrackingConfiguration;
     private final Provider<RegisterContentPagesConfiguration> registerContentPagesConfiguration;
+    private final Provider<ConfigManager> configManager;
 
     @Inject
     public ViewFactory(RequestContext requestContext,
@@ -38,7 +39,8 @@ public class ViewFactory {
                        Provider<RegisterMetadata> registerMetadata,
                        Provider<RegisterTrackingConfiguration> registerTrackingConfiguration,
                        RegisterResolver registerResolver,
-                       Provider<RegisterReadOnly> register) {
+                       Provider<RegisterReadOnly> register,
+                       Provider<ConfigManager> configManager) {
         this.requestContext = requestContext;
         this.publicBodiesConfiguration = publicBodiesConfiguration;
         this.organisationClient = organisationClient;
@@ -48,6 +50,7 @@ public class ViewFactory {
         this.registerTrackingConfiguration = registerTrackingConfiguration;
         this.registerResolver = registerResolver;
         this.register = register;
+        this.configManager = configManager;
     }
 
     public ThymeleafView thymeleafView(String templateName) {
@@ -70,7 +73,8 @@ public class ViewFactory {
                 new RegisterContentPages(registerContentPagesConfiguration.get().getRegisterHistoryPageUrl(),
                         registerContentPagesConfiguration.get().getCustodianName()),
                 registerTrackingConfiguration.get(),
-                registerResolver);
+                registerResolver,
+                configManager.get().getFieldsConfiguration());
     }
 
     public DownloadPageView downloadPageView(Boolean enableDownloadResource) {

--- a/src/test/java/uk/gov/register/views/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/views/HomePageViewTest.java
@@ -1,20 +1,23 @@
 package uk.gov.register.views;
 
+import org.apache.jena.ext.com.google.common.collect.Lists;
+import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.RegisterContentPages;
-import uk.gov.register.core.RegisterMetadata;
-import uk.gov.register.core.RegisterName;
-import uk.gov.register.core.RegisterReadOnly;
-import uk.gov.register.core.RegisterResolver;
+import uk.gov.register.core.*;
 import uk.gov.register.resources.RequestContext;
 
 import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.core.Is.is;
@@ -26,21 +29,26 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HomePageViewTest {
-
     private final RegisterResolver registerResolver = registerName -> URI.create("http://" + registerName + ".test.register.gov.uk");
+
     @Mock
     RequestContext mockRequestContext;
+
+    @Mock
+    FieldsConfiguration fieldsConfiguration;
+
     RegisterContentPages registerContentPages = new RegisterContentPages(Optional.empty(), Optional.empty());
 
     @Test
     public void getRegisterText_rendersRegisterTextAsMarkdown() throws Exception {
         String registerText = "foo *bar* [baz](/quux)";
 
+        RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("widget"), new ArrayList<>(), null, null, registerText, "alpha");
         RegisterReadOnly register = mock(RegisterReadOnly.class);
         when(register.getRegisterName()).thenReturn(new RegisterName("widget"));
-        when(register.getRegisterMetadata()).thenReturn(new RegisterMetadata(new RegisterName("widget"), null, null, null, registerText, "alpha"));
+        when(register.getRegisterMetadata()).thenReturn(registerMetadata);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, register, registerContentPages, () -> Optional.empty(), registerResolver);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration);
 
         String result = homePageView.getRegisterText();
 
@@ -51,14 +59,22 @@ public class HomePageViewTest {
     public void getLastUpdatedTime_formatsTheLocalDateTimeToUKDateTimeFormat() {
         Instant instant = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543).toInstant(ZoneOffset.UTC);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), null, registerContentPages, () -> Optional.empty(), registerResolver);
+        RegisterMetadata registerMetadata = mock(RegisterMetadata.class);
+        RegisterReadOnly register = mock(RegisterReadOnly.class);
+        when(register.getRegisterMetadata()).thenReturn(registerMetadata);
+
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration);
 
         assertThat(homePageView.getLastUpdatedTime(), equalTo("11 September 2015"));
     }
 
     @Test
     public void getLastUpdatedTime_returnsEmptyStringIfLastUpdatedTimeNotPresent() {
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), null, registerContentPages, () -> Optional.empty(), registerResolver);
+        RegisterMetadata registerMetadata = mock(RegisterMetadata.class);
+        RegisterReadOnly register = mock(RegisterReadOnly.class);
+        when(register.getRegisterMetadata()).thenReturn(registerMetadata);
+
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration);
 
         assertThat(homePageView.getLastUpdatedTime(), isEmptyString());
     }
@@ -69,23 +85,30 @@ public class HomePageViewTest {
 
         when(mockRequestContext.getScheme()).thenReturn("https");
 
+        RegisterMetadata registerMetadata = mock(RegisterMetadata.class);
+
         RegisterReadOnly register = mock(RegisterReadOnly.class);
         when(register.getRegisterName()).thenReturn(new RegisterName("school"));
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), register, registerContentPages, () -> Optional.empty(), registerResolver);
+        when(register.getRegisterMetadata()).thenReturn(registerMetadata);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration);
 
         assertThat(homePageView.getLinkToRegisterRegister(), equalTo(URI.create("http://register.test.register.gov.uk/record/school")));
     }
 
     @Test
     public void shouldGetHistoryPageIfAvailable() {
+        RegisterMetadata registerMetadata = mock(RegisterMetadata.class);
+        RegisterReadOnly register = mock(RegisterReadOnly.class);
+        when(register.getRegisterMetadata()).thenReturn(registerMetadata);
+
         RegisterContentPages registerContentPages = new RegisterContentPages(Optional.empty(), Optional.empty());
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), null, registerContentPages, () -> Optional.empty(), registerResolver);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration);
 
         assertThat(homePageView.getContentPages().getRegisterHistoryPageUrl().isPresent(), is(false));
 
         String historyUrl = "http://register-history.openregister.org";
         registerContentPages = new RegisterContentPages(Optional.of(historyUrl), Optional.empty());
-        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), null, registerContentPages, () -> Optional.empty(), registerResolver);
+        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration);
 
         assertThat(homePageView.getContentPages().getRegisterHistoryPageUrl().isPresent(), is(true));
         assertThat(homePageView.getContentPages().getRegisterHistoryPageUrl().get(), is(historyUrl));
@@ -93,16 +116,42 @@ public class HomePageViewTest {
 
     @Test
     public void shouldGetCustodianNameIfAvailable() {
+        RegisterMetadata registerMetadata = mock(RegisterMetadata.class);
+        RegisterReadOnly register = mock(RegisterReadOnly.class);
+        when(register.getRegisterMetadata()).thenReturn(registerMetadata);
+
         RegisterContentPages registerContentPages = new RegisterContentPages(Optional.empty(), Optional.empty());
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), null, registerContentPages, () -> Optional.empty(), registerResolver);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration);
 
         assertThat(homePageView.getContentPages().getCustodianName().isPresent(), is(false));
 
         String custodianName = "John Smith";
         registerContentPages = new RegisterContentPages(Optional.empty(), Optional.of(custodianName));
-        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), null, registerContentPages, () -> Optional.empty(), registerResolver);
+        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration);
 
         assertThat(homePageView.getContentPages().getCustodianName().isPresent(), is(true));
         assertThat(homePageView.getContentPages().getCustodianName().get(), is(custodianName));
+    }
+
+    @Test
+    public void getFields_shouldGetFields() {
+        Field height = new Field("height", "", null, null, "");
+        Field width = new Field("width", "", null, null, "");
+        Field title = new Field("title", "", null, null, "");
+
+        when(fieldsConfiguration.getField("height")).thenReturn(height);
+        when(fieldsConfiguration.getField("width")).thenReturn(width);
+        when(fieldsConfiguration.getField("title")).thenReturn(title);
+
+        RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("widget"), Arrays.asList("height", "width", "title"), null, null, null, "alpha");
+        RegisterReadOnly register = mock(RegisterReadOnly.class);
+        when(register.getRegisterName()).thenReturn(new RegisterName("widget"));
+        when(register.getRegisterMetadata()).thenReturn(registerMetadata);
+
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+
+        List<Field> actualFields = Lists.newArrayList(homePageView.getFields());
+
+        assertThat(actualFields, IsIterableContainingInOrder.contains(height, width, title));
     }
 }


### PR DESCRIPTION
This pull request exposes the register's `Field`s through the `HomePageView`. I decided to take the existing field names which are a part of `RegisterMetadata` and map them to actual `Field`s rather than change `RegisterMetadata` to have a `List<Field>`, because this list is actually formed from reading `registers.yaml`, not `fields.yaml`, meaning that we wouldn't have the necessary information available.