### PR TITLE
Simplify itemContent method logic

### DIFF
--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -68,7 +68,7 @@ public class RecordResource {
     }
 
     public Map<String, FieldValue> itemContent(Record record) {
-        return record.item.getFieldsStream().collect(Collectors.toMap(Map.Entry::getKey, itemConverter::convert));
+        return itemConverter.convertItem(record.item);
     }
 
     @GET


### PR DESCRIPTION
The logic in this method was duplicated in ItemCoverter.convertItem()
so it seemed sensible to reuse this.