### PR TITLE
Add Custodian to register home page

### DIFF
--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -32,8 +32,12 @@
       <div class="column-third">
         <aside class="govuk-related-items" role="complementary">
           <h2 class="heading-medium">About this register</h2>
+          <th:block th:if="${#bools.isTrue(homepageContent.custodianName.isPresent())}">
+            <h3 class="heading-small">Custodian</h3>
+            <p th:text="${homepageContent.custodianName.get()}"></p>
+          </th:block>
           <th:block th:replace="main.html::attribution"></th:block>
-          <h3 class="heading-small">Last updated:</h3>
+          <h3 class="heading-small">Last updated</h3>
           <p th:text="${lastUpdatedTime}">Last updated</p>
           <h3 class="heading-medium">More information</h3>
           <ul class="list">

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -49,7 +49,7 @@
 
   <th:block th:fragment="attribution">
     <div class="organisation">
-      <h3 class="heading-small">Managed by:</h3>
+      <h3 class="heading-small">Managed by</h3>
       <th:block th:include="main.html::organisation(${registry}, ${branding})"></th:block>
     </div>
   </th:block>


### PR DESCRIPTION
## Before
![screen shot 2017-01-10 at 10 25 59](https://cloud.githubusercontent.com/assets/3071606/21802816/317a33ec-d71f-11e6-9f65-c029713d72ef.png)

## After
![screen shot 2017-01-10 at 10 24 55](https://cloud.githubusercontent.com/assets/3071606/21802795/1a5325d4-d71f-11e6-8cf8-a4ac96a7484d.png)

This commit also removes colons from sidebar titles