### PR TITLE
Log requested register

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,3 +67,7 @@ logging:
   loggers:
     "uk.gov": DEBUG
     "org.skife.jdbi.v2": TRACE
+  appenders:
+    - type: console
+      target: stdout
+      logFormat: "%-5p [%d{ISO8601}] %X{register} %c: %m%n%rEx"

--- a/src/main/java/uk/gov/register/filters/LoggingFilter.java
+++ b/src/main/java/uk/gov/register/filters/LoggingFilter.java
@@ -1,0 +1,25 @@
+package uk.gov.register.filters;
+
+import org.slf4j.MDC;
+import uk.gov.register.core.RegisterContext;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+public class LoggingFilter implements ContainerRequestFilter {
+    private final javax.inject.Provider<RegisterContext> registerContext;
+
+    @Inject
+    public LoggingFilter(javax.inject.Provider<RegisterContext> registerContext) {
+        this.registerContext = registerContext;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        MDC.put("register", registerContext.get().getRegisterName().value());
+    }
+}


### PR DESCRIPTION
This PR adds a new `Filter` which will use MDC (Mapped Diagnostic Context) to store the current register, so that we can then write this out as part of the log entries. This change will add the register name for all user web requests as the story specifies, but will not add register name to the log entries on app startup (for example, during database migration).