### PR TITLE
Calculate links to from register

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -25,6 +25,7 @@ import uk.gov.register.monitoring.CloudWatchHeartbeater;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.resources.SchemeContext;
 import uk.gov.register.service.ItemConverter;
+import uk.gov.register.service.RegisterLinkService;
 import uk.gov.register.service.RegisterSerialisationFormatService;
 import uk.gov.register.thymeleaf.ThymeleafViewRenderer;
 import uk.gov.register.util.CanonicalJsonMapper;
@@ -79,7 +80,9 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         ConfigManager configManager = new ConfigManager(configuration, registersYamlFileUrl, fieldsYamlFileUrl);
         configManager.refreshConfig();
 
-        AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(dbiFactory, configManager, environment);
+        RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
+
+        AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(dbiFactory, configManager, environment, registerLinkService);
         allTheRegisters.stream().forEach(register -> register.getFlyway().migrate());
 
         jersey.register(new AbstractBinder() {
@@ -94,6 +97,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bindAsContract(RegisterFieldsConfiguration.class);
 
                 bind(configManager).to(ConfigManager.class);
+                bind(registerLinkService).to(RegisterLinkService.class);
                 bind(new PublicBodiesConfiguration(Optional.ofNullable(System.getProperty("publicBodiesYaml")))).to(PublicBodiesConfiguration.class);
 
                 bind(CanonicalJsonMapper.class).to(CanonicalJsonMapper.class);

--- a/src/main/java/uk/gov/register/core/AllTheRegistersFactory.java
+++ b/src/main/java/uk/gov/register/core/AllTheRegistersFactory.java
@@ -3,6 +3,7 @@ package uk.gov.register.core;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.service.RegisterLinkService;
 
 import java.util.Map;
 
@@ -19,16 +20,16 @@ public class AllTheRegistersFactory {
         this.defaultRegisterName = defaultRegisterName;
     }
 
-    public AllTheRegisters build(DBIFactory dbiFactory, ConfigManager configManager, Environment environment) {
+    public AllTheRegisters build(DBIFactory dbiFactory, ConfigManager configManager, Environment environment, RegisterLinkService registerLinkService) {
         Map<RegisterName, RegisterContext> builtRegisters = otherRegisters.entrySet().stream().collect(toMap(Map.Entry::getKey,
-                e -> buildRegister(e.getKey(), e.getValue(), dbiFactory, configManager, environment)));
+                e -> buildRegister(e.getKey(), e.getValue(), dbiFactory, configManager, environment, registerLinkService)));
         return new AllTheRegisters(
-                defaultRegisterFactory.build(defaultRegisterName, dbiFactory, configManager, environment),
+                defaultRegisterFactory.build(defaultRegisterName, dbiFactory, configManager, environment, registerLinkService),
                 builtRegisters
         );
     }
 
-    private RegisterContext buildRegister(RegisterName registerName, RegisterContextFactory registerFactory, DBIFactory dbiFactory, ConfigManager configManager, Environment environment) {
-        return registerFactory.build(registerName, dbiFactory, configManager, environment);
+    private RegisterContext buildRegister(RegisterName registerName, RegisterContextFactory registerFactory, DBIFactory dbiFactory, ConfigManager configManager, Environment environment, RegisterLinkService registerLinkService) {
+        return registerFactory.build(registerName, dbiFactory, configManager, environment, registerLinkService);
     }
 }

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -11,6 +11,7 @@ import uk.gov.register.configuration.*;
 import uk.gov.register.db.*;
 import uk.gov.register.exceptions.NoSuchConfigException;
 import uk.gov.register.service.ItemValidator;
+import uk.gov.register.service.RegisterLinkService;
 import uk.gov.verifiablelog.store.memoization.InMemoryPowOfTwoNoLeaves;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
@@ -27,6 +28,7 @@ public class RegisterContext implements
         ResourceConfiguration {
     private RegisterName registerName;
     private ConfigManager configManager;
+    private RegisterLinkService registerLinkService;
     private AtomicReference<MemoizationStore> memoizationStore;
     private DBI dbi;
     private Flyway flyway;
@@ -39,13 +41,14 @@ public class RegisterContext implements
     private RegisterMetadata registerMetadata;
     private RegisterAuthenticator authenticator;
 
-    public RegisterContext(RegisterName registerName, ConfigManager configManager,
+    public RegisterContext(RegisterName registerName, ConfigManager configManager, RegisterLinkService registerLinkService,
                            DBI dbi, Flyway flyway, Optional<String> trackingId, boolean enableRegisterDataDelete,
                            boolean enableDownloadResource, Optional<String> historyPageUrl,
                            Optional<String> custodianName, Optional<List<String>> similarRegisters,
                            RegisterAuthenticator authenticator) {
         this.registerName = registerName;
         this.configManager = configManager;
+        this.registerLinkService = registerLinkService;
         this.dbi = dbi;
         this.flyway = flyway;
         this.historyPageUrl = historyPageUrl;
@@ -115,6 +118,7 @@ public class RegisterContext implements
         if (enableRegisterDataDelete) {
             flyway.clean();
             configManager.refreshConfig();
+            registerLinkService.updateRegisterLinks(registerName);
             memoizationStore.set(new InMemoryPowOfTwoNoLeaves());
             flyway.migrate();
         }

--- a/src/main/java/uk/gov/register/core/RegisterContextFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterContextFactory.java
@@ -9,6 +9,7 @@ import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.register.auth.RegisterAuthenticatorFactory;
 import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.service.RegisterLinkService;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -81,7 +82,7 @@ public class RegisterContextFactory {
         return flywayFactory;
     }
 
-    public RegisterContext build(RegisterName registerName, DBIFactory dbiFactory, ConfigManager configManager, Environment environment) {
+    public RegisterContext build(RegisterName registerName, DBIFactory dbiFactory, ConfigManager configManager, Environment environment, RegisterLinkService registerLinkService) {
         database.getProperties().put("ApplicationName", "openregister_" + registerName);
         // dbiFactory.build() will ensure that this dataSource is correctly shut down
         // it will also be shared with flyway
@@ -90,6 +91,7 @@ public class RegisterContextFactory {
         return new RegisterContext(
                 registerName,
                 configManager,
+                registerLinkService,
                 dbiFactory.build(environment, database, managedDataSource, registerName.value()),
                 getFlywayFactory(registerName).build(managedDataSource),
                 trackingId,

--- a/src/main/java/uk/gov/register/core/RegisterLinks.java
+++ b/src/main/java/uk/gov/register/core/RegisterLinks.java
@@ -1,0 +1,21 @@
+package uk.gov.register.core;
+
+import java.util.List;
+
+public class RegisterLinks {
+    private final List<String> registersLinkedFrom;
+    private final List<String> registersLinkedTo;
+
+    public RegisterLinks(List<String> registersLinkedFrom, List<String> registersLinkedTo) {
+        this.registersLinkedFrom = registersLinkedFrom;
+        this.registersLinkedTo = registersLinkedTo;
+    }
+
+    public List<String> getRegistersLinkedFrom() {
+        return registersLinkedFrom;
+    }
+
+    public List<String> getRegistersLinkedTo() {
+        return registersLinkedTo;
+    }
+}

--- a/src/main/java/uk/gov/register/core/RegisterMetadata.java
+++ b/src/main/java/uk/gov/register/core/RegisterMetadata.java
@@ -1,10 +1,6 @@
 package uk.gov.register.core;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.StringUtils;
@@ -77,7 +73,7 @@ public class RegisterMetadata {
         return Iterables.filter(fields, not(equalTo(registerName.value())));
     }
 
-    public Iterable<String> getFields() {
+    public List<String> getFields() {
         return fields;
     }
 

--- a/src/main/java/uk/gov/register/service/RegisterLinkService.java
+++ b/src/main/java/uk/gov/register/service/RegisterLinkService.java
@@ -1,0 +1,71 @@
+package uk.gov.register.service;
+
+import com.google.common.collect.Lists;
+import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.configuration.RegistersConfiguration;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.RegisterLinks;
+import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.core.RegisterName;
+
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class RegisterLinkService {
+    private final ConfigManager configManager;
+    private Map<RegisterName, RegisterLinks> registersLinks = new ConcurrentHashMap<>();
+
+    @Inject
+    public RegisterLinkService(ConfigManager configManager) {
+        this.configManager = configManager;
+        this.configManager.getRegistersConfiguration().getAllRegisterMetaData().forEach(m -> updateRegisterLinks(m.getRegisterName()));
+    }
+
+    public List<String> getRegistersLinkedTo(RegisterName registerName) {
+        return registersLinks.get(registerName).getRegistersLinkedTo();
+    }
+
+    public List<String> getRegistersLinkedFrom(RegisterName registerName) {
+        return registersLinks.get(registerName).getRegistersLinkedFrom();
+    }
+
+    public void updateRegisterLinks(RegisterName registerName) {
+        RegisterLinks registerLinks = new RegisterLinks(calculateRegistersLinkedFrom(registerName), calculateRegistersLinkedTo(registerName));
+        registersLinks.put(registerName, registerLinks);
+    }
+
+    private List<String> calculateRegistersLinkedFrom(RegisterName registerName) {
+        Collection<Field> allFields = configManager.getFieldsConfiguration().getAllFields();
+        Collection<RegisterMetadata> registersMetadata = configManager.getRegistersConfiguration().getAllRegisterMetaData();
+
+        // Get fields that have a register property equal to the name of the current register
+        List<String> fieldsMatchingRegister = allFields.stream()
+                .filter(f -> f.getRegister().map(r -> r.equals(registerName)).orElse(false))
+                .map(f -> f.fieldName)
+                .collect(Collectors.toList());
+
+        // Next, get the registers which contain the fields matched above, excluding the current register
+        List<String> registers = registersMetadata.stream()
+                .filter(m -> m.getFields().stream().anyMatch(f -> fieldsMatchingRegister.contains(f) && !m.getRegisterName().value().equalsIgnoreCase(f)))//  !f.equalsIgnoreCase(registerName.value())))
+                .map(m -> m.getRegisterName().value())
+                .collect(Collectors.toList());
+
+        return registers;
+    }
+
+    private List<String> calculateRegistersLinkedTo(RegisterName registerName) {
+        Collection<Field> allFields = configManager.getFieldsConfiguration().getAllFields();
+
+        RegistersConfiguration registersConfiguration = configManager.getRegistersConfiguration();
+        List<String> registerFields = Lists.newArrayList(registersConfiguration.getRegisterMetadata(registerName).getFields());
+
+        return allFields.stream()
+                .filter(f -> registerFields.contains(f.fieldName) && f.getRegister().isPresent() && !f.fieldName.equalsIgnoreCase(registerName.value()))
+                .map(f -> f.fieldName)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/gov/register/service/RegisterLinkService.java
+++ b/src/main/java/uk/gov/register/service/RegisterLinkService.java
@@ -25,12 +25,8 @@ public class RegisterLinkService {
         this.configManager.getRegistersConfiguration().getAllRegisterMetaData().forEach(m -> updateRegisterLinks(m.getRegisterName()));
     }
 
-    public List<String> getRegistersLinkedTo(RegisterName registerName) {
-        return registersLinks.get(registerName).getRegistersLinkedTo();
-    }
-
-    public List<String> getRegistersLinkedFrom(RegisterName registerName) {
-        return registersLinks.get(registerName).getRegistersLinkedFrom();
+    public RegisterLinks getRegisterLinks(RegisterName registerName) {
+        return registersLinks.get(registerName);
     }
 
     public void updateRegisterLinks(RegisterName registerName) {
@@ -50,7 +46,7 @@ public class RegisterLinkService {
 
         // Next, get the registers which contain the fields matched above, excluding the current register
         List<String> registers = registersMetadata.stream()
-                .filter(m -> m.getFields().stream().anyMatch(f -> fieldsMatchingRegister.contains(f) && !m.getRegisterName().value().equalsIgnoreCase(f)))//  !f.equalsIgnoreCase(registerName.value())))
+                .filter(m -> m.getFields().stream().anyMatch(f -> fieldsMatchingRegister.contains(f) && !m.getRegisterName().value().equalsIgnoreCase(f)))
                 .map(m -> m.getRegisterName().value())
                 .collect(Collectors.toList());
 
@@ -65,7 +61,7 @@ public class RegisterLinkService {
 
         return allFields.stream()
                 .filter(f -> registerFields.contains(f.fieldName) && f.getRegister().isPresent() && !f.fieldName.equalsIgnoreCase(registerName.value()))
-                .map(f -> f.fieldName)
+                .map(f -> f.getRegister().get().value())
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/register/views/HomePageView.java
+++ b/src/main/java/uk/gov/register/views/HomePageView.java
@@ -7,6 +7,7 @@ import uk.gov.register.configuration.HomepageContent;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.*;
 import uk.gov.register.resources.RequestContext;
+import uk.gov.register.service.RegisterLinkService;
 
 import java.net.URI;
 import java.time.Instant;
@@ -25,6 +26,7 @@ public class HomePageView extends AttributionView<Object> {
     private final int totalEntries;
     private final HomepageContent homepageContent;
     private final Iterable<Field> fields;
+    private final RegisterLinks registerLinks;
 
     public HomePageView(
             PublicBody registry,
@@ -37,13 +39,15 @@ public class HomePageView extends AttributionView<Object> {
             HomepageContent homepageContent,
             RegisterTrackingConfiguration registerTrackingConfiguration,
             RegisterResolver registerResolver,
-            FieldsConfiguration fieldsConfiguration) {
+            FieldsConfiguration fieldsConfiguration,
+            RegisterLinkService registerLinkService) {
         super("home.html", requestContext, registry, registryBranding, register, registerTrackingConfiguration, registerResolver, null);
         this.totalRecords = totalRecords;
         this.totalEntries = totalEntries;
         this.lastUpdated = lastUpdated;
         this.homepageContent = homepageContent;
         this.fields = Iterables.transform(getRegister().getFields(), f -> fieldsConfiguration.getField(f));
+        this.registerLinks = registerLinkService.getRegisterLinks(getRegisterId());
     }
 
     @SuppressWarnings("unused, used from template")
@@ -79,4 +83,6 @@ public class HomePageView extends AttributionView<Object> {
     public Iterable<Field> getFields() {
         return fields;
     }
+
+    public RegisterLinks getRegisterLinks() { return registerLinks; }
 }

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -7,6 +7,7 @@ import uk.gov.register.configuration.*;
 import uk.gov.register.core.*;
 import uk.gov.register.resources.Pagination;
 import uk.gov.register.resources.RequestContext;
+import uk.gov.register.service.RegisterLinkService;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
 import javax.inject.Inject;
@@ -27,6 +28,7 @@ public class ViewFactory {
     private final Provider<RegisterTrackingConfiguration> registerTrackingConfiguration;
     private final Provider<HomepageContentConfiguration> homepageContentConfiguration;
     private final Provider<ConfigManager> configManager;
+    private final Provider<RegisterLinkService> registerLinkService;
 
     @Inject
     public ViewFactory(RequestContext requestContext,
@@ -38,7 +40,8 @@ public class ViewFactory {
                        Provider<RegisterTrackingConfiguration> registerTrackingConfiguration,
                        RegisterResolver registerResolver,
                        Provider<RegisterReadOnly> register,
-                       Provider<ConfigManager> configManager) {
+                       Provider<ConfigManager> configManager,
+                       Provider<RegisterLinkService> registerLinkService) {
         this.requestContext = requestContext;
         this.publicBodiesConfiguration = publicBodiesConfiguration;
         this.organisationClient = organisationClient;
@@ -49,6 +52,7 @@ public class ViewFactory {
         this.registerResolver = registerResolver;
         this.register = register;
         this.configManager = configManager;
+        this.registerLinkService = registerLinkService;
     }
 
     public ThymeleafView thymeleafView(String templateName) {
@@ -73,7 +77,8 @@ public class ViewFactory {
                         homepageContentConfiguration.get().getSimilarRegisters()),
                 registerTrackingConfiguration.get(),
                 registerResolver,
-                configManager.get().getFieldsConfiguration());
+                configManager.get().getFieldsConfiguration(),
+                registerLinkService.get());
     }
 
     public DownloadPageView downloadPageView(Boolean enableDownloadResource) {

--- a/src/test/java/uk/gov/register/core/RegisterContextTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterContextTest.java
@@ -7,6 +7,7 @@ import org.skife.jdbi.v2.DBI;
 import uk.gov.register.auth.RegisterAuthenticator;
 import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.exceptions.NoSuchConfigException;
+import uk.gov.register.service.RegisterLinkService;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.*;
 public class RegisterContextTest {
     private RegisterName registerName;
     private ConfigManager configManager;
+    private RegisterLinkService registerLinkService;
     private DBI dbi;
     private Flyway flyway;
 
@@ -23,13 +25,14 @@ public class RegisterContextTest {
     public void setup() {
         registerName = new RegisterName("register");
         configManager = mock(ConfigManager.class, RETURNS_DEEP_STUBS);
+        registerLinkService = mock(RegisterLinkService.class);
         dbi = mock(DBI.class);
         flyway = mock(Flyway.class);
     }
 
     @Test
     public void resetRegister_shouldNotResetRegister_whenEnableRegisterDataDeleteIsDisabled() throws IOException, NoSuchConfigException {
-        RegisterContext context = new RegisterContext(registerName, configManager, dbi, flyway, Optional.empty(), false, false, Optional.empty(), Optional.empty(), Optional.empty(), new RegisterAuthenticator("", ""));
+        RegisterContext context = new RegisterContext(registerName, configManager, registerLinkService, dbi, flyway, Optional.empty(), false, false, Optional.empty(), Optional.empty(), Optional.empty(), new RegisterAuthenticator("", ""));
         context.resetRegister();
 
         verify(flyway, never()).clean();
@@ -39,7 +42,7 @@ public class RegisterContextTest {
 
     @Test
     public void resetRegister_shouldResetRegister_whenEnableRegisterDataDeleteIsEnabled() throws IOException, NoSuchConfigException {
-        RegisterContext context = new RegisterContext(registerName, configManager, dbi, flyway, Optional.empty(), true, false, Optional.empty(), Optional.empty(), Optional.empty(), new RegisterAuthenticator("", ""));
+        RegisterContext context = new RegisterContext(registerName, configManager, registerLinkService, dbi, flyway, Optional.empty(), true, false, Optional.empty(), Optional.empty(), Optional.empty(), new RegisterAuthenticator("", ""));
         context.resetRegister();
 
         verify(flyway, times(1)).clean();

--- a/src/test/java/uk/gov/register/service/RegisterLinkServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterLinkServiceTest.java
@@ -1,0 +1,135 @@
+package uk.gov.register.service;
+
+import org.junit.Test;
+import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.configuration.FieldsConfiguration;
+import uk.gov.register.configuration.RegistersConfiguration;
+import uk.gov.register.core.Cardinality;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.core.RegisterName;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RegisterLinkServiceTest {
+    @Test
+    public void getRegistersLinkedFrom_shouldReturnNoRegisters_whenNoOtherRegistersLinkToCurrentRegister() {
+        RegisterName localAuthorityRegisterName = new RegisterName("local-authority");
+        RegisterMetadata localAuthorityMetadata = new RegisterMetadata(localAuthorityRegisterName, Arrays.asList("local-authority", "name", "address"), "", "", "", "");
+
+        RegistersConfiguration registersConfiguration = mock(RegistersConfiguration.class);
+        when(registersConfiguration.getRegisterMetadata(localAuthorityRegisterName)).thenReturn(localAuthorityMetadata);
+        when(registersConfiguration.getAllRegisterMetaData()).thenReturn(Arrays.asList(localAuthorityMetadata));
+
+        FieldsConfiguration fieldsConfiguration = mock(FieldsConfiguration.class);
+        when(fieldsConfiguration.getAllFields()).thenReturn(Arrays.asList(
+                new Field("address", "string", new RegisterName("address"), Cardinality.ONE, ""),
+                new Field("local-authority", "string", localAuthorityRegisterName, Cardinality.ONE, ""),
+                new Field("name", "string", null, Cardinality.ONE, "")
+        ));
+
+        ConfigManager configManager = mock(ConfigManager.class);
+        when(configManager.getRegistersConfiguration()).thenReturn(registersConfiguration);
+        when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
+
+        RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
+        List<String> registers = registerLinkService.getRegistersLinkedFrom(localAuthorityRegisterName);
+
+        assertThat(registers, is(empty()));
+    }
+
+    @Test
+    public void getRegistersLinkedFrom_shouldReturnRegisters_whenOtherRegistersLinkToCurrentRegister() {
+        RegisterName addressRegisterName = new RegisterName("address");
+        RegisterName companyRegisterName = new RegisterName("company");
+        RegisterName localAuthorityRegisterName = new RegisterName("local-authority");
+        RegisterMetadata addressMetadata = new RegisterMetadata(addressRegisterName, Arrays.asList("address", "street", "country"), "", "", "", "");
+        RegisterMetadata companyMetadata = new RegisterMetadata(companyRegisterName, Arrays.asList("company", "name", "registered-office"), "", "", "", "");
+        RegisterMetadata localAuthorityMetadata = new RegisterMetadata(localAuthorityRegisterName, Arrays.asList("local-authority", "name", "address"), "", "", "", "");
+
+        RegistersConfiguration registersConfiguration = mock(RegistersConfiguration.class);
+        when(registersConfiguration.getRegisterMetadata(addressRegisterName)).thenReturn(addressMetadata);
+        when(registersConfiguration.getRegisterMetadata(companyRegisterName)).thenReturn(companyMetadata);
+        when(registersConfiguration.getRegisterMetadata(localAuthorityRegisterName)).thenReturn(localAuthorityMetadata);
+        when(registersConfiguration.getAllRegisterMetaData()).thenReturn(Arrays.asList(addressMetadata, companyMetadata, localAuthorityMetadata));
+
+        FieldsConfiguration fieldsConfiguration = mock(FieldsConfiguration.class);
+        when(fieldsConfiguration.getAllFields()).thenReturn(Arrays.asList(
+                new Field("address", "string", addressRegisterName, Cardinality.ONE, ""),
+                new Field("company", "string", companyRegisterName, Cardinality.ONE, ""),
+                new Field("local-authority", "string", localAuthorityRegisterName, Cardinality.ONE, ""),
+                new Field("name", "string", null, Cardinality.ONE, ""),
+                new Field("street", "string", null, Cardinality.ONE, ""),
+                new Field("registered-office", "string", addressRegisterName, Cardinality.ONE, "")
+        ));
+
+        ConfigManager configManager = mock(ConfigManager.class);
+        when(configManager.getRegistersConfiguration()).thenReturn(registersConfiguration);
+        when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
+
+        RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
+        List<String> registers = registerLinkService.getRegistersLinkedFrom(addressRegisterName);
+
+        assertThat(registers, contains("company", "local-authority"));
+    }
+
+    @Test
+    public void getRegistersLinkedTo_shouldReturnNoRegisters_whenCurrentRegisterLinksToNoOtherRegisters() {
+        RegisterName registerName = new RegisterName("address");
+        RegisterMetadata registerMetadata = new RegisterMetadata(registerName, Arrays.asList("address", "property", "street", "postcode", "country"), "", "", "", "");
+
+        RegistersConfiguration registersConfiguration = mock(RegistersConfiguration.class);
+        when(registersConfiguration.getRegisterMetadata(registerName)).thenReturn(registerMetadata);
+        when(registersConfiguration.getAllRegisterMetaData()).thenReturn(Arrays.asList(registerMetadata));
+
+        FieldsConfiguration fieldsConfiguration = mock(FieldsConfiguration.class);
+        when(fieldsConfiguration.getAllFields()).thenReturn(Arrays.asList(
+                new Field("address", "string", registerName, Cardinality.ONE, ""),
+                new Field("property", "string", null, Cardinality.ONE, ""),
+                new Field("street", "string", null, Cardinality.ONE, "")
+        ));
+
+        ConfigManager configManager = mock(ConfigManager.class);
+        when(configManager.getRegistersConfiguration()).thenReturn(registersConfiguration);
+        when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
+
+        RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
+        List<String> registers = registerLinkService.getRegistersLinkedTo(registerName);
+
+        assertThat(registers, is(empty()));
+    }
+
+    @Test
+    public void getRegistersLinkedTo_shouldReturnRegisters_whenCurrentRegisterLinksToOtherRegisters() {
+        RegisterName registerName = new RegisterName("address");
+        RegisterMetadata registerMetadata = new RegisterMetadata(registerName, Arrays.asList("address", "property", "street", "postcode", "country"), "", "", "", "");
+
+        RegistersConfiguration registersConfiguration = mock(RegistersConfiguration.class);
+        when(registersConfiguration.getRegisterMetadata(registerName)).thenReturn(registerMetadata);
+        when(registersConfiguration.getAllRegisterMetaData()).thenReturn(Arrays.asList(registerMetadata));
+
+        FieldsConfiguration fieldsConfiguration = mock(FieldsConfiguration.class);
+        when(fieldsConfiguration.getAllFields()).thenReturn(Arrays.asList(
+                new Field("address", "string", registerName, Cardinality.ONE, ""),
+                new Field("property", "string", null, Cardinality.ONE, ""),
+                new Field("street", "string", null, Cardinality.ONE, ""),
+                new Field("postcode", "string", new RegisterName("postcode"), Cardinality.ONE, ""),
+                new Field("country", "string", new RegisterName("country"), Cardinality.ONE, "")
+        ));
+
+        ConfigManager configManager = mock(ConfigManager.class);
+        when(configManager.getRegistersConfiguration()).thenReturn(registersConfiguration);
+        when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
+
+        RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
+        List<String> registers = registerLinkService.getRegistersLinkedTo(registerName);
+
+        assertThat(registers, contains("postcode", "country"));
+    }
+}

--- a/src/test/java/uk/gov/register/service/RegisterLinkServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterLinkServiceTest.java
@@ -39,7 +39,7 @@ public class RegisterLinkServiceTest {
         when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
 
         RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
-        List<String> registers = registerLinkService.getRegistersLinkedFrom(localAuthorityRegisterName);
+        List<String> registers = registerLinkService.getRegisterLinks(localAuthorityRegisterName).getRegistersLinkedFrom();
 
         assertThat(registers, is(empty()));
     }
@@ -74,7 +74,7 @@ public class RegisterLinkServiceTest {
         when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
 
         RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
-        List<String> registers = registerLinkService.getRegistersLinkedFrom(addressRegisterName);
+        List<String> registers = registerLinkService.getRegisterLinks(addressRegisterName).getRegistersLinkedFrom();
 
         assertThat(registers, contains("company", "local-authority"));
     }
@@ -100,7 +100,7 @@ public class RegisterLinkServiceTest {
         when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
 
         RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
-        List<String> registers = registerLinkService.getRegistersLinkedTo(registerName);
+        List<String> registers = registerLinkService.getRegisterLinks(registerName).getRegistersLinkedTo();
 
         assertThat(registers, is(empty()));
     }
@@ -108,7 +108,7 @@ public class RegisterLinkServiceTest {
     @Test
     public void getRegistersLinkedTo_shouldReturnRegisters_whenCurrentRegisterLinksToOtherRegisters() {
         RegisterName registerName = new RegisterName("address");
-        RegisterMetadata registerMetadata = new RegisterMetadata(registerName, Arrays.asList("address", "property", "street", "postcode", "country"), "", "", "", "");
+        RegisterMetadata registerMetadata = new RegisterMetadata(registerName, Arrays.asList("address", "property", "street", "postcode", "country", "registry"), "", "", "", "");
 
         RegistersConfiguration registersConfiguration = mock(RegistersConfiguration.class);
         when(registersConfiguration.getRegisterMetadata(registerName)).thenReturn(registerMetadata);
@@ -120,7 +120,8 @@ public class RegisterLinkServiceTest {
                 new Field("property", "string", null, Cardinality.ONE, ""),
                 new Field("street", "string", null, Cardinality.ONE, ""),
                 new Field("postcode", "string", new RegisterName("postcode"), Cardinality.ONE, ""),
-                new Field("country", "string", new RegisterName("country"), Cardinality.ONE, "")
+                new Field("country", "string", new RegisterName("country"), Cardinality.ONE, ""),
+                new Field("registry", "string", new RegisterName("public-body"), Cardinality.ONE, "")
         ));
 
         ConfigManager configManager = mock(ConfigManager.class);
@@ -128,8 +129,8 @@ public class RegisterLinkServiceTest {
         when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
 
         RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
-        List<String> registers = registerLinkService.getRegistersLinkedTo(registerName);
+        List<String> registers = registerLinkService.getRegisterLinks(registerName).getRegistersLinkedTo();
 
-        assertThat(registers, contains("postcode", "country"));
+        assertThat(registers, contains("postcode", "country", "public-body"));
     }
 }

--- a/src/test/java/uk/gov/register/views/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/views/HomePageViewTest.java
@@ -10,6 +10,7 @@ import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.HomepageContent;
 import uk.gov.register.core.*;
 import uk.gov.register.resources.RequestContext;
+import uk.gov.register.service.RegisterLinkService;
 
 import java.net.URI;
 import java.time.Instant;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
 
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.text.IsEmptyString.isEmptyString;
@@ -34,6 +36,9 @@ public class HomePageViewTest {
     @Mock
     FieldsConfiguration fieldsConfiguration;
 
+    @Mock
+    RegisterLinkService registerLinkService;
+
     HomepageContent homepageContent = new HomepageContent(Optional.empty(), Optional.empty(), Optional.empty());
 
     @Test
@@ -45,7 +50,7 @@ public class HomePageViewTest {
         when(register.getRegisterName()).thenReturn(new RegisterName("widget"));
         when(register.getRegisterMetadata()).thenReturn(registerMetadata);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         String result = homePageView.getRegisterText();
 
@@ -60,7 +65,7 @@ public class HomePageViewTest {
         RegisterReadOnly register = mock(RegisterReadOnly.class);
         when(register.getRegisterMetadata()).thenReturn(registerMetadata);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         assertThat(homePageView.getLastUpdatedTime(), equalTo("11 September 2015"));
     }
@@ -71,7 +76,7 @@ public class HomePageViewTest {
         RegisterReadOnly register = mock(RegisterReadOnly.class);
         when(register.getRegisterMetadata()).thenReturn(registerMetadata);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         assertThat(homePageView.getLastUpdatedTime(), isEmptyString());
     }
@@ -87,7 +92,7 @@ public class HomePageViewTest {
         RegisterReadOnly register = mock(RegisterReadOnly.class);
         when(register.getRegisterName()).thenReturn(new RegisterName("school"));
         when(register.getRegisterMetadata()).thenReturn(registerMetadata);
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         assertThat(homePageView.getLinkToRegisterRegister(), equalTo(URI.create("http://register.test.register.gov.uk/record/school")));
     }
@@ -99,13 +104,13 @@ public class HomePageViewTest {
         when(register.getRegisterMetadata()).thenReturn(registerMetadata);
 
         HomepageContent homepageContent = new HomepageContent(Optional.empty(), Optional.empty(), Optional.empty());
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         assertThat(homePageView.getHomepageContent().getRegisterHistoryPageUrl().isPresent(), is(false));
 
         String historyUrl = "http://register-history.openregister.org";
         homepageContent = new HomepageContent(Optional.of(historyUrl), Optional.empty(), Optional.empty());
-        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         assertThat(homePageView.getHomepageContent().getRegisterHistoryPageUrl().isPresent(), is(true));
         assertThat(homePageView.getHomepageContent().getRegisterHistoryPageUrl().get(), is(historyUrl));
@@ -118,13 +123,13 @@ public class HomePageViewTest {
         when(register.getRegisterMetadata()).thenReturn(registerMetadata);
 
         HomepageContent homepageContent = new HomepageContent(Optional.empty(), Optional.empty(), Optional.empty());
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         assertThat(homePageView.getHomepageContent().getCustodianName().isPresent(), is(false));
 
         String custodianName = "John Smith";
         homepageContent = new HomepageContent(Optional.empty(), Optional.of(custodianName), Optional.empty());
-        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         assertThat(homePageView.getHomepageContent().getCustodianName().isPresent(), is(true));
         assertThat(homePageView.getHomepageContent().getCustodianName().get(), is(custodianName));
@@ -145,11 +150,36 @@ public class HomePageViewTest {
         when(register.getRegisterName()).thenReturn(new RegisterName("widget"));
         when(register.getRegisterMetadata()).thenReturn(registerMetadata);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         List<Field> actualFields = Lists.newArrayList(homePageView.getFields());
 
         assertThat(actualFields, IsIterableContainingInOrder.contains(height, width, title));
+    }
+
+    @Test
+    public void getRegisterLinks_shouldGetRegisterLinks() {
+        RegisterName registerName = new RegisterName("premises");
+        RegisterMetadata registerMetadata = new RegisterMetadata(registerName, new ArrayList<>(), null, null, null, "alpha");
+        RegisterReadOnly register = mock(RegisterReadOnly.class);
+        when(register.getRegisterName()).thenReturn(registerName);
+        when(register.getRegisterMetadata()).thenReturn(registerMetadata);
+        when(registerLinkService.getRegisterLinks(registerName)).thenReturn(new RegisterLinks(new ArrayList<>(), new ArrayList<>()));
+
+        HomepageContent homepageContent = new HomepageContent(Optional.empty(), Optional.empty(), Optional.empty());
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
+
+        assertThat(homePageView.getRegisterLinks().getRegistersLinkedFrom(), is(empty()));
+        assertThat(homePageView.getRegisterLinks().getRegistersLinkedTo(), is(empty()));
+
+        List<String> expectedLinkedFromRegisters = Arrays.asList("business");
+        List<String> expectedLinkedToRegisters = Arrays.asList("company", "industry");
+
+        when(registerLinkService.getRegisterLinks(registerName)).thenReturn(new RegisterLinks(expectedLinkedFromRegisters, expectedLinkedToRegisters));
+        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
+
+        assertThat(homePageView.getRegisterLinks().getRegistersLinkedFrom(), equalTo(expectedLinkedFromRegisters));
+        assertThat(homePageView.getRegisterLinks().getRegistersLinkedTo(), equalTo(expectedLinkedToRegisters));
     }
 
     @Test
@@ -159,13 +189,13 @@ public class HomePageViewTest {
         when(register.getRegisterMetadata()).thenReturn(registerMetadata);
 
         HomepageContent homepageContent = new HomepageContent(Optional.empty(), Optional.empty(), Optional.empty());
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         assertThat(homePageView.getHomepageContent().getSimilarRegisters().isPresent(), is(false));
 
         List<String> similarRegisters = Arrays.asList("address", "territory");
         homepageContent = new HomepageContent(Optional.empty(), Optional.empty(), Optional.of(similarRegisters));
-        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration);
+        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         assertThat(homePageView.getHomepageContent().getSimilarRegisters().isPresent(), is(true));
         assertThat(homePageView.getHomepageContent().getSimilarRegisters().get(), IsIterableContainingInOrder.contains("address", "territory"));

--- a/src/test/java/uk/gov/register/views/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/views/HomePageViewTest.java
@@ -15,10 +15,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;

--- a/src/test/java/uk/gov/register/views/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/views/HomePageViewTest.java
@@ -176,7 +176,7 @@ public class HomePageViewTest {
         List<String> expectedLinkedToRegisters = Arrays.asList("company", "industry");
 
         when(registerLinkService.getRegisterLinks(registerName)).thenReturn(new RegisterLinks(expectedLinkedFromRegisters, expectedLinkedToRegisters));
-        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, registerContentPages, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
+        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), register, homepageContent, () -> Optional.empty(), registerResolver, fieldsConfiguration, registerLinkService);
 
         assertThat(homePageView.getRegisterLinks().getRegistersLinkedFrom(), equalTo(expectedLinkedFromRegisters));
         assertThat(homePageView.getRegisterLinks().getRegistersLinkedTo(), equalTo(expectedLinkedToRegisters));


### PR DESCRIPTION
This PR adds functionality to calculate links between all registers, exposed through a new `RegisterLinkService` and makes this data available to `HomePageView`. Links between registers will be recalculated when the main register application starts, in addition to on demand through the `/delete-register-data` endpoint when register and field configurations are re-loaded.