### PR TITLE
Make fields description available on pages (records, record, item)

### DIFF
--- a/src/main/java/uk/gov/register/resources/ItemResource.java
+++ b/src/main/java/uk/gov/register/resources/ItemResource.java
@@ -18,22 +18,18 @@ import java.util.Optional;
 public class ItemResource {
     private final RegisterReadOnly register;
     private final ViewFactory viewFactory;
-    private final ItemConverter itemConverter;
-    private final RegisterMetadata registerMetadata;
 
     @Inject
     public ItemResource(RegisterReadOnly register, ViewFactory viewFactory, ItemConverter itemConverter, RegisterMetadata registerMetadata) {
         this.register = register;
         this.viewFactory = viewFactory;
-        this.itemConverter = itemConverter;
-        this.registerMetadata = registerMetadata;
     }
 
     @GET
     @Path("/sha-256:{item-hash}")
     @Produces(ExtraMediaType.TEXT_HTML)
     public AttributionView<ItemView> getItemWebViewByHex(@PathParam("item-hash") String itemHash) {
-        return getItem(itemHash).map((item) -> viewFactory.getItemView(makeItemView(item)))
+        return getItem(itemHash).map(viewFactory::getItemView)
                 .orElseThrow(() -> new NotFoundException("No item found with item hash: " + itemHash));
     }
 
@@ -41,7 +37,7 @@ public class ItemResource {
     @Path("/sha-256:{item-hash}")
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_TTL, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV})
     public ItemView getItemDataByHex(@PathParam("item-hash") String itemHash) {
-        return getItem(itemHash).map(this::makeItemView)
+        return getItem(itemHash).map(viewFactory::getItemMediaView)
                 .orElseThrow(() -> new NotFoundException("No item found with item hash: " + itemHash));
     }
 
@@ -50,10 +46,5 @@ public class ItemResource {
         return register.getItemBySha256(hash);
     }
 
-    private ItemView makeItemView(Item item) {
-        return new ItemView(item.getSha256hex(),
-                itemConverter.convertItem(item),
-                registerMetadata.getFields()
-        );
-    }
+
 }

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -1,21 +1,10 @@
 package uk.gov.register.resources;
 
 import io.dropwizard.jersey.params.IntParam;
-import uk.gov.register.core.Entry;
-import uk.gov.register.core.FieldValue;
-import uk.gov.register.core.Record;
-import uk.gov.register.core.RegisterMetadata;
-import uk.gov.register.core.RegisterName;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.*;
 import uk.gov.register.providers.params.IntegerParam;
 import uk.gov.register.service.ItemConverter;
-import uk.gov.register.views.AttributionView;
-import uk.gov.register.views.EntryListView;
-import uk.gov.register.views.ItemView;
-import uk.gov.register.views.PaginatedView;
-import uk.gov.register.views.RecordView;
-import uk.gov.register.views.RecordsView;
-import uk.gov.register.views.ViewFactory;
+import uk.gov.register.views.*;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.inject.Inject;
@@ -25,7 +14,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
@@ -45,8 +33,9 @@ public class RecordResource {
         this.viewFactory = viewFactory;
         this.requestContext = requestContext;
         this.httpServletResponseAdapter = new HttpServletResponseAdapter(requestContext.httpServletResponse);
-        registerPrimaryKey = register.getRegisterName();
+        this.registerPrimaryKey = register.getRegisterName();
         this.itemConverter = itemConverter;
+
         this.fields = registerMetadata.getFields();
     }
 
@@ -160,9 +149,7 @@ public class RecordResource {
     }
 
     private RecordView toRecordView(Record r) {
-        Map<String, FieldValue> itemContent = itemContent(r);
-        ItemView itemView = new ItemView(r.item.getSha256hex(), itemContent, fields);
-        return new RecordView(r.entry, itemView, fields);
+        return new RecordView(r.entry, viewFactory.getItemMediaView(r.item), fields);
     }
 
 }

--- a/src/main/java/uk/gov/register/views/ItemView.java
+++ b/src/main/java/uk/gov/register/views/ItemView.java
@@ -1,6 +1,8 @@
 package uk.gov.register.views;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.Iterables;
+import uk.gov.register.core.Field;
 import uk.gov.register.core.FieldValue;
 import uk.gov.register.core.Item;
 import uk.gov.register.util.HashValue;
