### PR TITLE
remove unused config item

### DIFF
--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -64,15 +64,6 @@ public class RegisterConfiguration extends Configuration
     @JsonProperty
     private RegisterName register;
 
-    @SuppressWarnings("unused")
-    @Valid
-    @JsonProperty
-    @Deprecated
-    /**
-     * no longer used.
-     */
-    private String cloudWatchEnvironmentName;
-
     @Override
     public String getRegisterDomain() {
         return registerDomain;


### PR DESCRIPTION
I've checked in all our configs, and we don't ever set this to
anything, so we can safely remove this config item.