### PR TITLE
Temporarily increase the deploy timeout

### DIFF
--- a/deploy/appspec.yml
+++ b/deploy/appspec.yml
@@ -18,5 +18,5 @@ hooks:
       runas: root
   ValidateService:
     - location: scripts/validate.sh
-      timeout: 300
+      timeout: 600
       runas: root


### PR DESCRIPTION
Deploying to alpha is currently flakey and it appears to be due to
Flyway migration checks which are very slow. We should look at solving
the problem of why these are slow but at the moment deploying to alpha
is unreliable.