### PR TITLE
Log openregister via fluentd

### DIFF
--- a/deploy/scripts/stop-service.sh
+++ b/deploy/scripts/stop-service.sh
@@ -2,4 +2,8 @@
 
 docker stop openregister
 docker rm openregister
+
+docker stop fluentd
+docker rm fluentd
+
 exit 0


### PR DESCRIPTION
This PR sets up a new sidecar container to run `fluentd` and the `fluentd-sumologic plugin` (https://github.com/SumoLogic/fluentd-output-sumologic), then updates the docker container running openregister to use `--log-driver=fluentd`.