### PR TITLE
Layout fix for long field names on register home page

### DIFF
--- a/src/main/resources/assets/sass/main.scss
+++ b/src/main/resources/assets/sass/main.scss
@@ -215,8 +215,10 @@ dl {
   overflow: hidden;
 
   dt {
+    clear: left;
     float: left;
     font-weight: bold;
+    padding-bottom: 1em;
     width: 35%;
   }
 


### PR DESCRIPTION
## Before
![screen shot 2017-01-17 at 11 10 27](https://cloud.githubusercontent.com/assets/3071606/22018206/993d463c-dca5-11e6-9642-906b35ef5dd2.png)

## After
![screen shot 2017-01-17 at 11 10 24](https://cloud.githubusercontent.com/assets/3071606/22018209/9aeb41aa-dca5-11e6-9ef7-d46e5e806831.png)
