### PR TITLE
Add support to Entry for multiple item hashes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ configurations {
 }
 
 dependencies {
-    compile dropwizard, stringTemplate, apacheCommonsCodec, awsS3
+    compile dropwizard, stringTemplate, apacheCommonsCodec, apacheCommonsCollections, awsS3
     compile jacksonCsv, jena, jerseyMedia, markdown, thymeleaf, verifiableLog
     compile jdbi, jersey_client
     compile(postgresClient) {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -7,4 +7,11 @@
         <gav regex="true">^org\.markdownj:markdownj-core:.*$</gav>
         <cpe>cpe:/a:jcore:jcore</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: commons-collections4-4.1.jar
+   ]]></notes>
+        <gav regex="true">^org\.apache\.commons:commons-collections4:.*$</gav>
+        <cve>CVE-2015-6420</cve>
+    </suppress>
 </suppressions>

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -26,6 +26,8 @@ ext {
     postgresClient = 'org.postgresql:postgresql:9.4.1211'
 
     apacheCommonsCodec = 'commons-codec:commons-codec:1.10'
+    apacheCommonsCollections = 'org.apache.commons:commons-collections4:4.1';
+
     // force AWS's dependency on dataformat-cbor to match our jackson_version
     awsS3 = ['com.amazonaws:aws-java-sdk-s3:1.11.77', "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"]
 

--- a/src/main/java/uk/gov/register/core/Entry.java
+++ b/src/main/java/uk/gov/register/core/Entry.java
@@ -10,12 +10,14 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.google.common.collect.Lists;
+import org.apache.commons.collections4.CollectionUtils;
 import uk.gov.register.util.HashValue;
 import uk.gov.register.util.ISODateFormatter;
 import uk.gov.register.views.CsvRepresentationView;
 import uk.gov.register.views.representations.CsvRepresentation;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -30,7 +32,7 @@ public class Entry implements CsvRepresentationView<Entry> {
 
     public Entry(int entryNumber, HashValue hashValue, Instant timestamp, String key) {
         this.entryNumber = entryNumber;
-        this.hashValues = Arrays.asList(hashValue);
+        this.hashValues = new ArrayList<>(Arrays.asList(hashValue));
         this.timestamp = timestamp;
         this.key = key;
     }
@@ -108,13 +110,25 @@ public class Entry implements CsvRepresentationView<Entry> {
         Entry entry = (Entry) o;
 
         if (entryNumber != entry.entryNumber) return false;
-        return hashValues == null ? entry.hashValues == null : hashValues.equals(entry.hashValues);
+        if (key != null ? !key.equals(entry.key) : entry.key != null) return false;
+        if (timestamp != null ? !timestamp.equals(entry.timestamp) : entry.timestamp != null) return false;
+        return hashValues == null ? entry.hashValues == null : CollectionUtils.isEqualCollection(hashValues, entry.hashValues);
     }
 
     @Override
     public int hashCode() {
-        int result = hashValues != null ? hashValues.hashCode() : 0;
-        result = 31 * entryNumber + result;
+        int result = 0;
+
+        Iterator<HashValue> iterator = hashValues.iterator();
+        while (iterator.hasNext()) {
+            HashValue hashValue = iterator.next();
+            result += hashValue.hashCode();
+        }
+
+        result = 31 * result + entryNumber;
+        result = 31 * result + (timestamp != null ? timestamp.hashCode() : 0);
+        result = 31 * result + (key != null ? key.hashCode() : 0);
+
         return result;
     }
 }

--- a/src/main/java/uk/gov/register/core/Entry.java
+++ b/src/main/java/uk/gov/register/core/Entry.java
@@ -16,6 +16,7 @@ import uk.gov.register.views.CsvRepresentationView;
 import uk.gov.register.views.representations.CsvRepresentation;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -23,13 +24,20 @@ import java.util.List;
 @JsonPropertyOrder({"entry-number", "entry-timestamp", "item-hash", "key"})
 public class Entry implements CsvRepresentationView<Entry> {
     private final int entryNumber;
-    private final HashValue hashValue;
+    private final List<HashValue> hashValues;
     private final Instant timestamp;
     private String key;
 
     public Entry(int entryNumber, HashValue hashValue, Instant timestamp, String key) {
         this.entryNumber = entryNumber;
-        this.hashValue = hashValue;
+        this.hashValues = Arrays.asList(hashValue);
+        this.timestamp = timestamp;
+        this.key = key;
+    }
+
+    public Entry(int entryNumber, List<HashValue> hashValues, Instant timestamp, String key) {
+        this.entryNumber = entryNumber;
+        this.hashValues = hashValues;
         this.timestamp = timestamp;
         this.key = key;
     }
@@ -42,7 +50,12 @@ public class Entry implements CsvRepresentationView<Entry> {
     @SuppressWarnings("unused, used from DAO")
     @JsonProperty("item-hash")
     public HashValue getSha256hex() {
-        return hashValue;
+        return hashValues.get(0);
+    }
+
+    @JsonIgnore
+    public List<HashValue> getItemHashes() {
+        return hashValues;
     }
 
     @JsonIgnore
@@ -95,12 +108,12 @@ public class Entry implements CsvRepresentationView<Entry> {
         Entry entry = (Entry) o;
 
         if (entryNumber != entry.entryNumber) return false;
-        return hashValue == null ? entry.hashValue == null : hashValue.equals(entry.hashValue);
+        return hashValues == null ? entry.hashValues == null : hashValues.equals(entry.hashValues);
     }
 
     @Override
     public int hashCode() {
-        int result = hashValue != null ? hashValue.hashCode() : 0;
+        int result = hashValues != null ? hashValues.hashCode() : 0;
         result = 31 * entryNumber + result;
         return result;
     }

--- a/src/test/java/uk/gov/register/core/EntryTest.java
+++ b/src/test/java/uk/gov/register/core/EntryTest.java
@@ -1,13 +1,23 @@
 package uk.gov.register.core;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Test;
 import uk.gov.register.util.HashValue;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 public class EntryTest {
+    private final HashValue hash1 = new HashValue(HashingAlgorithm.SHA256, "hash1");
+    private final HashValue hash2 = new HashValue(HashingAlgorithm.SHA256, "hash2");
+
     @Test
     public void getTimestampAsISOFormat_returnsTheFormattedTimestamp() {
         Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), Instant.ofEpochSecond(1470403440), "sample-key");
@@ -30,5 +40,127 @@ public class EntryTest {
     public void getkey_returnskeyValue() {
         Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), Instant.ofEpochSecond(1470403440), "sample-key");
         assertThat(entry.getKey(), equalTo("sample-key"));
+    }
+
+    @Test
+    public void equals_shouldReturnTrue_whenEntriesAreEqual() {
+        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+        Entry entry2 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+
+        assertThat(entry1, equalTo(entry2));
+    }
+
+    @Test
+    public void equals_shouldReturnFalse_whenKeyIsNotEqual() {
+        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "GB");
+        Entry entry2 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "US");
+
+        assertThat(entry1, not(entry2));
+    }
+
+    @Test
+    public void equals_shouldReturnFalse_whenTimestampIsNotEqual() {
+        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+        Entry entry2 = new Entry(1, hash1, Instant.parse("2020-10-10T00:00:00Z"), "key");
+
+        assertThat(entry1, not(entry2));
+    }
+
+    @Test
+    public void equals_shouldReturnTrue_whenListsAreNotInSameOrder() {
+        List<HashValue> list1 = new ArrayList<>(Arrays.asList(hash1, hash2, hash1));
+        List<HashValue> list2 = new ArrayList<>(Arrays.asList(hash2, hash1, hash1));
+
+        assertThat(CollectionUtils.isEqualCollection(list1, list2), is(true));
+    }
+
+    @Test
+    public void equals_shouldReturnTrue_whenItemHashesAreEqualButInDifferentOrder() {
+        List<HashValue> list1 = new ArrayList<>(Arrays.asList(hash1, hash2));
+        List<HashValue> list2 = new ArrayList<>(Arrays.asList(hash2, hash1));
+
+        Entry entryWithList1 = new Entry(1, list1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+        Entry entryWithList2 = new Entry(1, list2, Instant.parse("2017-03-10T00:00:00Z"), "key");
+
+        assertThat(entryWithList1.equals(entryWithList2), is(true));
+    }
+
+    @Test
+    public void equals_shouldReturnTrue_whenCardinalityItemHashesIsEqual() {
+        List<HashValue> list1 = new ArrayList<>(Arrays.asList(hash1, hash2, hash1));
+        List<HashValue> list2 = new ArrayList<>(Arrays.asList(hash2, hash1, hash1));
+
+        Entry entryWithList1 = new Entry(1, list1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+        Entry entryWithList2 = new Entry(1, list2, Instant.parse("2017-03-10T00:00:00Z"), "key");
+
+        assertThat(entryWithList1.equals(entryWithList2), is(true));
+    }
+
+    @Test
+    public void equals_shouldReturnFalse_whenCardinalityItemHashesIsNotEqual() {
+        List<HashValue> list1 = new ArrayList<>(Arrays.asList(hash1, hash2, hash1));
+        List<HashValue> list2 = new ArrayList<>(Arrays.asList(hash2, hash1, hash1, hash2));
+
+        Entry entryWithList1 = new Entry(1, list1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+        Entry entryWithList2 = new Entry(1, list2, Instant.parse("2017-03-10T00:00:00Z"), "key");
+
+        assertThat(entryWithList1.equals(entryWithList2), is(false));
+    }
+
+    @Test
+    public void hashcode_shouldReturnSameHashcode_whenEntriesAreEqual() {
+        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+        Entry entry2 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+
+        assertThat(entry1.hashCode(), equalTo(entry2.hashCode()));
+    }
+
+    @Test
+    public void hashcode_shouldReturnDifferentHashCode_whenKeyIsNotEqual() {
+        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "GB");
+        Entry entry2 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "US");
+
+        assertThat(entry1.hashCode(), not(entry2.hashCode()));
+    }
+
+    @Test
+    public void hashcode_shouldReturnDifferentHashCode_whenTimestampIsNotEqual() {
+        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+        Entry entry2 = new Entry(1, hash1, Instant.parse("2020-10-10T00:00:00Z"), "key");
+
+        assertThat(entry1.hashCode(), not(entry2.hashCode()));
+    }
+
+    @Test
+    public void hashcode_shouldReturnSameHashcode_whenItemHashesAreInEqualButInDifferentOrder() {
+        List<HashValue> list1 = new ArrayList<>(Arrays.asList(hash1, hash2));
+        List<HashValue> list2 = new ArrayList<>(Arrays.asList(hash2, hash1));
+
+        Entry entryWithList1 = new Entry(1, list1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+        Entry entryWithList2 = new Entry(1, list2, Instant.parse("2017-03-10T00:00:00Z"), "key");
+
+        assertThat(entryWithList1.hashCode(), equalTo(entryWithList2.hashCode()));
+    }
+
+    @Test
+    public void hashcode_shouldReturnSameHashcode_whenCardinalityItemHashesIsEqual() {
+        List<HashValue> list1 = new ArrayList<>(Arrays.asList(hash1, hash2, hash1));
+        List<HashValue> list2 = new ArrayList<>(Arrays.asList(hash2, hash1, hash1));
+
+        Entry entryWithList1 = new Entry(1, list1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+        Entry entryWithList2 = new Entry(1, list2, Instant.parse("2017-03-10T00:00:00Z"), "key");
+
+        assertThat(entryWithList1.hashCode(), equalTo(entryWithList2.hashCode()));
+    }
+
+    @Test
+    public void hashcode_shouldReturnDifferentHashCode_whenCardinalityItemHashesIsNotEqual() {
+        List<HashValue> list1 = new ArrayList<>(Arrays.asList(hash1, hash2, hash1));
+        List<HashValue> list2 = new ArrayList<>(Arrays.asList(hash2, hash1, hash1, hash2));
+
+        Entry entryWithList1 = new Entry(1, list1, Instant.parse("2017-03-10T00:00:00Z"), "key");
+        Entry entryWithList2 = new Entry(1, list2, Instant.parse("2017-03-10T00:00:00Z"), "key");
+
+        assertThat(entryWithList1.hashCode(), not(entryWithList2.hashCode()));
     }
 }

--- a/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
@@ -62,7 +62,7 @@ public class DataUploadFunctionalTest {
         assertThat(storedItem.hashValue, equalTo(Item.itemHash(inputItem)));
 
         Entry entry = testEntryDAO.getAllEntries().get(0);
-        assertThat(entry, equalTo(new Entry(1, storedItem.hashValue, Instant.now(), "ft_openregister_test")));
+        assertThat(entry, equalTo(new Entry(1, storedItem.hashValue, entry.getTimestamp(), "ft_openregister_test")));
 
         TestRecord record = testRecordDAO.getRecord("ft_openregister_test");
         assertThat(record.getEntryNumber(), equalTo(1));
@@ -94,10 +94,11 @@ public class DataUploadFunctionalTest {
         JsonNode canonicalItem2 = canonicalJsonMapper.readFromBytes(item2.getBytes());
 
         List<Entry> entries = testEntryDAO.getAllEntries();
+        Instant timestamp = entries.get(0).getTimestamp();
         assertThat(entries,
                 contains(
-                        new Entry(1, Item.itemHash(canonicalItem1), Instant.now(), "register1"),
-                        new Entry(2, Item.itemHash(canonicalItem2), Instant.now(), "register2")
+                        new Entry(1, Item.itemHash(canonicalItem1), timestamp, "register1"),
+                        new Entry(2, Item.itemHash(canonicalItem2), timestamp, "register2")
                 )
         );
 
@@ -130,10 +131,12 @@ public class DataUploadFunctionalTest {
         JsonNode canonicalItem = canonicalJsonMapper.readFromBytes(item1.getBytes());
 
         List<Entry> entries = testEntryDAO.getAllEntries();
+        Instant timestamp = entries.get(0).getTimestamp();
+
         assertThat(entries,
                 contains(
-                        new Entry(1, Item.itemHash(canonicalItem), Instant.now(), "register1"),
-                        new Entry(2, Item.itemHash(canonicalItem), Instant.now(), "register2")
+                        new Entry(1, Item.itemHash(canonicalItem), timestamp, "register1"),
+                        new Entry(2, Item.itemHash(canonicalItem), timestamp, "register1")
                 )
         );
 
@@ -166,11 +169,12 @@ public class DataUploadFunctionalTest {
         JsonNode canonicalItem2 = canonicalJsonMapper.readFromBytes(item2.getBytes());
 
         List<Entry> entries = testEntryDAO.getAllEntries();
+        Instant timestamp = entries.get(0).getTimestamp();
         assertThat(entries,
                 contains(
-                        new Entry(1, Item.itemHash(canonicalItem1), Instant.now(), "register1"),
-                        new Entry(2, Item.itemHash(canonicalItem1), Instant.now(), "register1"),
-                        new Entry(3, Item.itemHash(canonicalItem2), Instant.now(), "register2")
+                        new Entry(1, Item.itemHash(canonicalItem1), timestamp, "register1"),
+                        new Entry(2, Item.itemHash(canonicalItem1), timestamp, "register1"),
+                        new Entry(3, Item.itemHash(canonicalItem2), timestamp, "register2")
                 )
         );
 

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -125,9 +125,9 @@ public class PostgresRegisterTransactionalFunctionalTest {
         Item item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash1"), new ObjectMapper().readTree("{\"address\":\"aaa\"}"));
         Item item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash2"), new ObjectMapper().readTree("{\"address\":\"bbb\"}"));
         Item item3 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash3"), new ObjectMapper().readTree("{\"address\":\"ccc\"}"));
-        Entry entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "itemhash1"), Instant.now(), "aaa");
-        Entry entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "itemhash2"), Instant.now(), "bbb");
-        Entry entry3 = new Entry(3, new HashValue(HashingAlgorithm.SHA256, "itemhash3"), Instant.now(), "ccc");
+        Entry entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "itemhash1"), Instant.parse("2017-03-10T00:00:00Z"), "aaa");
+        Entry entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "itemhash2"), Instant.parse("2017-03-10T00:00:00Z"), "bbb");
+        Entry entry3 = new Entry(3, new HashValue(HashingAlgorithm.SHA256, "itemhash3"), Instant.parse("2017-03-10T00:00:00Z"), "ccc");
 
         RegisterContext.useTransaction(dbi, handle -> {
             PostgresRegister postgresRegister = getPostgresRegister(handle);


### PR DESCRIPTION
This PR adds support for multiple items per entry in the register model. It is a fairly straightforward change, but I will elaborate a little on the modification of the Entry `equals` method.

In order to be able to compare items in the entry, we don't need to worry about what order these item hashes are in. We also allow the possibility of duplicate item hashes per entry, so we can't just store all of these hashes as a set. To get around this problem and not need to re-invent the wheel, I've pulled in the Apache Commons Collection library (http://commons.apache.org/proper/commons-collections/index.html) and am using the method `CollectionUtils.isEqualCollection` to satisfy the above requirements (see the source code at https://commons.apache.org/proper/commons-collections/apidocs/src-html/org/apache/commons/collections4/CollectionUtils.html). If we didn't pull in this library and instead wanted to use the default `List.equals` method that Java provides, we'd have to sort the hashes stored by each entry before doing comparison, as this is how the default method operates. If/when we get to the scale where each entry has many items, this may not be feasible, and is a reason why I went with the Commons Collection library (this by comparison builds up a map of frequencies of each of the items in each of the lists, eliminating the need to sort, but still resulting in an entire pass of each of the lists on each comparison).

Pulling in this library raised a potential security vulnerability during our build process (https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20151209-java-deserialization) but after studying this with Sam, I don't believe this will affect us as we don't allow users to supply serialized data.

Aside from the above, this PR also changes the `equals` and `hashcode` methods of `Entry` to enforce that the fields `key` and `timestamp` should be taken into account when comparing the equality of entries; we were not doing this before. As a consequence, some of the tests have been refactored to accommodate for this.