### PR TITLE
Add download spreadsheet (csv) option on download page

### DIFF
--- a/src/main/resources/templates/download.html
+++ b/src/main/resources/templates/download.html
@@ -24,6 +24,7 @@
               <li><a href="/records.ttl?page-size=5000" rel="alternate" class="js-download" data-download-type="TTL">TTL</a></li>
               <li><a href="/records.tsv?page-size=5000" rel="alternate" class="js-download" data-download-type="TSV">TSV</a></li>
               <li><a href="/records.csv?page-size=5000" rel="alternate" class="js-download" data-download-type="CSV">CSV</a></li>
+              <li><a href="/records.csv?page-size=5000" rel="alternate" class="js-download" data-download-type="spreadsheet">spreadsheet</a></li>
             </ul>
             <p>You can download a section of a register by navigating to the page of records you need and selecting ‘Download this data’ at the bottom of the page.</p>
             <p>You can download more entries or select a portion of the register by amending your URL. Use <code class="url-param">page-size</code> to define the number of records you want to download. You can use <code class="url-param">page-index</code> to specify a particular page of the register.</p>


### PR DESCRIPTION
https://trello.com/c/u3VsZtxI/598-make-it-possible-to-download-existing-resources-as-xls

After consultation we've decided to add clearer option on the download page
which ensures people that they download what they know which is
a spreadsheets which still serves CSV underneath.