### PR TITLE
Add dependency-check gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ compass {
 }
 
 dependencyCheck {
+    failBuildOnCVSS = 0
     skipConfigurations = ['jrubyExec']
     suppressionFile = 'dependency-check-suppressions.xml'
 }
@@ -174,6 +175,7 @@ task runConformanceTests(type: Exec) {
 
 check {
     dependsOn << runConformanceTests
+    dependsOn << 'dependencyCheck'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,14 @@ buildscript {
         classpath "com.github.ben-manes:gradle-versions-plugin:0.13.0"
         classpath "com.github.jengelman.gradle.plugins:shadow:1.2.3"
         classpath "com.github.robfletcher:compass-gradle-plugin:2.0.6"
+        classpath 'org.owasp:dependency-check-gradle:1.4.4.1'
     }
 }
 
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: "com.github.johnrengelman.shadow"
 apply plugin: "com.github.robfletcher.compass"
+apply plugin: 'org.owasp.dependencycheck'
 
 def assetsDir = new File(projectDir, "src/main/resources/assets")
 
@@ -33,6 +35,11 @@ compass {
     outputStyle = "expanded"
     force = true
     sourcemap = true
+}
+
+dependencyCheck {
+    skipConfigurations = ['jrubyExec']
+    suppressionFile = 'dependency-check-suppressions.xml'
 }
 
 // because we build into src/main/resources, we need compassCompile to run before processResources

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+    <suppress>
+        <notes><![CDATA[
+      file name: markdownj-core-0.4.jar
+      ]]></notes>
+        <gav regex="true">^org\.markdownj:markdownj-core:.*$</gav>
+        <cpe>cpe:/a:jcore:jcore</cpe>
+    </suppress>
+</suppressions>

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -22,7 +22,8 @@ ext {
     postgresClient = 'org.postgresql:postgresql:9.4.1211'
 
     apacheCommonsCodec = 'commons-codec:commons-codec:1.10'
-    awsS3 = 'com.amazonaws:aws-java-sdk-s3:1.11.38'
+    // force AWS's dependency on dataformat-cbor to match our jackson_version
+    awsS3 = ['com.amazonaws:aws-java-sdk-s3:1.11.77', "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"]
 
     jdbi = 'org.jdbi:jdbi:2.77'
     jersey_client = "org.glassfish.jersey.core:jersey-client:${jersey_version}"


### PR DESCRIPTION
this adds the [OWASP dependency check][] gradle plugin.  You can run
it using:

    ./gradlew dependencyCheck

I have also made some changes based on its reports:

 - I deliberately exclude the `jrubyExec` configuration because it
   doesn't go into the final app artefact; it's only used to compile
   sass
 - there is a dependency-check-suppressions.xml file which describes
   false positives to suppress.  In particular, markdownj-core was
   falsely detected as vulnerable to CVE-2012-4232 (which instead
   affects jCore), so this has been suppressed.
 - there was an alarm (probably false?) for
   jackson-dataformat-cbor:2.6.6 due to a transitive dependency from
   AWS SDK.  I've added a thing to force it to the same version of
   jackson as we use everywhere else.

[OWASP dependency check]: http://jeremylong.github.io/DependencyCheck/index.html