### PR TITLE
Update field description layout on home page

### DIFF
--- a/src/main/resources/assets/sass/main.scss
+++ b/src/main/resources/assets/sass/main.scss
@@ -209,3 +209,21 @@ table {
     }
   }
 }
+
+// Defintion lists
+dl {
+  overflow: hidden;
+
+  dt {
+    float: left;
+    font-weight: bold;
+    width: 35%;
+  }
+
+  dd {
+    float: left;
+    margin: 0;
+    padding-bottom: 1em;
+    width: 65%;
+  }
+}

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -19,12 +19,12 @@
         </p>
         <p class="text">You can also <a href="/download">download a copy</a> of the register.</p>
         <p class="text">The <span th:utext="${friendlyRegisterName}"></span> contains <span th:text="${totalRecords}"></span> records and includes the following fields:</p>
-        <ul class="list-bullet">
-          <li th:each="field : ${fields}">
-            <th:block th:text="${field.fieldName}"></th:block>
-            (<th:block th:text="${field.text}"></th:block>)
-          </li>
-        </ul>
+        <dl>
+          <th:block th:each="field : ${fields}">
+            <dt th:text="${#strings.capitalize(field.fieldName) + ':'}"></dt>
+            <dd th:text="${field.text}"></dd>
+          </th:block>
+        </dl>
         <h3 class="heading-small">Using this register</h3>
         <p>Download a copy of this register. You'll need to regularly update it to make sure you have the most current version of the data.</p>
         <p>If you're building a service, you can use this data to create elements for forms.</p>


### PR DESCRIPTION
Update un-ordered list to definition list for the fields name

### Before
![screen shot 2017-01-13 at 15 52 53](https://cloud.githubusercontent.com/assets/3071606/21936230/5c49fb44-d9a8-11e6-8d88-32c2ce83472b.png)

### After
<img width="1392" alt="screen shot 2017-01-16 at 09 19 11" src="https://cloud.githubusercontent.com/assets/3071606/21977145/df3c1bf6-dbcc-11e6-8d37-760ff7c5a288.png">
