### PR TITLE
run flyway migrations in parallel

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -86,7 +86,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
 
         AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(dbiFactory, configManager, environment, registerLinkService);
-        allTheRegisters.stream().parallel().forEach(register -> register.getFlyway().migrate());
+        allTheRegisters.stream().parallel().forEach(RegisterContext::migrate);
 
         jersey.register(new AbstractBinder() {
             @Override

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -86,7 +86,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
 
         AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(dbiFactory, configManager, environment, registerLinkService);
-        allTheRegisters.stream().forEach(register -> register.getFlyway().migrate());
+        allTheRegisters.stream().parallel().forEach(register -> register.getFlyway().migrate());
 
         jersey.register(new AbstractBinder() {
             @Override

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -74,8 +74,8 @@ public class RegisterContext implements
         return registerMetadata;
     }
 
-    public Flyway getFlyway() {
-        return flyway;
+    public int migrate() {
+        return flyway.migrate();
     }
 
     public Register buildOnDemandRegister() {


### PR DESCRIPTION
We shouldn't need to wait for one register's db migration to finish
before starting another.  As each register is a logically independent
entity, it should be okay to run these migrations in parallel.  For
long-running migrations, this should save time.