### PR TITLE
Refresh register metadata after deleting data fix

### DIFF
--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -41,7 +41,6 @@ public class RegisterContext implements
     private final List<String> similarRegisters;
     private final boolean enableRegisterDataDelete;
     private final boolean enableDownloadResource;
-    private RegisterMetadata registerMetadata;
     private RegisterAuthenticator authenticator;
 
     public RegisterContext(RegisterName registerName, ConfigManager configManager, RegisterLinkService registerLinkService,
@@ -61,7 +60,6 @@ public class RegisterContext implements
         this.trackingId = trackingId;
         this.enableRegisterDataDelete = enableRegisterDataDelete;
         this.enableDownloadResource = enableDownloadResource;
-        this.registerMetadata = configManager.getRegistersConfiguration().getRegisterMetadata(registerName);
         this.authenticator = authenticator;
     }
 
@@ -74,7 +72,7 @@ public class RegisterContext implements
     }
 
     public RegisterMetadata getRegisterMetadata() {
-        return registerMetadata;
+        return configManager.getRegistersConfiguration().getRegisterMetadata(registerName);
     }
 
     public int migrate() {

--- a/src/test/java/uk/gov/register/core/RegisterContextTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterContextTest.java
@@ -57,7 +57,7 @@ public class RegisterContextTest {
 
     @Test
     public void getRegisterMetadata_returnsUpToDateConfigProvidedByConfigManager() {
-        RegisterMetadata initialMetadata = new RegisterMetadata(
+        RegisterMetadata expectedInitialMetadata = new RegisterMetadata(
                 new RegisterName("test-register-1"),
                 Collections.emptyList(),
                 "copyright-1",
@@ -75,17 +75,15 @@ public class RegisterContextTest {
 
 
         RegistersConfiguration rcMock = mock(RegistersConfiguration.class);
-
-        when(rcMock.getRegisterMetadata(registerName)).thenReturn(initialMetadata);
         when(configManager.getRegistersConfiguration()).thenReturn(rcMock);
+        when(rcMock.getRegisterMetadata(registerName))
+                .thenReturn(expectedInitialMetadata)
+                .thenReturn(expectedUpdatedMetadata);
 
         RegisterContext context = new RegisterContext(registerName, configManager, registerLinkService, dbi, flyway, Optional.empty(), true, false, Optional.empty(), Optional.empty(), emptyList(), new RegisterAuthenticator("", ""));
 
         RegisterMetadata actualInitialMetadata = context.getRegisterMetadata();
-        assertThat(actualInitialMetadata, equalTo(initialMetadata));
-
-        when(rcMock.getRegisterMetadata(registerName)).thenReturn(expectedUpdatedMetadata);
-        when(configManager.getRegistersConfiguration()).thenReturn(rcMock);
+        assertThat(actualInitialMetadata, equalTo(expectedInitialMetadata));
 
         RegisterMetadata actualUpdatedMetadata = context.getRegisterMetadata();
         assertThat(actualUpdatedMetadata, equalTo(expectedUpdatedMetadata));


### PR DESCRIPTION
https://trello.com/c/nkoekkqu/596-register-metadata-fails-to-update-in-some-places-upon-delete-register-data

This fixes the update of the fields. If a user modifies register or field
data and then resets a register (eg by calling `/delete-register-data`)
the register metadata is not being refreshed making home page look the same etc.

The bug was in `RegisterContext` class which was storing `RegisterMetadata`
as field passed in the constructor hence after a reload even though
`ConfigManage`r  had never data Context was still using it's field.