### PR TITLE
Update record entry record name in breadcrumb

### DIFF
--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -18,7 +18,7 @@
             <a href="/records">Records</a>
           </li>
           <li th:if="${content.recordKey.present}">
-            <a th:href="${'/record/' + content.recordKey.get()}" th:text="${content.recordKey.get()}"></a>
+            <a th:href="${'/record/' + content.recordKey.get()}" th:text="${'Record ' + content.recordKey.get()}"></a>
           </li>
           <li>Entries</li>
         </ol>


### PR DESCRIPTION
## Before
<img width="1377" alt="screen shot 2017-01-31 at 14 50 57" src="https://cloud.githubusercontent.com/assets/3071606/22469651/afe89f24-e7c4-11e6-81a2-fab4199bc214.png">

## After
<img width="1377" alt="screen shot 2017-01-31 at 14 50 18" src="https://cloud.githubusercontent.com/assets/3071606/22469635/a7be5d2a-e7c4-11e6-9a1d-86fa6aa1f059.png">

To make sure the breadcrumb is consistent with the record page -
<img width="1377" alt="screen shot 2017-01-31 at 14 51 24" src="https://cloud.githubusercontent.com/assets/3071606/22469681/c100c69c-e7c4-11e6-9b6f-bd3b34ae14de.png">



