### PR TITLE
Change the URL for the technical documentation to new location

### DIFF
--- a/src/main/java/uk/gov/register/configuration/HomepageContent.java
+++ b/src/main/java/uk/gov/register/configuration/HomepageContent.java
@@ -25,8 +25,8 @@ public class HomepageContent {
     }
 
     @SuppressWarnings("unused, used from template")
-    public String getSpecificationUrl() {
-        return "https://open-registers-docs.readthedocs.io/en/latest/";
+    public String getTechDocsUrl() {
+        return "https://registers-docs.cloudapps.digital";
     }
 
     @SuppressWarnings("unused, used from template")

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -78,7 +78,7 @@
               <a th:href="${homepageContent.usingRegistersGuidanceUrl}">Guidance for using registers</a>
             </li>
             <li>
-              <a th:href="${homepageContent.specificationUrl}">Technical documentation</a>
+              <a th:href="${homepageContent.techDocsUrl}">Technical documentation</a>
             </li>
           </ul>
         </aside>


### PR DESCRIPTION
Also rename the variable to make more sense, since this points to
the tech docs and not the specification.