### PR TITLE
Fix header for really long register names

### DIFF
--- a/src/main/resources/assets/sass/main.scss
+++ b/src/main/resources/assets/sass/main.scss
@@ -53,10 +53,10 @@ body {
 
   .header-wrapper {
     background-color: $register;
-  }
 
-  .header-logo {
-    width: 100%;
+    .header-global .header-logo {
+      width: 100%;
+    }
   }
 
   #logo {


### PR DESCRIPTION
### Before
<img width="1336" alt="screen shot 2017-01-12 at 15 53 58" src="https://cloud.githubusercontent.com/assets/3071606/21896754/5a32d57a-d8df-11e6-87fc-3418064835ad.png">

### After
<img width="1336" alt="screen shot 2017-01-12 at 15 52 47" src="https://cloud.githubusercontent.com/assets/3071606/21896701/318d1fcc-d8df-11e6-88b0-f084575498fa.png">
