### PR TITLE
Use Docker image owned by the `openregister` organization

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -34,7 +34,7 @@ docker run \
     --volume /srv/openregister-java/fluentd.conf:/fluentd/etc/fluentd.conf \
     --network openregisters \
     --env FLUENTD_CONF=fluentd.conf \
-    samcrang/fluentd-sumologic
+    openregister/fluentd-sumologic
 
 docker run \
     --detach \


### PR DESCRIPTION
We struggled to get Docker Hub to create automated builds from GitHub
repos owned by an organization. In the Docker Hub UI we could only see
personal repos and not any repos from organizations we were members of.
In order to get something working we just used a personal GitHub
account. We initially assumed this was due to some weirdness with
permissions/access tokens.

However, it turns out this had nothing to do with permissions (which
makes sense, all our repos are public). After a bit of digging it turns
out you can hit this magical endpoint to create an automated build from
any(?) public repo:

```
https://hub.docker.com/add/automated-build/github/form/{organization}/{repository_name}
```
Source: https://forums.docker.com/t/cant-access-new-github-organization-for-automated-builds/1080/13