### PR TITLE
move to official openjdk docker image

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -28,7 +28,7 @@ docker run \
     --restart "unless-stopped" \
     --volume /srv/openregister-java:/srv/openregister-java \
     --log-driver=fluentd \
-    jstepien/openjdk8 \
+    openjdk:8-jre-alpine \
     java \
       -Xmx"${MAX_JVM_HEAP_SIZE}k" \
       -Dfile.encoding=UTF-8 \


### PR DESCRIPTION
This moves us to the official openjdk docker image, rather than
jstepien/openjdk8.  Currently, the official build is at `u111` while
jstepien/openjdk8 is `u92`.

Also, I picked the alpine-based image.  Alpine is a super minimal
linux environment suitable for running a single process, ideal for our
use case.  (The `openjdk:8-jre` image is based on debian.)