@@ -9,11 +11,11 @@ import uk.gov.register.views.representations.CsvRepresentation;
 import java.util.Map;
 
 public class ItemView implements CsvRepresentationView<Map<String, FieldValue>> {
-    private Iterable<String> fields;
+    private Iterable<Field> fields;
     private Map<String, FieldValue> fieldValueMap;
     private final HashValue sha256hex;
 
-    public ItemView(HashValue sha256hex, Map<String, FieldValue> fieldValueMap, Iterable<String> fields) {
+    public ItemView(HashValue sha256hex, Map<String, FieldValue> fieldValueMap, Iterable<Field> fields) {
         this.fields = fields;
         this.fieldValueMap = fieldValueMap;
         this.sha256hex = sha256hex;
@@ -26,11 +28,16 @@ public class ItemView implements CsvRepresentationView<Map<String, FieldValue>> 
 
     @Override
     public CsvRepresentation<Map<String, FieldValue>> csvRepresentation() {
-        return new CsvRepresentation<>(Item.csvSchema(fields),
-                fieldValueMap);
+        Iterable<String> fieldNames = Iterables.transform(fields, f -> f.fieldName);
+        return new CsvRepresentation<>(Item.csvSchema(fieldNames), fieldValueMap);
     }
 
     public HashValue getItemHash() {
         return sha256hex;
     }
+
+    public Iterable<Field> getFields() {
+        return fields;
+    }
+
 }

--- a/src/main/java/uk/gov/register/views/RecordView.java
+++ b/src/main/java/uk/gov/register/views/RecordView.java
@@ -3,8 +3,10 @@ package uk.gov.register.views;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Iterables;
 import io.dropwizard.jackson.Jackson;
 import uk.gov.register.core.Entry;
+import uk.gov.register.core.Field;
 import uk.gov.register.core.FieldValue;
 import uk.gov.register.core.Record;
 import uk.gov.register.views.representations.CsvRepresentation;
@@ -15,9 +17,9 @@ import java.util.Optional;
 public class RecordView implements CsvRepresentationView {
     private final Entry entry;
     private final ItemView itemView;
-    private final Iterable<String> fields;
+    private final Iterable<Field> fields;
 
-    public RecordView(Entry entry, ItemView itemView, Iterable<String> fields) {
+    public RecordView(Entry entry, ItemView itemView, Iterable<Field> fields) {
         this.entry = entry;
         this.itemView = itemView;
         this.fields = fields;
@@ -48,7 +50,8 @@ public class RecordView implements CsvRepresentationView {
 
     @Override
     public CsvRepresentation<ObjectNode> csvRepresentation() {
-        return new CsvRepresentation<>(Record.csvSchema(fields), getRecordJson());
+        Iterable<String> fieldNames = Iterables.transform(fields, f -> f.fieldName);
+        return new CsvRepresentation<>(Record.csvSchema(fieldNames), getRecordJson());
     }
 
     public ItemView getItemView() {
@@ -57,5 +60,9 @@ public class RecordView implements CsvRepresentationView {
 
     public Entry getEntry() {
         return entry;
+    }
+
+    public Iterable<Field> getFields() {
+        return fields;
     }
 }

--- a/src/main/java/uk/gov/register/views/RecordsView.java
+++ b/src/main/java/uk/gov/register/views/RecordsView.java
@@ -1,6 +1,8 @@
 package uk.gov.register.views;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.Iterables;
+import uk.gov.register.core.Field;
 import uk.gov.register.core.Record;
 import uk.gov.register.views.representations.CsvRepresentation;
 
@@ -11,9 +13,11 @@ import java.util.stream.Collectors;
 
 public class RecordsView implements CsvRepresentationView {
     private List<RecordView> records;
-    private Iterable<String> fields;
 
-    public RecordsView(List<RecordView> records, Iterable<String> fields) {
+
+    private Iterable<Field> fields;
+
+    public RecordsView(List<RecordView> records, Iterable<Field> fields) {
         this.records = records;
         this.fields = fields;
     }
@@ -29,6 +33,11 @@ public class RecordsView implements CsvRepresentationView {
 
     @Override
     public CsvRepresentation<Collection<RecordView>> csvRepresentation() {
-        return new CsvRepresentation<>(Record.csvSchema(fields), getRecords());
+        Iterable<String> fieldNames = Iterables.transform(fields, f -> f.fieldName);
+        return new CsvRepresentation<>(Record.csvSchema(fieldNames), getRecords());
+    }
+
+    public Iterable<Field> getFields() {
+        return fields;
     }
 }

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -130,6 +130,18 @@ public class ViewFactory {
                 recordsView);
     }
 
+    public ItemView getItemMediaView(Item item) {
+        return new ItemView(item.getSha256hex(), itemConverter.convertItem(item), getFields());
+    }
+
+    public RecordView getRecordMediaView(Record record) {
+        return new RecordView(record.entry, getItemMediaView(record.item), getFields());
+    }
+
+    public RecordsView getRecordsMediaView(List<RecordView> recordViews) {
+        return new RecordsView(recordViews, getFields());
+    }
+
     private PublicBody getRegistry() {
         return publicBodiesConfiguration.getPublicBody(registerMetadata.get().getRegistry());
     }
@@ -144,18 +156,5 @@ public class ViewFactory {
         return register.get().getRegisterMetadata().getFields().stream()
                 .map(fieldsConfiguration::getField)
                 .collect(Collectors.toList());
-    }
-
-
-    public ItemView getItemMediaView(Item item) {
-        return new ItemView(item.getSha256hex(), itemConverter.convertItem(item), getFields());
-    }
-
-    public RecordView getRecordMediaView(Record record) {
-        return new RecordView(record.entry, getItemMediaView(record.item), getFields());
-    }
-
-    public RecordsView getRecordsMediaView(List<RecordView> recordViews) {
-        return new RecordsView(recordViews, getFields());
     }
 }

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -148,7 +148,14 @@ public class ViewFactory {
 
 
     public ItemView getItemMediaView(Item item) {
-
         return new ItemView(item.getSha256hex(), itemConverter.convertItem(item), getFields());
+    }
+
+    public RecordView getRecordMediaView(Record record) {
+        return new RecordView(record.entry, getItemMediaView(record.item), getFields());
+    }
+
+    public RecordsView getRecordsMediaView(List<RecordView> recordViews) {
+        return new RecordsView(recordViews, getFields());
     }
 }

--- a/src/main/resources/templates/fragments/field-list.html
+++ b/src/main/resources/templates/fragments/field-list.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<body>
+  <div th:fragment="field-list(fields)">
+    <dl>
+      <th:block th:each="field : ${fields}">
+        <dt th:text="${#strings.capitalize(field.fieldName) + ':'}"></dt>
+        <dd th:text="${field.text}"></dd>
+      </th:block>
+    </dl>
+  </div>
+</body>
+</html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -19,12 +19,8 @@
         </p>
         <p class="text">You can also <a href="/download">download a copy</a> of the register.</p>
         <p class="text">The <span th:utext="${friendlyRegisterName}"></span> contains <span th:text="${totalRecords}"></span> records and includes the following fields:</p>
-        <dl>
-          <th:block th:each="field : ${fields}">
-            <dt th:text="${#strings.capitalize(field.fieldName) + ':'}"></dt>
-            <dd th:text="${field.text}"></dd>
-          </th:block>
-        </dl>
+        <div th:replace="fragments/field-list.html::field-list(${fields})"></div>
+
         <h3 class="heading-small">Using this register</h3>
         <p>Download a copy of this register. You'll need to regularly update it to make sure you have the most current version of the data.</p>
         <p>If you're building a service, you can use this data to create elements for forms.</p>

--- a/src/main/resources/templates/item.html
+++ b/src/main/resources/templates/item.html
@@ -25,8 +25,6 @@
         <div class="column-third" th:include="fragments/attribution.html::attribution"></div>
       </div>
 
-      <p class="text">The <span th:utext="${friendlyRegisterName}"></span> contains <span th:text="${totalRecords}"></span> records and includes the following fields:</p>
-
       <div th:include="fragments/item-table.html :: item-table (content = ${content.content})" class="table-wrapper"></div>
 
       <div th:include="fragments/data-formats.html::data-formats"></div>

--- a/src/main/resources/templates/item.html
+++ b/src/main/resources/templates/item.html
@@ -25,6 +25,8 @@
         <div class="column-third" th:include="fragments/attribution.html::attribution"></div>
       </div>
 
+      <p class="text">The <span th:utext="${friendlyRegisterName}"></span> contains <span th:text="${totalRecords}"></span> records and includes the following fields:</p>
+
       <div th:include="fragments/item-table.html :: item-table (content = ${content.content})" class="table-wrapper"></div>
 
       <div th:include="fragments/data-formats.html::data-formats"></div>

--- a/src/test/java/uk/gov/register/views/RecordsViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordsViewTest.java
@@ -19,59 +19,62 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class RecordsViewTest {
-    @Test
-    public void recordsJson_returnsTheMapOfRecords() throws IOException, JSONException {
-        Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
-        Instant t2 = Instant.parse("2016-03-28T09:49:26Z");
-        ImmutableList<String> fields = ImmutableList.of("address", "street");
-        List<RecordView> records = Lists.newArrayList(
-                new RecordView(
-                        new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123"),
-                        new ItemView(new HashValue(HashingAlgorithm.SHA256, "ab"),
-                                ImmutableMap.of("address", new StringValue("123"),
-                                        "street", new StringValue("foo")),
-                                fields),
-                        fields
-                ),
-                new RecordView(
-                        new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cd"), t2, "456"),
-                        new ItemView(new HashValue(HashingAlgorithm.SHA256, "cd"),
-                                ImmutableMap.of("address", new StringValue("456"),
-                                        "street", new StringValue("bar")),
-                                fields),
-                        fields
-                )
-        );
-        RecordsView recordsView = new RecordsView(records, fields);
-
-        Map<String, RecordView> result = recordsView.recordsJson();
-        assertThat(result.size(), equalTo(2));
-
-
-        JSONAssert.assertEquals(
-                "{" +
-                        "\"entry-number\":\"1\"," +
-                        "\"item-hash\":\"sha-256:ab\"," +
-                        "\"entry-timestamp\":\"2016-03-29T08:59:25Z\"," +
-                        "\"address\":\"123\"," +
-                        "\"street\":\"foo\"" +
-                        "}",
-                Jackson.newObjectMapper().writeValueAsString(result.get("123")),
-                false
-        );
-
-        JSONAssert.assertEquals(
-                "{" +
-                        "\"entry-number\":\"2\"," +
-                        "\"item-hash\":\"sha-256:cd\"," +
-                        "\"entry-timestamp\":\"2016-03-28T09:49:26Z\"," +
-                        "\"address\":\"456\"," +
-                        "\"street\":\"bar\"" +
-                        "}",
-                Jackson.newObjectMapper().writeValueAsString(result.get("456")),
-                false
-        );
-    }
+//    @Test
+//    public void recordsJson_returnsTheMapOfRecords() throws IOException, JSONException {
+//        Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
+//        Instant t2 = Instant.parse("2016-03-28T09:49:26Z");
+//        ImmutableList<Field> fields = ImmutableList.of(
+//                new Field("address", "datatype", new RegisterName("address"), Cardinality.ONE, "text"),
+//                new Field("street", "datatype", new RegisterName("address"), Cardinality.ONE, "text"));
+//
+//        List<RecordView> records = Lists.newArrayList(
+//                new RecordView(
+//                        new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123"),
+//                        new ItemView(new HashValue(HashingAlgorithm.SHA256, "ab"),
+//                                ImmutableMap.of("address", new StringValue("123"),
+//                                        "street", new StringValue("foo")),
+//                                fields),
+//                        fields
+//                ),
+//                new RecordView(
+//                        new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cd"), t2, "456"),
+//                        new ItemView(new HashValue(HashingAlgorithm.SHA256, "cd"),
+//                                ImmutableMap.of("address", new StringValue("456"),
+//                                        "street", new StringValue("bar")),
+//                                fields),
+//                        fields
+//                )
+//        );
+//        RecordsView recordsView = new RecordsView(records, fields);
+//
+//        Map<String, RecordView> result = recordsView.recordsJson();
+//        assertThat(result.size(), equalTo(2));
+//
+//
+//        JSONAssert.assertEquals(
+//                "{" +
+//                        "\"entry-number\":\"1\"," +
+//                        "\"item-hash\":\"sha-256:ab\"," +
+//                        "\"entry-timestamp\":\"2016-03-29T08:59:25Z\"," +
+//                        "\"address\":\"123\"," +
+//                        "\"street\":\"foo\"" +
+//                        "}",
+//                Jackson.newObjectMapper().writeValueAsString(result.get("123")),
+//                false
+//        );
+//
+//        JSONAssert.assertEquals(
+//                "{" +
+//                        "\"entry-number\":\"2\"," +
+//                        "\"item-hash\":\"sha-256:cd\"," +
+//                        "\"entry-timestamp\":\"2016-03-28T09:49:26Z\"," +
+//                        "\"address\":\"456\"," +
+//                        "\"street\":\"bar\"" +
+//                        "}",
+//                Jackson.newObjectMapper().writeValueAsString(result.get("456")),
+//                false
+//        );
+//    }
 
 
 }

--- a/src/test/java/uk/gov/register/views/RecordsViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordsViewTest.java
@@ -19,62 +19,62 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class RecordsViewTest {
-//    @Test
-//    public void recordsJson_returnsTheMapOfRecords() throws IOException, JSONException {
-//        Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
-//        Instant t2 = Instant.parse("2016-03-28T09:49:26Z");
-//        ImmutableList<Field> fields = ImmutableList.of(
-//                new Field("address", "datatype", new RegisterName("address"), Cardinality.ONE, "text"),
-//                new Field("street", "datatype", new RegisterName("address"), Cardinality.ONE, "text"));
-//
-//        List<RecordView> records = Lists.newArrayList(
-//                new RecordView(
-//                        new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123"),
-//                        new ItemView(new HashValue(HashingAlgorithm.SHA256, "ab"),
-//                                ImmutableMap.of("address", new StringValue("123"),
-//                                        "street", new StringValue("foo")),
-//                                fields),
-//                        fields
-//                ),
-//                new RecordView(
-//                        new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cd"), t2, "456"),
-//                        new ItemView(new HashValue(HashingAlgorithm.SHA256, "cd"),
-//                                ImmutableMap.of("address", new StringValue("456"),
-//                                        "street", new StringValue("bar")),
-//                                fields),
-//                        fields
-//                )
-//        );
-//        RecordsView recordsView = new RecordsView(records, fields);
-//
-//        Map<String, RecordView> result = recordsView.recordsJson();
-//        assertThat(result.size(), equalTo(2));
-//
-//
-//        JSONAssert.assertEquals(
-//                "{" +
-//                        "\"entry-number\":\"1\"," +
-//                        "\"item-hash\":\"sha-256:ab\"," +
-//                        "\"entry-timestamp\":\"2016-03-29T08:59:25Z\"," +
-//                        "\"address\":\"123\"," +
-//                        "\"street\":\"foo\"" +
-//                        "}",
-//                Jackson.newObjectMapper().writeValueAsString(result.get("123")),
-//                false
-//        );
-//
-//        JSONAssert.assertEquals(
-//                "{" +
-//                        "\"entry-number\":\"2\"," +
-//                        "\"item-hash\":\"sha-256:cd\"," +
-//                        "\"entry-timestamp\":\"2016-03-28T09:49:26Z\"," +
-//                        "\"address\":\"456\"," +
-//                        "\"street\":\"bar\"" +
-//                        "}",
-//                Jackson.newObjectMapper().writeValueAsString(result.get("456")),
-//                false
-//        );
-//    }
+    @Test
+    public void recordsJson_returnsTheMapOfRecords() throws IOException, JSONException {
+        Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
+        Instant t2 = Instant.parse("2016-03-28T09:49:26Z");
+        ImmutableList<Field> fields = ImmutableList.of(
+                new Field("address", "datatype", new RegisterName("address"), Cardinality.ONE, "text"),
+                new Field("street", "datatype", new RegisterName("address"), Cardinality.ONE, "text"));
+
+        List<RecordView> records = Lists.newArrayList(
+                new RecordView(
+                        new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123"),
+                        new ItemView(new HashValue(HashingAlgorithm.SHA256, "ab"),
+                                ImmutableMap.of("address", new StringValue("123"),
+                                        "street", new StringValue("foo")),
+                                fields),
+                        fields
+                ),
+                new RecordView(
+                        new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cd"), t2, "456"),
+                        new ItemView(new HashValue(HashingAlgorithm.SHA256, "cd"),
+                                ImmutableMap.of("address", new StringValue("456"),
+                                        "street", new StringValue("bar")),
+                                fields),
+                        fields
+                )
+        );
+        RecordsView recordsView = new RecordsView(records, fields);
+
+        Map<String, RecordView> result = recordsView.recordsJson();
+        assertThat(result.size(), equalTo(2));
+
+
+        JSONAssert.assertEquals(
+                "{" +
+                        "\"entry-number\":\"1\"," +
+                        "\"item-hash\":\"sha-256:ab\"," +
+                        "\"entry-timestamp\":\"2016-03-29T08:59:25Z\"," +
+                        "\"address\":\"123\"," +
+                        "\"street\":\"foo\"" +
+                        "}",
+                Jackson.newObjectMapper().writeValueAsString(result.get("123")),
+                false
+        );
+
+        JSONAssert.assertEquals(
+                "{" +
+                        "\"entry-number\":\"2\"," +
+                        "\"item-hash\":\"sha-256:cd\"," +
+                        "\"entry-timestamp\":\"2016-03-28T09:49:26Z\"," +
+                        "\"address\":\"456\"," +
+                        "\"street\":\"bar\"" +
+                        "}",
+                Jackson.newObjectMapper().writeValueAsString(result.get("456")),
+                false
+        );
+    }
 
 
 }

--- a/src/test/java/uk/gov/register/views/representations/CsvWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/CsvWriterTest.java
@@ -20,7 +20,11 @@ import static org.junit.Assert.assertThat;
 public class CsvWriterTest {
 
     CsvWriter csvWriter = new CsvWriter();
-    private final ImmutableList<String> fields = ImmutableList.of("key1", "key2", "key3", "key4");
+    private final ImmutableList<Field> fields = ImmutableList.of(
+            new Field("key1", "datatype", new RegisterName("register"),Cardinality.ONE, "text"),
+            new Field("key2", "datatype", new RegisterName("register"),Cardinality.ONE, "text"),
+            new Field("key3", "datatype", new RegisterName("register"),Cardinality.ONE, "text"),
+            new Field("key4", "datatype", new RegisterName("register"),Cardinality.ONE, "text"));
 
     @Test
     public void writes_EntryListView_to_output_stream() throws IOException {

--- a/src/test/java/uk/gov/register/views/representations/TsvWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/TsvWriterTest.java
@@ -3,9 +3,7 @@ package uk.gov.register.views.representations;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
-import uk.gov.register.core.FieldValue;
-import uk.gov.register.core.ListValue;
-import uk.gov.register.core.StringValue;
+import uk.gov.register.core.*;
 import uk.gov.register.views.ItemView;
 
 import java.io.ByteArrayOutputStream;
@@ -19,7 +17,11 @@ import static org.junit.Assert.assertThat;
 public class TsvWriterTest {
 
     private final TsvWriter writer = new TsvWriter();
-    private final Iterable<String> fields = ImmutableList.of("key1", "key2", "key3", "key4");
+    private final Iterable<Field> fields = ImmutableList.of(
+            new Field("key1", "datatype", new RegisterName("register"),Cardinality.ONE, "text"),
+            new Field("key2", "datatype", new RegisterName("register"),Cardinality.ONE, "text"),
+            new Field("key3", "datatype", new RegisterName("register"),Cardinality.ONE, "text"),
+            new Field("key4", "datatype", new RegisterName("register"),Cardinality.ONE, "text"));
 
     @Test
     public void tsv_entriesAreGenerated() throws IOException {

--- a/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
@@ -21,7 +21,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TurtleRepresentationWriterTest {
     private final RegisterResolver registerResolver = register -> URI.create("http://" + register + ".test.register.gov.uk");
 
-    private final Set<String> fields = ImmutableSet.of("address", "location", "link-values", "string-values");
+    private final Set<Field> fields = ImmutableSet.of(
+            new Field("address", "datatype", new RegisterName("register"), Cardinality.ONE, "text"),
+            new Field("location", "datatype", new RegisterName("register"), Cardinality.ONE, "text"),
+            new Field("link-values", "datatype", new RegisterName("register"), Cardinality.ONE, "text"),
+            new Field("string-values", "datatype", new RegisterName("register"), Cardinality.ONE, "text"));
 
     @Test
     public void rendersFieldPrefixFromConfiguration() throws Exception {
@@ -60,7 +64,7 @@ public class TurtleRepresentationWriterTest {
         Map<String, FieldValue> map =
                 ImmutableMap.of(
                         "address", new LinkValue(new RegisterName("address"), "1111111"),
-                        "location", new LinkValue(new RegisterName( "address"), "location-value"),
+                        "location", new LinkValue(new RegisterName("address"), "location-value"),
                         "name", new StringValue("foo")
                 );
 


### PR DESCRIPTION
Additionally extracted fields html fragment which can be re-used on multiple pages, sample from homepage:
`<div th:replace="fragments/field-list.html::field-list(${fields})"></div>`

story: https://trello.com/c/SwsyrCzo/619-make-field-descriptions-available-to-records-record-and-item-pages