### PR TITLE
Fields location in config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,9 +47,14 @@ enableDownloadResource: true
 
 historyPageUrl: https://registers-history.herokuapp.com/school-eng
 
-externalConfigDirectory: /tmp/openregister-java/external
+externalConfigDirectory: /tmp
 
 downloadConfigs: true
+
+# can be http: file s3: or classpath: url
+fieldsYamlLocation: classpath://config/fields.yaml
+
+registersYamlLocation: classpath://config/registers.yaml
 
 similarRegisters:
   - address

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -82,10 +82,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         DropwizardResourceConfig resourceConfig = jersey.getResourceConfig();
         Client client = new JerseyClientBuilder(environment).using(configuration.getJerseyClientConfiguration()).build("http-client");
 
-        Optional<String> registersYamlFileUrl = Optional.ofNullable(System.getProperty("registersYaml"));
-        Optional<String> fieldsYamlFileUrl = Optional.ofNullable(System.getProperty("fieldsYaml"));
-
-        ConfigManager configManager = new ConfigManager(configuration, registersYamlFileUrl, fieldsYamlFileUrl);
+        ConfigManager configManager = new ConfigManager(configuration);
         configManager.refreshConfig();
 
         RegisterLinkService registerLinkService = new RegisterLinkService(configManager);

--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -102,6 +102,16 @@ public class RegisterConfiguration extends Configuration
     @JsonProperty
     private Map<RegisterName, RegisterContextFactory> registers = new HashMap<>();
 
+    @JsonProperty
+    @NotNull
+    @Valid
+    private String fieldsYamlLocation;
+
+    @JsonProperty
+    @NotNull
+    @Valid
+    private String registersYamlLocation;
+
     public DataSourceFactory getDatabase() {
         return database;
     }
@@ -132,4 +142,15 @@ public class RegisterConfiguration extends Configuration
 
     @Override
     public boolean getDownloadConfigs() { return downloadConfigs; }
+
+    @Override
+    public String getFieldsYamlLocation() {
+        return fieldsYamlLocation;
+    }
+
+    @Override
+    public String getRegistersYamlLocation() {
+        return registersYamlLocation;
+    }
+
 }

