### PR TITLE
support compassWatch properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ deployable_bundle
 .cache
 
 .sass-cache
-src/main/resources/assets/css

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Recompile the `.scss` files to `.css` via Gradle task:
 
     ./gradlew compassCompile
 
+If you are want to make iterative changes, you can start a compass
+watch task to automatically update a running app with scss changes:
+
+    ./gradlew compassWatch
+
+While compassWatch is running, any changed `.scss` file will
+automatically be compiled to `.css` and picked up by the running app.
+
 ## Running the server
 
 Run a local server with:

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Recompile the `.scss` files to `.css` via Gradle task:
 
     ./gradlew compassCompile
 
-If you are want to make iterative changes, you can start a compass
-watch task to automatically update a running app with scss changes:
+If you want to make iterative changes, you can start a compass watch
+task to automatically update a running app with scss changes:
 
     ./gradlew compassWatch
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ compass {
         new File(assetsDir, "govuk_template/source/assets/stylesheets")
     )
     sassDir = new File(assetsDir, "sass")
-    cssDir = new File(assetsDir, "css")
+    cssDir = file("build/resources/main/assets/css")
     outputStyle = "expanded"
     force = true
     sourcemap = true


### PR DESCRIPTION
This configures gradle properly such that

    ./gradlew compassWatch

will start a task which watches for changes in .scss files and writes
them into the correct path, such that a running app (started with
./run-application.sh) will see the updated css files.

This means we can iterate on scss changes without needed to restart
the app.