### PR TITLE
don't die if fluentd isn't immediately available

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -29,6 +29,7 @@ docker run \
     --restart "unless-stopped" \
     --volume /srv/openregister-java:/srv/openregister-java \
     --log-driver=fluentd \
+    --log-opt fluentd-async-connect=true \
     openjdk:8-jre-alpine \
     java \
       -Xmx"${MAX_JVM_HEAP_SIZE}k" \


### PR DESCRIPTION
Both the fluentd container and the openregister-java container have
the --restart "unless-stopped" option, which means they will be
restarted after a machine reboot.

However, the openregister-java container will fail to start on boot
unless the fluentd container has managed to open its port in time.

This changes the openregister-java container to use the
[fluentd-async-connect][] option, so that if fluentd hasn't started,
the docker daemon will buffer logs until fluentd is available.

There is a potential risk here: if the fluentd container dies, we will
silently not collect logs while the openregister container continues
to run.  I think we could accept this risk for the moment, and look to
remedy in future?  That way we can at least focus on getting automatic
reboots going.

[fluentd-async-connect]: https://docs.docker.com/engine/admin/logging/fluentd/#/fluentd-async-connect