--- a/src/main/java/uk/gov/register/configuration/ConfigManager.java
+++ b/src/main/java/uk/gov/register/configuration/ConfigManager.java
@@ -12,9 +12,9 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ConfigManager {
-    private final Optional<String> registersConfigFileUrl;
+    private final String registersConfigFileUrl;
     private final String registersConfigFilePath;
-    private final Optional<String> fieldsConfigFileUrl;
+    private final String fieldsConfigFileUrl;
     private final String fieldsConfigFilePath;
     private final boolean refresh;
     private final String externalConfigDirectory;
@@ -22,9 +22,9 @@ public class ConfigManager {
     private AtomicReference<RegistersConfiguration> registersConfiguration = new AtomicReference<>();
     private AtomicReference<FieldsConfiguration> fieldsConfiguration = new AtomicReference<>();
 
-    public ConfigManager(RegisterConfigConfiguration registerConfigConfiguration, Optional<String> registersConfigFileUrl, Optional<String> fieldsConfigFileUrl) {
-        this.registersConfigFileUrl = registersConfigFileUrl;
-        this.fieldsConfigFileUrl = fieldsConfigFileUrl;
+    public ConfigManager(RegisterConfigConfiguration registerConfigConfiguration) {
+        this.registersConfigFileUrl = registerConfigConfiguration.getRegistersYamlLocation();
+        this.fieldsConfigFileUrl = registerConfigConfiguration.getFieldsYamlLocation();
         this.refresh = registerConfigConfiguration.getDownloadConfigs();
         this.externalConfigDirectory = registerConfigConfiguration.getExternalConfigDirectory();
         this.registersConfigFilePath = externalConfigDirectory + "/" + "registers.yaml";
@@ -34,13 +34,8 @@ public class ConfigManager {
     public void refreshConfig() throws NoSuchConfigException, IOException {
         if (refresh) {
             try {
-                if (registersConfigFileUrl.isPresent()) {
-                    Files.copy(new URL(registersConfigFileUrl.get()).openStream(), Paths.get(registersConfigFilePath), StandardCopyOption.REPLACE_EXISTING);
-                }
-                if (fieldsConfigFileUrl.isPresent()) {
-                    Files.copy(new URL(fieldsConfigFileUrl.get()).openStream(), Paths.get(fieldsConfigFilePath), StandardCopyOption.REPLACE_EXISTING);
-                }
-
+                Files.copy(new URL(registersConfigFileUrl).openStream(), Paths.get(registersConfigFilePath), StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(new URL(fieldsConfigFileUrl).openStream(), Paths.get(fieldsConfigFilePath), StandardCopyOption.REPLACE_EXISTING);
                 registersConfiguration.set(createRegistersConfiguration());
                 fieldsConfiguration.set(createFieldsConfiguration());
             } catch (FileNotFoundException e) {
@@ -57,11 +52,11 @@ public class ConfigManager {
         return fieldsConfiguration.get();
     }
 
-    private RegistersConfiguration createRegistersConfiguration() {
-        return new RegistersConfiguration(registersConfigFileUrl.map(s -> registersConfigFilePath));
+    private RegistersConfiguration createRegistersConfiguration() throws IOException {
+        return new RegistersConfiguration(registersConfigFilePath);
     }
 
     private FieldsConfiguration createFieldsConfiguration() {
-        return new FieldsConfiguration(fieldsConfigFileUrl.map(s -> fieldsConfigFilePath));
+        return new FieldsConfiguration(fieldsConfigFilePath);
     }
 }

--- a/src/main/java/uk/gov/register/configuration/ConfigManager.java
+++ b/src/main/java/uk/gov/register/configuration/ConfigManager.java
@@ -8,7 +8,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ConfigManager {
@@ -17,7 +16,6 @@ public class ConfigManager {
     private final String fieldsConfigFileUrl;
     private final String fieldsConfigFilePath;
     private final boolean refresh;
-    private final String externalConfigDirectory;
 
     private AtomicReference<RegistersConfiguration> registersConfiguration = new AtomicReference<>();
     private AtomicReference<FieldsConfiguration> fieldsConfiguration = new AtomicReference<>();
@@ -26,7 +24,8 @@ public class ConfigManager {
         this.registersConfigFileUrl = registerConfigConfiguration.getRegistersYamlLocation();
         this.fieldsConfigFileUrl = registerConfigConfiguration.getFieldsYamlLocation();
         this.refresh = registerConfigConfiguration.getDownloadConfigs();
-        this.externalConfigDirectory = registerConfigConfiguration.getExternalConfigDirectory();
+
+        String externalConfigDirectory = registerConfigConfiguration.getExternalConfigDirectory();
         this.registersConfigFilePath = externalConfigDirectory + "/" + "registers.yaml";
         this.fieldsConfigFilePath = externalConfigDirectory + "/" + "fields.yaml";
     }
@@ -52,7 +51,7 @@ public class ConfigManager {
         return fieldsConfiguration.get();
     }
 
-    private RegistersConfiguration createRegistersConfiguration() throws IOException {
+    private RegistersConfiguration createRegistersConfiguration() {
         return new RegistersConfiguration(registersConfigFilePath);
     }
 

--- a/src/main/java/uk/gov/register/configuration/FieldsConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/FieldsConfiguration.java
@@ -7,18 +7,14 @@ import uk.gov.register.util.ResourceYamlFileReader;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 public class FieldsConfiguration {
 
     private final Collection<Field> fields;
 
-    public FieldsConfiguration(Optional<String> fieldsResourceYamlPath) {
-        fields = new ResourceYamlFileReader().readResource(
-                fieldsResourceYamlPath,
-                "config/fields.yaml",
-                new TypeReference<Map<String, Field>>() {
-                });
+    public FieldsConfiguration(String fieldsResourceYamlPath) {
+        fields = new ResourceYamlFileReader().readResourceFromPath(fieldsResourceYamlPath, new TypeReference<Map<String, Field>>() {
+        });
     }
 
     public Field getField(String fieldName) {

--- a/src/main/java/uk/gov/register/configuration/RegisterConfigConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/RegisterConfigConfiguration.java
@@ -5,5 +5,10 @@ import org.jvnet.hk2.annotations.Contract;
 @Contract
 public interface RegisterConfigConfiguration {
     boolean getDownloadConfigs();
+
     String getExternalConfigDirectory();
+
+    String getFieldsYamlLocation();
+
+    String getRegistersYamlLocation();
 }

--- a/src/main/java/uk/gov/register/configuration/RegistersConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/RegistersConfiguration.java
@@ -5,22 +5,19 @@ import uk.gov.register.core.RegisterMetadata;
 import uk.gov.register.core.RegisterName;
 import uk.gov.register.util.ResourceYamlFileReader;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 public class RegistersConfiguration {
 
     private final Collection<RegisterMetadata> registers;
 
-    public RegistersConfiguration(Optional<String> registersResourceYamlPath) {
-        registers = new ResourceYamlFileReader().readResource(
-                registersResourceYamlPath,
-                "config/registers.yaml",
-                new TypeReference<Map<String, RegisterMetadata>>() {
-                }
-        );
+    public RegistersConfiguration(String registersResourceYamlPath) throws IOException {
+        registers = new ResourceYamlFileReader().readResourceFromPath(registersResourceYamlPath, new TypeReference<Map<String,
+                RegisterMetadata>>() {
+        });
     }
 
     public RegisterMetadata getRegisterMetadata(RegisterName registerName) {

--- a/src/main/java/uk/gov/register/configuration/RegistersConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/RegistersConfiguration.java
@@ -5,7 +5,6 @@ import uk.gov.register.core.RegisterMetadata;
 import uk.gov.register.core.RegisterName;
 import uk.gov.register.util.ResourceYamlFileReader;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -14,7 +13,7 @@ public class RegistersConfiguration {
 
     private final Collection<RegisterMetadata> registers;
 
-    public RegistersConfiguration(String registersResourceYamlPath) throws IOException {
+    public RegistersConfiguration(String registersResourceYamlPath) {
         registers = new ResourceYamlFileReader().readResourceFromPath(registersResourceYamlPath, new TypeReference<Map<String,
                 RegisterMetadata>>() {
         });

--- a/src/main/java/uk/gov/register/protocols/classpath/ClasspathURLConnection.java
+++ b/src/main/java/uk/gov/register/protocols/classpath/ClasspathURLConnection.java
@@ -5,8 +5,6 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/uk/gov/register/protocols/classpath/ClasspathURLConnection.java
+++ b/src/main/java/uk/gov/register/protocols/classpath/ClasspathURLConnection.java
@@ -1,0 +1,39 @@
+package uk.gov.register.protocols.classpath;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ClasspathURLConnection extends URLConnection {
+
+    private final Pattern classpathPattern = Pattern.compile("classpath://(.+)");
+
+    ClasspathURLConnection(URL url) {
+        super(url);
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        String path = getPath(url);
+        return this.getClass().getClassLoader().getResourceAsStream(path);
+    }
+
+    private String getPath(URL url) throws MalformedURLException {
+        Matcher matcher = classpathPattern.matcher(url.toString());
+        if (matcher.matches() && matcher.groupCount() == 1) {
+            return matcher.group(1);
+        }
+        throw new MalformedURLException("url did not match pattern for classpath url: " + url.toString());
+    }
+
+    @Override
+    public void connect() throws IOException {
+        // do nothing
+    }
+}

--- a/src/main/java/uk/gov/register/protocols/classpath/Handler.java
+++ b/src/main/java/uk/gov/register/protocols/classpath/Handler.java
@@ -1,0 +1,20 @@
+package uk.gov.register.protocols.classpath;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+/**
+ * The presence of this class in the package corresponding to the protocol name i.e. classpath
+ * under the package specified by the system property "java.protocol.handler.pkgs" allows
+ * Java to read from a classpath://path url
+ */
+public class Handler extends URLStreamHandler {
+
+    @Override
+    protected URLConnection openConnection(URL url) throws IOException {
+        return new ClasspathURLConnection(url);
+    }
+
+}

--- a/src/main/java/uk/gov/register/util/ResourceYamlFileReader.java
+++ b/src/main/java/uk/gov/register/util/ResourceYamlFileReader.java
@@ -33,10 +33,9 @@ public class ResourceYamlFileReader {
         }
     }
 
-    public <N> Collection<N> readResource(byte[] bytes,
-                                          TypeReference<Map<String, N>> typeReference) {
+    public <N> Collection<N> readResourceFromPath(String path, TypeReference<Map<String, N>> typeReference) {
         try {
-            return YAML_OBJECT_MAPPER.<Map<String, N>>readValue(bytes, typeReference).values();
+            return YAML_OBJECT_MAPPER.<Map<String, N>>readValue(getStreamForFile(path), typeReference).values();
         } catch (IOException e) {
             throw new UncheckedIOException("Error loading resources configuration file.", e);
         }

--- a/src/test/java/uk/gov/register/configuration/ConfigManagerTest.java
+++ b/src/test/java/uk/gov/register/configuration/ConfigManagerTest.java
@@ -46,7 +46,6 @@ public class ConfigManagerTest {
         externalConfigsFolderPath = externalConfigsFolder.getRoot().toString();
     }
 
-
     @Test
     public void refreshConfig_shouldNotRefresh_whenRefreshIsDisabled() throws NoSuchConfigException, IOException {
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(false);
@@ -124,7 +123,6 @@ public class ConfigManagerTest {
         List<String> registerNames = allRegisterMetaData.stream().map(md -> md.getRegisterName().toString()).collect(toList());
 
         assertThat(registerNames, hasItems("food-premises","country"));
-
     }
 
     @Test(expected = NoSuchConfigException.class)
@@ -158,7 +156,6 @@ public class ConfigManagerTest {
 
         ConfigManager configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
-
     }
 
     @Test(expected = MalformedURLException.class)

--- a/src/test/java/uk/gov/register/configuration/ConfigManagerTest.java
+++ b/src/test/java/uk/gov/register/configuration/ConfigManagerTest.java
@@ -1,13 +1,14 @@
 package uk.gov.register.configuration;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import uk.gov.register.core.Field;
 import uk.gov.register.core.RegisterMetadata;
 import uk.gov.register.exceptions.NoSuchConfigException;
-import uk.gov.register.util.ResourceYamlFileReader;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,29 +16,41 @@ import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
+import java.util.List;
 
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ConfigManagerTest {
     @Rule
     public TemporaryFolder externalConfigsFolder = new TemporaryFolder();
 
+    private String missingConfigFileUrl = "file:///config-that-does-not-exist.yaml";
+
+    private String registersConfigFileUrl = Paths.get("src/test/resources/config/external-registers.yaml").toUri().toString();
+
+    private String fieldsConfigFileUrl = Paths.get("src/test/resources/config/external-fields.yaml").toUri().toString();
+
+    private String externalConfigsFolderPath;
+
+    @Mock
+    private RegisterConfigConfiguration registerConfigConfiguration;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        externalConfigsFolderPath = externalConfigsFolder.getRoot().toString();
+    }
+
+
     @Test
     public void refreshConfig_shouldNotRefresh_whenRefreshIsDisabled() throws NoSuchConfigException, IOException {
-        RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(false);
-
-        Optional<String> registersConfigFileUrl = Optional.of("file:///config-that-does-not-exist.yaml");
-        Optional<String> fieldsConfigFileUrl = Optional.of("file:///config-that-does-not-exist.yaml");
-
-        ConfigManager configManager = new ConfigManager(registerConfigConfiguration, registersConfigFileUrl, fieldsConfigFileUrl);
+        ConfigManager configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
 
         assertNull(configManager.getRegistersConfiguration());
@@ -47,14 +60,15 @@ public class ConfigManagerTest {
     @Test
     public void refreshConfig_shouldDownloadAndStoreRegistersConfigFile_whenRegistersConfigFileUrlIsSpecified() throws Exception {
         File createdRegistersFile = externalConfigsFolder.newFile("registers.yaml");
-        String externalRegistersUrl = Paths.get("src/test/resources/config/external-registers.yaml").toUri().toString();
 
-        RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
         when(registerConfigConfiguration.getExternalConfigDirectory()).thenReturn(externalConfigsFolder.getRoot().getAbsolutePath());
+        when(registerConfigConfiguration.getFieldsYamlLocation()).thenReturn(this.fieldsConfigFileUrl);
+        when(registerConfigConfiguration.getRegistersYamlLocation()).thenReturn(this.registersConfigFileUrl);
 
-        ConfigManager configManager = new ConfigManager(registerConfigConfiguration, Optional.of(externalRegistersUrl), Optional.empty());
+        ConfigManager configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
+
         String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/config/external-registers.yaml")));
         String copiedConfig = new String(Files.readAllBytes(createdRegistersFile.toPath()));
         assertThat(copiedConfig, is(expected));
@@ -63,136 +77,98 @@ public class ConfigManagerTest {
     @Test
     public void refreshConfig_shouldDownloadAndStoreFieldsConfigFile_whenFieldsConfigFileUrlIsSpecified() throws Exception {
         File createdFieldsFile = externalConfigsFolder.newFile("fields.yaml");
-        String externalFieldsUrl = Paths.get("src/test/resources/config/external-fields.yaml").toUri().toString();
 
-        RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
         when(registerConfigConfiguration.getExternalConfigDirectory()).thenReturn(externalConfigsFolder.getRoot().getAbsolutePath());
+        when(registerConfigConfiguration.getFieldsYamlLocation()).thenReturn(this.fieldsConfigFileUrl);
+        when(registerConfigConfiguration.getRegistersYamlLocation()).thenReturn(this.registersConfigFileUrl);
 
-        ConfigManager configManager = new ConfigManager(registerConfigConfiguration, Optional.empty(), Optional.of(externalFieldsUrl));
+        ConfigManager configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
+
         String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/config/external-fields.yaml")));
         String copiedConfig = new String(Files.readAllBytes(createdFieldsFile.toPath()));
         assertThat(copiedConfig, is(expected));
     }
 
-    @Test
-    public void refreshConfig_shouldRefreshConfigsFromDefaultFiles_whenNoConfigFileUrlsSpecified() throws NoSuchConfigException, IOException {
-        RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
-        when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
-
-        Optional<String> registersConfigFileUrl = Optional.empty();
-        Optional<String> fieldsConfigFileUrl = Optional.empty();
-
-        ResourceYamlFileReader resourceYamlFileReader = new ResourceYamlFileReader();
-        Collection<Field> expectedFields = resourceYamlFileReader.readResource(fieldsConfigFileUrl, "config/fields.yaml", new TypeReference<Map<String, Field>>(){});
-        Collection<RegisterMetadata> expectedRegisters = resourceYamlFileReader.readResource(registersConfigFileUrl, "config/registers.yaml", new TypeReference<Map<String, RegisterMetadata>>(){});
-
-        ConfigManager configManager = new ConfigManager(registerConfigConfiguration, registersConfigFileUrl, fieldsConfigFileUrl);
-        configManager.refreshConfig();
-
-        Collection<Field> actualFields = configManager.getFieldsConfiguration().getAllFields();
-        Collection<RegisterMetadata> actualRegisters = configManager.getRegistersConfiguration().getAllRegisterMetaData();
-
-        assertTrue(expectedFields.containsAll(actualFields));
-        assertTrue(expectedRegisters.containsAll(actualRegisters));
-    }
 
     @Test
     public void refreshConfig_shouldRefreshFieldsConfigurationUsingFileUrl_whenFieldsConfigFileUrlIsSpecified() throws NoSuchConfigException, IOException {
-        String externalConfigsFolderPath = externalConfigsFolder.getRoot().toString();
 
-        RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
         when(registerConfigConfiguration.getExternalConfigDirectory()).thenReturn(externalConfigsFolderPath);
+        when(registerConfigConfiguration.getRegistersYamlLocation()).thenReturn(registersConfigFileUrl);
+        when(registerConfigConfiguration.getFieldsYamlLocation()).thenReturn(fieldsConfigFileUrl);
 
-        Optional<String> registersConfigFileUrl = Optional.empty();
-        Optional<String> fieldsConfigFileUrl = Optional.of(Paths.get("src/test/resources/config/external-fields.yaml").toUri().toString());
-
-        ResourceYamlFileReader resourceYamlFileReader = new ResourceYamlFileReader();
-        Collection<Field> expectedFields = resourceYamlFileReader.readResource(Optional.of("src/test/resources/config/external-fields.yaml"), "config/fields.yaml", new TypeReference<Map<String, Field>>(){});
-        Collection<RegisterMetadata> expectedRegisters = resourceYamlFileReader.readResource(Optional.empty(), "config/registers.yaml", new TypeReference<Map<String, RegisterMetadata>>(){});
-
-        ConfigManager configManager = new ConfigManager(registerConfigConfiguration, registersConfigFileUrl, fieldsConfigFileUrl);
+        ConfigManager configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
 
         Collection<Field> actualFields = configManager.getFieldsConfiguration().getAllFields();
-        Collection<RegisterMetadata> actualRegisters = configManager.getRegistersConfiguration().getAllRegisterMetaData();
+        List<String> fieldNames = actualFields.stream().map(f -> f.fieldName).collect(toList());
 
-        assertTrue(expectedFields.containsAll(actualFields));
-        assertTrue(expectedRegisters.containsAll(actualRegisters));
+        assertThat(fieldNames, hasItems("country","food-premises-types","copyright"));
     }
 
     @Test
     public void refreshConfig_shouldRefreshRegistersConfigurationUsingFileUrl_whenRegistersConfigFileUrlIsSpecified() throws NoSuchConfigException, IOException {
-        String externalConfigsFolderPath = externalConfigsFolder.getRoot().toString();
 
-        RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
         when(registerConfigConfiguration.getExternalConfigDirectory()).thenReturn(externalConfigsFolderPath);
+        when(registerConfigConfiguration.getRegistersYamlLocation()).thenReturn(registersConfigFileUrl);
+        when(registerConfigConfiguration.getFieldsYamlLocation()).thenReturn(fieldsConfigFileUrl);
 
-        Optional<String> registersConfigFileUrl = Optional.of(Paths.get("src/test/resources/config/external-registers.yaml").toUri().toString());
-        Optional<String> fieldsConfigFileUrl = Optional.empty();
-
-        ResourceYamlFileReader resourceYamlFileReader = new ResourceYamlFileReader();
-        Collection<Field> expectedFields = resourceYamlFileReader.readResource(Optional.empty(), "config/fields.yaml", new TypeReference<Map<String, Field>>(){});
-        Collection<RegisterMetadata> expectedRegisters = resourceYamlFileReader.readResource(Optional.of("src/test/resources/config/external-registers.yaml"), "config/registers.yaml", new TypeReference<Map<String, RegisterMetadata>>(){});
-
-        ConfigManager configManager = new ConfigManager(registerConfigConfiguration, registersConfigFileUrl, fieldsConfigFileUrl);
+        ConfigManager configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
 
-        Collection<Field> actualFields = configManager.getFieldsConfiguration().getAllFields();
-        Collection<RegisterMetadata> actualRegisters = configManager.getRegistersConfiguration().getAllRegisterMetaData();
+        Collection<RegisterMetadata> allRegisterMetaData = configManager.getRegistersConfiguration().getAllRegisterMetaData();
+        List<String> registerNames = allRegisterMetaData.stream().map(md -> md.getRegisterName().toString()).collect(toList());
 
-        assertTrue(expectedFields.containsAll(actualFields));
-        assertTrue(expectedRegisters.containsAll(actualRegisters));
+        assertThat(registerNames, hasItems("food-premises","country"));
+
     }
 
     @Test(expected = NoSuchConfigException.class)
     public void refreshConfig_shouldThrowNoSuchConfigException_whenSpecifiedRegistersConfigFileUrlIsNotFound() throws NoSuchConfigException, IOException {
-        RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
+        when(registerConfigConfiguration.getExternalConfigDirectory()).thenReturn(externalConfigsFolderPath);
+        when(registerConfigConfiguration.getFieldsYamlLocation()).thenReturn(this.fieldsConfigFileUrl);
+        when(registerConfigConfiguration.getRegistersYamlLocation()).thenReturn(this.missingConfigFileUrl);
 
-        Optional<String> registersConfigFileUrl = Optional.of("file:///config-that-does-not-exist.yaml");
-        Optional<String> fieldsConfigFileUrl = Optional.empty();
-
-        ConfigManager configManager = new ConfigManager(registerConfigConfiguration, registersConfigFileUrl, fieldsConfigFileUrl);
+        ConfigManager configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
     }
 
     @Test(expected = NoSuchConfigException.class)
     public void refreshConfig_shouldThrowNoSuchConfigException_whenSpecifiedFieldsConfigFileUrlIsNotFound() throws NoSuchConfigException, IOException {
-        RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
+        when(registerConfigConfiguration.getExternalConfigDirectory()).thenReturn(externalConfigsFolderPath);
+        when(registerConfigConfiguration.getFieldsYamlLocation()).thenReturn(missingConfigFileUrl);
+        when(registerConfigConfiguration.getRegistersYamlLocation()).thenReturn(this.registersConfigFileUrl);
 
-        Optional<String> registersConfigFileUrl = Optional.empty();
-        Optional<String> fieldsConfigFileUrl = Optional.of("file:///config-that-does-not-exist.yaml");
-
-        ConfigManager configManager = new ConfigManager(registerConfigConfiguration, registersConfigFileUrl, fieldsConfigFileUrl);
+        ConfigManager configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
     }
 
     @Test(expected = MalformedURLException.class)
     public void refreshConfig_shouldThrowIOException_whenSpecifiedRegistersConfigUrlIsMalformed() throws IOException, NoSuchConfigException {
-        RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
+        when(registerConfigConfiguration.getExternalConfigDirectory()).thenReturn(externalConfigsFolderPath);
+        when(registerConfigConfiguration.getRegistersYamlLocation()).thenReturn("zzz://config-that-does-not-exist.yaml");
+        when(registerConfigConfiguration.getRegistersYamlLocation()).thenReturn(this.fieldsConfigFileUrl);
 
-        Optional<String> registersConfigFileUrl = Optional.of("config-that-does-not-exist.yaml");
-        Optional<String> fieldsConfigFileUrl = Optional.empty();
-
-        ConfigManager configManager = new ConfigManager(registerConfigConfiguration, registersConfigFileUrl, fieldsConfigFileUrl);
+        ConfigManager configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
+
     }
 
     @Test(expected = MalformedURLException.class)
     public void refreshConfig_shouldThrowIOException_whenSpecifiedFieldsConfigUrlIsMalformed() throws IOException, NoSuchConfigException {
-        RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
+        when(registerConfigConfiguration.getExternalConfigDirectory()).thenReturn(externalConfigsFolderPath);
+        when(registerConfigConfiguration.getFieldsYamlLocation()).thenReturn("zzz://config-that-does-not-exist.yaml");
+        when(registerConfigConfiguration.getRegistersYamlLocation()).thenReturn(this.registersConfigFileUrl);
 
-        Optional<String> registersConfigFileUrl = Optional.empty();
-        Optional<String> fieldsConfigFileUrl = Optional.of("config-that-does-not-exist.yaml");
-
-        ConfigManager configManager = new ConfigManager(registerConfigConfiguration, registersConfigFileUrl, fieldsConfigFileUrl);
+        ConfigManager configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
     }
 }

--- a/src/test/java/uk/gov/register/configuration/FieldsConfigurationTest.java
+++ b/src/test/java/uk/gov/register/configuration/FieldsConfigurationTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertThat;
 public class FieldsConfigurationTest {
     @Test
     public void loadConfigurationWithDefaultFieldsResourceFile() {
-        FieldsConfiguration fieldsConfiguration = new FieldsConfiguration(Optional.empty());
+        FieldsConfiguration fieldsConfiguration = new FieldsConfiguration("src/main/resources/config/fields.yaml");
 
         assertThat(fieldsConfiguration.getField("register").fieldName, equalTo("register"));
     }
@@ -22,7 +22,7 @@ public class FieldsConfigurationTest {
         @SuppressWarnings("ConstantConditions")
         String fileUrl = ResourceHelpers.resourceFilePath("config/fields.yaml");
 
-        FieldsConfiguration fieldsConfiguration = new FieldsConfiguration(Optional.of(fileUrl));
+        FieldsConfiguration fieldsConfiguration = new FieldsConfiguration(fileUrl);
 
         assertThat(fieldsConfiguration.getField("register").fieldName, equalTo("register"));
     }

--- a/src/test/java/uk/gov/register/configuration/RegistersConfigurationTest.java
+++ b/src/test/java/uk/gov/register/configuration/RegistersConfigurationTest.java
@@ -4,25 +4,23 @@ import org.junit.Test;
 import uk.gov.register.core.RegisterMetadata;
 import uk.gov.register.core.RegisterName;
 
-import java.util.Optional;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.fail;
 
 public class RegistersConfigurationTest {
     @Test
-    public void configuration_shouldReturnRegisterData_whenRegisterExists() {
-        RegistersConfiguration configuration = new RegistersConfiguration(Optional.ofNullable(System.getProperty("registersYaml")));
+    public void configuration_shouldReturnRegisterData_whenRegisterExists() throws Exception {
+        RegistersConfiguration configuration = new RegistersConfiguration("src/main/resources/config/registers.yaml");
         RegisterMetadata data = configuration.getRegisterMetadata(new RegisterName("register"));
 
         assertThat("register", equalTo(data.getRegisterName().toString()));
     }
 
     @Test
-    public void configuration_shouldThrowException_whenRegisterDoesNotExist() {
+    public void configuration_shouldThrowException_whenRegisterDoesNotExist() throws Exception {
         try {
-            RegistersConfiguration configuration = new RegistersConfiguration(Optional.ofNullable(System.getProperty("registersYaml")));
+            RegistersConfiguration configuration = new RegistersConfiguration("src/main/resources/config/registers.yaml");
             configuration.getRegisterMetadata(new RegisterName("register-that-does-not-exist"));
             fail();
         } catch (RuntimeException e) {

--- a/src/test/java/uk/gov/register/protocols/classpath/ClasspathURLConnectionTest.java
+++ b/src/test/java/uk/gov/register/protocols/classpath/ClasspathURLConnectionTest.java
@@ -1,0 +1,44 @@
+package uk.gov.register.protocols.classpath;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Scanner;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class ClasspathURLConnectionTest {
+    @Before
+    public void setProtocolHandlers(){
+        System.setProperty("java.protocol.handler.pkgs", "uk.gov.register.protocols");
+    }
+
+    @Test
+    public void shouldGetInputStream() throws Exception {
+        URL url = new URL("classpath://config/external-fields.yaml");
+        ClasspathURLConnection connection = new ClasspathURLConnection(url);
+        InputStream inputStream = connection.getInputStream();
+        Scanner scanner = new Scanner(inputStream);
+        String line1 = scanner.nextLine();
+        assertThat(line1, is("---"));
+        String line2 = scanner.nextLine();
+        assertThat(line2, is("country:"));
+
+    }
+
+    @Test(expected = MalformedURLException.class)
+    public void shouldFailForInvalidScheme() throws Exception{
+        URL url = new URL("zz:///my-path");
+        ClasspathURLConnection connection = new ClasspathURLConnection(url);
+    }
+
+    @After
+    public void unsetProtocolHandlers(){
+        System.clearProperty("java.protocol.handler.pkgs");
+    }
+}

--- a/src/test/java/uk/gov/register/service/ItemConverterTest.java
+++ b/src/test/java/uk/gov/register/service/ItemConverterTest.java
@@ -3,7 +3,9 @@ package uk.gov.register.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.dropwizard.jackson.Jackson;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.configuration.RegisterConfigConfiguration;
 import uk.gov.register.core.FieldValue;
@@ -13,6 +15,7 @@ import uk.gov.register.core.StringValue;
 import uk.gov.register.exceptions.NoSuchConfigException;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
 
@@ -23,15 +26,24 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ItemConverterTest {
+
+    @Rule
+    public TemporaryFolder externalConfigsFolder = new TemporaryFolder();
     private ConfigManager configManager;
     private ItemConverter itemConverter;
+    private String registersConfigFileUrl = Paths.get("src/main/resources/config/registers.yaml").toUri().toString();
+    private String fieldsConfigFileUrl = Paths.get("src/main/resources/config/fields.yaml").toUri().toString();
 
     @Before
     public void setup() throws IOException, NoSuchConfigException {
         RegisterConfigConfiguration registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
         when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
+        when(registerConfigConfiguration.getFieldsYamlLocation()).thenReturn(fieldsConfigFileUrl);
+        when(registerConfigConfiguration.getRegistersYamlLocation()).thenReturn(registersConfigFileUrl);
+        String externalConfigsFolderPath = externalConfigsFolder.getRoot().toString();
+        when(registerConfigConfiguration.getExternalConfigDirectory()).thenReturn(externalConfigsFolderPath);
 
-        configManager = new ConfigManager(registerConfigConfiguration, Optional.empty(), Optional.empty());
+        configManager = new ConfigManager(registerConfigConfiguration);
         configManager.refreshConfig();
         itemConverter = new ItemConverter(configManager);
     }

--- a/src/test/java/uk/gov/register/service/ItemValidatorTest.java
+++ b/src/test/java/uk/gov/register/service/ItemValidatorTest.java
@@ -2,37 +2,71 @@ package uk.gov.register.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.RegisterConfigConfiguration;
+import uk.gov.register.configuration.RegistersConfiguration;
+import uk.gov.register.core.Cardinality;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.RegisterMetadata;
 import uk.gov.register.core.RegisterName;
 import uk.gov.register.exceptions.ItemValidationException;
 import uk.gov.register.exceptions.NoSuchConfigException;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ItemValidatorTest {
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private RegisterConfigConfiguration registerConfigConfiguration;
+    @Mock
     private ConfigManager configManager;
+
+    @Mock
+    private RegisterMetadata registerMetadata;
+
+    @Mock
+    private RegistersConfiguration registersConfiguration;
+
+    @Mock
+    private FieldsConfiguration fieldsConfiguration;
+
     private ItemValidator itemValidator;
 
     @Before
     public void setup() throws NoSuchConfigException, IOException {
-        registerConfigConfiguration = mock(RegisterConfigConfiguration.class);
-        when(registerConfigConfiguration.getDownloadConfigs()).thenReturn(true);
+        MockitoAnnotations.initMocks(this);
+        RegisterName registerName = new RegisterName("register");
 
-        configManager = new ConfigManager(registerConfigConfiguration, Optional.empty(), Optional.empty());
-        configManager.refreshConfig();
+        when(configManager.getRegistersConfiguration()).thenReturn(registersConfiguration);
+        when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
+        when(registersConfiguration.getRegisterMetadata(any(RegisterName.class))).thenReturn(registerMetadata);
+        when(registerMetadata.getRegisterName()).thenReturn(registerName);
+
+        when(registerMetadata.getFields()).thenReturn(Arrays.asList("register", "text", "registry", "phase", "copyright", "fields"));
+        Field textField = new Field("text", "text", registerName, Cardinality.ONE, "text text");
+        Field registerField = new Field("register", "text", registerName, Cardinality.ONE, "register text");
+        Field fieldsField = new Field("fields", "string", registerName, Cardinality.MANY, "fields text");
+
+        when(fieldsConfiguration.getField("text")).thenReturn(textField);
+        when(fieldsConfiguration.getField("register")).thenReturn(registerField);
+        when(fieldsConfiguration.getField("fields")).thenReturn(fieldsField);
+
         itemValidator = new ItemValidator(configManager, new RegisterName("register"));
     }
 
@@ -64,6 +98,7 @@ public class ItemValidatorTest {
 
     @Test
     public void validateItem_throwsValidationException_givenFieldValueIsNotOfCorrectDatatypeType() throws IOException {
+
         String jsonString = "{\"register\":\"aregister\",\"text\":5}";
         JsonNode jsonNode = nodeOf(jsonString);
         try {
@@ -136,4 +171,5 @@ public class ItemValidatorTest {
             assertThat(e.getEntry().toString(), equalTo(jsonString));
         }
     }
+
 }

--- a/src/test/resources/conformance-app-config.yaml
+++ b/src/test/resources/conformance-app-config.yaml
@@ -31,3 +31,13 @@ database:
 
 enableDownloadResource: true
 enableRegisterDataDelete: true
+
+# can be http: file s3: or classpath: url
+fieldsYamlLocation: classpath://config/fields.yaml
+
+registersYamlLocation: classpath://config/registers.yaml
+
+externalConfigDirectory: /tmp
+
+downloadConfigs: true
+

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -77,3 +77,9 @@ database:
 enableDownloadResource: true
 
 propertyToTestUnknownPropertiesAllowed: true
+
+externalConfigDirectory: /tmp
+
+fieldsYamlLocation: classpath://config/fields.yaml
+
+registersYamlLocation: classpath://config/registers.yaml


### PR DESCRIPTION
NOT for merging until new config items have been added for test etc. Just for review.

I've added the ability to read classpath://xxx urls and then set the default config items in the project to be classpath urls. This is to reduce the number of Optional objects being passed around when the config is read as the application will complain and fail to start if the config items are missing. I also tidied up a couple of tests. 