### PR TITLE
Migration to add new entry_item table

### DIFF
--- a/src/main/java/uk/gov/register/core/Entry.java
+++ b/src/main/java/uk/gov/register/core/Entry.java
@@ -17,10 +17,7 @@ import uk.gov.register.views.CsvRepresentationView;
 import uk.gov.register.views.representations.CsvRepresentation;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 @JsonPropertyOrder({"entry-number", "entry-timestamp", "item-hash", "key"})
@@ -52,7 +49,7 @@ public class Entry implements CsvRepresentationView<Entry> {
     @SuppressWarnings("unused, used from DAO")
     @JsonProperty("item-hash")
     public HashValue getSha256hex() {
-        return hashValues.get(0);
+        return hashValues.isEmpty() ? new HashValue("", "") : hashValues.get(0);
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -79,7 +79,7 @@ public class PostgresRegister implements Register {
 
     @Override
     public Collection<Entry> allEntriesOfRecord(String key) {
-        return recordIndex.findAllEntriesOfRecordBy(registerName, key);
+        return recordIndex.findAllEntriesOfRecordBy(key);
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/RecordIndex.java
+++ b/src/main/java/uk/gov/register/core/RecordIndex.java
@@ -15,7 +15,7 @@ public interface RecordIndex {
 
     List<Record> findMax100RecordsByKeyValue(String key, String value);
 
-    Collection<Entry> findAllEntriesOfRecordBy(RegisterName registerName, String key);
+    Collection<Entry> findAllEntriesOfRecordBy(String key);
 
     void checkpoint();
 }

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -93,7 +93,8 @@ public class RegisterContext implements
                 getRegisterFieldsConfiguration(),
                 new TransactionalEntryLog(memoizationStore,
                         handle.attach(EntryQueryDAO.class),
-                        handle.attach(EntryDAO.class)),
+                        handle.attach(EntryDAO.class),
+                        handle.attach((EntryItemDAO.class))),
                 new TransactionalItemStore(
                         handle.attach(ItemDAO.class),
                         handle.attach(ItemQueryDAO.class),

--- a/src/main/java/uk/gov/register/db/AbstractRecordIndex.java
+++ b/src/main/java/uk/gov/register/db/AbstractRecordIndex.java
@@ -41,8 +41,8 @@ public abstract class AbstractRecordIndex implements RecordIndex {
     }
 
     @Override
-    public Collection<Entry> findAllEntriesOfRecordBy(RegisterName registerName, String key) {
+    public Collection<Entry> findAllEntriesOfRecordBy(String key) {
         checkpoint();
-        return recordQueryDAO.findAllEntriesOfRecordBy(registerName.value(), key);
+        return recordQueryDAO.findAllEntriesOfRecordBy(key);
     }
 }

--- a/src/main/java/uk/gov/register/db/EntryItemDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryItemDAO.java
@@ -1,12 +1,12 @@
 package uk.gov.register.db;
 
+import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
-import uk.gov.register.core.Entry;
-import uk.gov.register.store.postgres.BindEntry;
+import uk.gov.register.util.EntryItemPair;
 
 public interface EntryItemDAO {
-    @SqlBatch("insert into entry_item(entry_number, sha256hex) values (:entry_number, :sha256hex)")
+    @SqlBatch("insert into entry_item(entry_number, sha256hex) values (:entryNumber, :sha256hex)")
     @BatchChunkSize(1000)
-    void insertInBatch(@BindEntry Iterable<Entry> entries);
+    void insertInBatch(@BindBean Iterable<EntryItemPair> entries);
 }

--- a/src/main/java/uk/gov/register/db/EntryItemDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryItemDAO.java
@@ -1,0 +1,12 @@
+package uk.gov.register.db;
+
+import org.skife.jdbi.v2.sqlobject.SqlBatch;
+import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
+import uk.gov.register.core.Entry;
+import uk.gov.register.store.postgres.BindEntry;
+
+public interface EntryItemDAO {
+    @SqlBatch("insert into entry_item(entry_number, sha256hex) values (:entry_number, :sha256hex)")
+    @BatchChunkSize(1000)
+    void insertInBatch(@BindEntry Iterable<Entry> entries);
+}

--- a/src/main/java/uk/gov/register/db/EntryQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryQueryDAO.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 public interface EntryQueryDAO {
     @RegisterMapper(EntryMapper.class)
     @SingleValueResult(Entry.class)
-    @SqlQuery("select entry_number, sha256hex, timestamp, key from entry where entry_number=:entryNumber")
+    @SqlQuery("select e.entry_number, ei.sha256hex, e.timestamp, e.key from entry e join entry_item ei on ei.entry_number = e.entry_number where e.entry_number = :entryNumber")
     Optional<Entry> findByEntryNumber(@Bind("entryNumber") int entryNumber);
 
     @RegisterMapper(LongTimestampToInstantMapper.class)
@@ -31,24 +31,24 @@ public interface EntryQueryDAO {
 
     //Note: This is fine for small data registers like country
     @RegisterMapper(EntryMapper.class)
-    @SqlQuery("SELECT entry_number, sha256hex, timestamp, key from entry order by entry_number desc")
+    @SqlQuery("SELECT e.entry_number, ei.sha256hex, e.timestamp, e.key from entry e join entry_item ei on ei.entry_number = e.entry_number order by e.entry_number desc")
     Collection<Entry> getAllEntriesNoPagination();
 
     @RegisterMapper(EntryMapper.class)
-    @SqlQuery("select entry_number, sha256hex, timestamp, key from entry where entry_number >= :start and entry_number \\< :start + :limit order by entry_number asc")
+    @SqlQuery("select e.entry_number, ei.sha256hex, e.timestamp, e.key from entry e join entry_item ei on ei.entry_number = e.entry_number where e.entry_number >= :start and e.entry_number \\< :start + :limit order by e.entry_number asc")
     Collection<Entry> getEntries(@Bind("start") int start, @Bind("limit") int limit);
 
-    @SqlQuery("SELECT entry_number, sha256hex, timestamp, key FROM entry WHERE entry_number >= :entryNumber ORDER BY entry_number")
+    @SqlQuery("SELECT e.entry_number, ei.sha256hex, e.timestamp, e.key FROM entry e join entry_item ei on ei.entry_number = e.entry_number WHERE e.entry_number >= :entryNumber ORDER BY e.entry_number")
     @RegisterMapper(EntryMapper.class)
     @FetchSize(262144) // Has to be non-zero to enable cursor mode https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
     ResultIterator<Entry> entriesIteratorFrom(@Bind("entryNumber") int entryNumber);
 
-    @SqlQuery("SELECT entry_number, sha256hex, timestamp, key FROM entry ORDER BY entry_number")
+    @SqlQuery("SELECT e.entry_number, ei.sha256hex, e.timestamp, e.key FROM entry e join entry_item ei on ei.entry_number = e.entry_number ORDER BY e.entry_number")
     @RegisterMapper(EntryMapper.class)
     @FetchSize(10000)
     Iterator<Entry> getIterator();
 
-    @SqlQuery("SELECT entry_number, sha256hex, timestamp, key FROM entry WHERE entry_number > :totalEntries1 and entry_number <= :totalEntries2 ORDER BY entry_number")
+    @SqlQuery("SELECT e.entry_number, ei.sha256hex, e.timestamp, e.key FROM entry e join entry_item ei on ei.entry_number = e.entry_number WHERE e.entry_number > :totalEntries1 and e.entry_number <= :totalEntries2 ORDER BY e.entry_number")
     @RegisterMapper(EntryMapper.class)
     @FetchSize(10000)
     Iterator<Entry> getIterator(@Bind("totalEntries1") int totalEntries1, @Bind("totalEntries2") int totalEntries2);

--- a/src/main/java/uk/gov/register/db/EntryQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryQueryDAO.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 public interface EntryQueryDAO {
     @RegisterMapper(EntryMapper.class)
     @SingleValueResult(Entry.class)
-    @SqlQuery("select e.entry_number, ei.sha256hex, e.timestamp, e.key from entry e join entry_item ei on ei.entry_number = e.entry_number where e.entry_number = :entryNumber")
+    @SqlQuery("select e.entry_number, array_remove(array_agg(ei.sha256hex), null) as sha256hex, e.timestamp, e.key from entry e left join entry_item ei on ei.entry_number = e.entry_number where e.entry_number = :entryNumber group by e.entry_number")
     Optional<Entry> findByEntryNumber(@Bind("entryNumber") int entryNumber);
 
     @RegisterMapper(LongTimestampToInstantMapper.class)
@@ -31,24 +31,24 @@ public interface EntryQueryDAO {
 
     //Note: This is fine for small data registers like country
     @RegisterMapper(EntryMapper.class)
-    @SqlQuery("SELECT e.entry_number, ei.sha256hex, e.timestamp, e.key from entry e join entry_item ei on ei.entry_number = e.entry_number order by e.entry_number desc")
+    @SqlQuery("select e.entry_number, array_remove(array_agg(ei.sha256hex), null) as sha256hex, e.timestamp, e.key from entry e left join entry_item ei on ei.entry_number = e.entry_number group by e.entry_number order by e.entry_number desc")
     Collection<Entry> getAllEntriesNoPagination();
 
     @RegisterMapper(EntryMapper.class)
-    @SqlQuery("select e.entry_number, ei.sha256hex, e.timestamp, e.key from entry e join entry_item ei on ei.entry_number = e.entry_number where e.entry_number >= :start and e.entry_number \\< :start + :limit order by e.entry_number asc")
+    @SqlQuery("select e.entry_number, array_remove(array_agg(ei.sha256hex), null) as sha256hex, e.timestamp, e.key from entry e left join entry_item ei on ei.entry_number = e.entry_number where e.entry_number >= :start and e.entry_number \\< :start + :limit group by e.entry_number order by e.entry_number asc")
     Collection<Entry> getEntries(@Bind("start") int start, @Bind("limit") int limit);
 
-    @SqlQuery("SELECT e.entry_number, ei.sha256hex, e.timestamp, e.key FROM entry e join entry_item ei on ei.entry_number = e.entry_number WHERE e.entry_number >= :entryNumber ORDER BY e.entry_number")
+    @SqlQuery("select e.entry_number, array_remove(array_agg(ei.sha256hex), null) as sha256hex, e.timestamp, e.key from entry e left join entry_item ei on ei.entry_number = e.entry_number where e.entry_number >= :entryNumber group by e.entry_number order by e.entry_number")
     @RegisterMapper(EntryMapper.class)
     @FetchSize(262144) // Has to be non-zero to enable cursor mode https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
     ResultIterator<Entry> entriesIteratorFrom(@Bind("entryNumber") int entryNumber);
 
-    @SqlQuery("SELECT e.entry_number, ei.sha256hex, e.timestamp, e.key FROM entry e join entry_item ei on ei.entry_number = e.entry_number ORDER BY e.entry_number")
+    @SqlQuery("select e.entry_number, array_remove(array_agg(ei.sha256hex), null) as sha256hex, e.timestamp, e.key from entry e left join entry_item ei on ei.entry_number = e.entry_number group by e.entry_number order by e.entry_number")
     @RegisterMapper(EntryMapper.class)
     @FetchSize(10000)
     Iterator<Entry> getIterator();
 
-    @SqlQuery("SELECT e.entry_number, ei.sha256hex, e.timestamp, e.key FROM entry e join entry_item ei on ei.entry_number = e.entry_number WHERE e.entry_number > :totalEntries1 and e.entry_number <= :totalEntries2 ORDER BY e.entry_number")
+    @SqlQuery("select e.entry_number, array_remove(array_agg(ei.sha256hex), null) as sha256hex, e.timestamp, e.key from entry e left join entry_item ei on ei.entry_number = e.entry_number where e.entry_number > :totalEntries1 and e.entry_number <= :totalEntries2 group by e.entry_number order by e.entry_number")
     @RegisterMapper(EntryMapper.class)
     @FetchSize(10000)
     Iterator<Entry> getIterator(@Bind("totalEntries1") int totalEntries1, @Bind("totalEntries2") int totalEntries2);

--- a/src/main/java/uk/gov/register/db/ItemQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/ItemQueryDAO.java
@@ -24,12 +24,14 @@ public interface ItemQueryDAO {
     @RegisterMapper(ItemMapper.class)
     Collection<Item> getAllItemsNoPagination();
 
-    @SqlQuery("select sha256hex, content from item where exists(select 1 from entry where item.sha256hex = entry.sha256hex)")
+    // TODO: This query will need to change to remove `distinct` when download-rsf supports multiple items per entry.
+    @SqlQuery("select distinct ei.sha256hex, i.content from item i join entry_item ei on i.sha256hex = ei.sha256hex")
     @RegisterMapper(ItemMapper.class)
     @FetchSize(10000)
     Iterator<Item> getIterator();
 
-    @SqlQuery("select sha256hex, content from item where exists(select 1 from entry where item.sha256hex = entry.sha256hex and entry_number > :startEntryNo and entry_number <= :endEntryNo)")
+    // TODO: This query will need to change to remove `distinct` when download-rsf supports multiple items per entry.
+    @SqlQuery("select distinct ei.sha256hex, i.content from item i join entry_item ei on i.sha256hex = ei.sha256hex and ei.entry_number > :startEntryNo and ei.entry_number <= :endEntryNo")
     @RegisterMapper(ItemMapper.class)
     @FetchSize(10000)
     Iterator<Item> getIterator(@Bind("startEntryNo") int startEntryNo, @Bind("endEntryNo") int endEntryNo);

--- a/src/main/java/uk/gov/register/db/ItemQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/ItemQueryDAO.java
@@ -24,16 +24,13 @@ public interface ItemQueryDAO {
     @RegisterMapper(ItemMapper.class)
     Collection<Item> getAllItemsNoPagination();
 
-    // TODO: This query will need to change to remove `distinct` when download-rsf supports multiple items per entry.
-    @SqlQuery("select distinct ei.sha256hex, i.content from item i join entry_item ei on i.sha256hex = ei.sha256hex")
+    @SqlQuery("select i.sha256hex, i.content from item i where exists(select 1 from entry_item ei where i.sha256hex = ei.sha256hex)")
     @RegisterMapper(ItemMapper.class)
     @FetchSize(10000)
     Iterator<Item> getIterator();
 
-    // TODO: This query will need to change to remove `distinct` when download-rsf supports multiple items per entry.
-    @SqlQuery("select distinct ei.sha256hex, i.content from item i join entry_item ei on i.sha256hex = ei.sha256hex and ei.entry_number > :startEntryNo and ei.entry_number <= :endEntryNo")
+    @SqlQuery("select i.sha256hex, i.content from item i where exists(select 1 from entry_item ei where i.sha256hex = ei.sha256hex and ei.entry_number > :startEntryNo and ei.entry_number <= :endEntryNo)")
     @RegisterMapper(ItemMapper.class)
     @FetchSize(10000)
     Iterator<Item> getIterator(@Bind("startEntryNo") int startEntryNo, @Bind("endEntryNo") int endEntryNo);
-
 }

--- a/src/main/java/uk/gov/register/db/RecordQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/RecordQueryDAO.java
@@ -16,42 +16,35 @@ import uk.gov.register.db.mappers.EntryMapper;
 import uk.gov.register.db.mappers.RecordMapper;
 
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public abstract class RecordQueryDAO {
-
     private static final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
     @SqlQuery("SELECT count FROM total_records")
     public abstract int getTotalRecords();
 
-    @SqlQuery("select e.entry_number, e.timestamp, ei.sha256hex as sha256hex, e.key, i.content from entry e join entry_item ei on ei.entry_number = e.entry_number join item i on i.sha256hex = ei.sha256hex and e.entry_number = (select entry_number from current_keys where current_keys.key=:key)")
+    @SqlQuery("select e.entry_number, array_agg(ei.sha256hex) as sha256hex, e.timestamp, e.key, array_agg(i.content) as content from entry e join entry_item ei on ei.entry_number = e.entry_number and e.entry_number = (select entry_number from current_keys where current_keys.key=:key) join item i on i.sha256hex = ei.sha256hex group by e.entry_number")
     @SingleValueResult(Record.class)
     @RegisterMapper(RecordMapper.class)
     public abstract Optional<Record> findByPrimaryKey(@Bind("key") String key);
 
-    @SqlQuery("select e.entry_number, e.timestamp, ei.sha256hex as sha256hex, e.key, i.content from entry e join entry_item ei on ei.entry_number = e.entry_number join current_keys ck on ck.entry_number = e.entry_number join item i on i.sha256hex = ei.sha256hex order by e.entry_number desc limit :limit offset :offset")
+    @SqlQuery("select e.entry_number, array_agg(ei.sha256hex) as sha256hex, e.timestamp, e.key, array_agg(i.content) as content from entry e join entry_item ei on ei.entry_number = e.entry_number join item i on i.sha256hex = ei.sha256hex join current_keys ck on ck.entry_number = e.entry_number group by e.entry_number order by e.entry_number desc limit :limit offset :offset")
     @RegisterMapper(RecordMapper.class)
     public abstract List<Record> getRecords(@Bind("limit") long limit, @Bind("offset") long offset);
 
-    @SqlQuery("select e.entry_number, e.timestamp, ei.sha256hex, e.key from entry e join entry_item ei on ei.entry_number = e.entry_number join item i on i.sha256hex = ei.sha256hex and i.content @> :contentPGobject order by e.entry_number asc")
+    @SqlQuery("select e.entry_number, array_remove(array_agg(ei.sha256hex), null) as sha256hex, e.timestamp, e.key from entry e left join entry_item ei on ei.entry_number = e.entry_number where e.key = :key group by e.entry_number order by e.entry_number asc")
     @RegisterMapper(EntryMapper.class)
-    public abstract Collection<Entry> __findAllEntriesOfRecordBy(@Bind("contentPGobject") PGobject content);
+    public abstract List<Entry> findAllEntriesOfRecordBy(@Bind("key") String key);
 
-    @SqlQuery("select e.entry_number, e.timestamp, ei.sha256hex as sha256hex, e.key, i.content from entry e join entry_item ei on ei.entry_number = e.entry_number join item i on i.sha256hex = ei.sha256hex join current_keys ck on ck.entry_number = e.entry_number where i.content @> :contentPGobject and i.sha256hex = ei.sha256hex limit 100")
+    @SqlQuery("select e.entry_number, array_agg(ei.sha256hex) as sha256hex, e.timestamp, e.key, array_agg(i.content) as content from entry e join entry_item ei on ei.entry_number = e.entry_number join item i on i.sha256hex = ei.sha256hex join current_keys ck on ck.entry_number = e.entry_number where i.content @> :contentPGobject group by e.entry_number limit 100")
     @RegisterMapper(RecordMapper.class)
     public abstract List<Record> __findMax100RecordsByKeyValue(@Bind("contentPGobject") PGobject content);
-
-    public Collection<Entry> findAllEntriesOfRecordBy(String key, String value) {
-        return __findAllEntriesOfRecordBy(writePGObject(key, value));
-    }
 
     public List<Record> findMax100RecordsByKeyValue(String key, String value) {
         return __findMax100RecordsByKeyValue(writePGObject(key, value));
     }
-
 
     private PGobject writePGObject(String key, String value) {
         try {

--- a/src/main/java/uk/gov/register/db/RecordQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/RecordQueryDAO.java
@@ -27,20 +27,20 @@ public abstract class RecordQueryDAO {
     @SqlQuery("SELECT count FROM total_records")
     public abstract int getTotalRecords();
 
-    @SqlQuery("select entry_number, timestamp, e.sha256hex as sha256hex, key, content from entry e, item i where e.sha256hex=i.sha256hex and e.entry_number = (select entry_number from current_keys where current_keys.key=:key)")
+    @SqlQuery("select e.entry_number, e.timestamp, ei.sha256hex as sha256hex, e.key, i.content from entry e join entry_item ei on ei.entry_number = e.entry_number join item i on i.sha256hex = ei.sha256hex and e.entry_number = (select entry_number from current_keys where current_keys.key=:key)")
     @SingleValueResult(Record.class)
     @RegisterMapper(RecordMapper.class)
     public abstract Optional<Record> findByPrimaryKey(@Bind("key") String key);
 
-    @SqlQuery("select entry.entry_number, timestamp, entry.sha256hex as sha256hex, entry.key, content from item, entry, current_keys where current_keys.entry_number = entry.entry_number and item.sha256hex=entry.sha256hex order by entry.entry_number desc limit :limit offset :offset")
+    @SqlQuery("select e.entry_number, e.timestamp, ei.sha256hex as sha256hex, e.key, i.content from entry e join entry_item ei on ei.entry_number = e.entry_number join current_keys ck on ck.entry_number = e.entry_number join item i on i.sha256hex = ei.sha256hex order by e.entry_number desc limit :limit offset :offset")
     @RegisterMapper(RecordMapper.class)
     public abstract List<Record> getRecords(@Bind("limit") long limit, @Bind("offset") long offset);
 
-    @SqlQuery("select entry_number, timestamp, sha256hex, key from entry where sha256hex in (select sha256hex from item where (content @> :contentPGobject)) order by entry_number asc")
+    @SqlQuery("select e.entry_number, e.timestamp, ei.sha256hex, e.key from entry e join entry_item ei on ei.entry_number = e.entry_number join item i on i.sha256hex = ei.sha256hex and i.content @> :contentPGobject order by e.entry_number asc")
     @RegisterMapper(EntryMapper.class)
     public abstract Collection<Entry> __findAllEntriesOfRecordBy(@Bind("contentPGobject") PGobject content);
 
-    @SqlQuery("select entry.entry_number, timestamp, entry.sha256hex as sha256hex, entry.key, content from item, entry, current_keys where current_keys.entry_number = entry.entry_number and item.content @> :contentPGobject and item.sha256hex=entry.sha256hex limit 100")
+    @SqlQuery("select e.entry_number, e.timestamp, ei.sha256hex as sha256hex, e.key, i.content from entry e join entry_item ei on ei.entry_number = e.entry_number join item i on i.sha256hex = ei.sha256hex join current_keys ck on ck.entry_number = e.entry_number where i.content @> :contentPGobject and i.sha256hex = ei.sha256hex limit 100")
     @RegisterMapper(RecordMapper.class)
     public abstract List<Record> __findMax100RecordsByKeyValue(@Bind("contentPGobject") PGobject content);
 

--- a/src/main/java/uk/gov/register/db/TransactionalEntryLog.java
+++ b/src/main/java/uk/gov/register/db/TransactionalEntryLog.java
@@ -14,12 +14,14 @@ public class TransactionalEntryLog extends AbstractEntryLog {
     private final List<Entry> stagedEntries;
     private final EntryQueryDAO entryQueryDAO;
     private final EntryDAO entryDAO;
+    private final EntryItemDAO entryItemDAO;
 
-    public TransactionalEntryLog(MemoizationStore memoizationStore, EntryQueryDAO entryQueryDAO, EntryDAO entryDAO) {
+    public TransactionalEntryLog(MemoizationStore memoizationStore, EntryQueryDAO entryQueryDAO, EntryDAO entryDAO, EntryItemDAO entryItemDAO) {
         super(entryQueryDAO, memoizationStore);
         this.stagedEntries = new ArrayList<>();
         this.entryQueryDAO = entryQueryDAO;
         this.entryDAO = entryDAO;
+        this.entryItemDAO = entryItemDAO;
     }
 
     @Override
@@ -49,6 +51,7 @@ public class TransactionalEntryLog extends AbstractEntryLog {
             return;
         }
         entryDAO.insertInBatch(stagedEntries);
+        entryItemDAO.insertInBatch(stagedEntries);
         entryDAO.setEntryNumber(entryDAO.currentEntryNumber() + stagedEntries.size());
         stagedEntries.clear();
     }

--- a/src/main/java/uk/gov/register/db/TransactionalEntryLog.java
+++ b/src/main/java/uk/gov/register/db/TransactionalEntryLog.java
@@ -1,6 +1,7 @@
 package uk.gov.register.db;
 
 import uk.gov.register.core.Entry;
+import uk.gov.register.util.EntryItemPair;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import java.util.ArrayList;
@@ -50,8 +51,12 @@ public class TransactionalEntryLog extends AbstractEntryLog {
         if (stagedEntries.isEmpty()) {
             return;
         }
+
+        List<EntryItemPair> entryItemPairs = new ArrayList<>();
+        stagedEntries.forEach(se -> se.getItemHashes().forEach(h -> entryItemPairs.add(new EntryItemPair(se.getEntryNumber(), h))));
+
         entryDAO.insertInBatch(stagedEntries);
-        entryItemDAO.insertInBatch(stagedEntries);
+        entryItemDAO.insertInBatch(entryItemPairs);
         entryDAO.setEntryNumber(entryDAO.currentEntryNumber() + stagedEntries.size());
         stagedEntries.clear();
     }

--- a/src/main/java/uk/gov/register/db/mappers/EntryMapper.java
+++ b/src/main/java/uk/gov/register/db/mappers/EntryMapper.java
@@ -8,6 +8,8 @@ import uk.gov.register.util.HashValue;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class EntryMapper implements ResultSetMapper<Entry> {
     private final LongTimestampToInstantMapper longTimestampToInstantMapper;
@@ -18,6 +20,8 @@ public class EntryMapper implements ResultSetMapper<Entry> {
 
     @Override
     public Entry map(int index, ResultSet r, StatementContext ctx) throws SQLException {
-        return new Entry(r.getInt("entry_number"), new HashValue(HashingAlgorithm.SHA256, r.getString("sha256hex")), longTimestampToInstantMapper.map(index, r, ctx), r.getString("key"));
+        List<HashValue> hashes = Arrays.asList((String[]) r.getArray("sha256hex").getArray()).stream().map(h -> new HashValue(HashingAlgorithm.SHA256, h)).collect(Collectors.toList());
+
+        return new Entry(r.getInt("entry_number"), hashes, longTimestampToInstantMapper.map(index, r, ctx), r.getString("key"));
     }
 }

--- a/src/main/java/uk/gov/register/db/mappers/RecordMapper.java
+++ b/src/main/java/uk/gov/register/db/mappers/RecordMapper.java
@@ -1,26 +1,52 @@
 package uk.gov.register.db.mappers;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
+import uk.gov.register.util.HashValue;
 
+import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RecordMapper implements ResultSetMapper<Record> {
     private final EntryMapper entryMapper;
-    private final ItemMapper itemMapper;
+    private final ObjectMapper objectMapper;
 
     public RecordMapper() {
         this.entryMapper = new EntryMapper();
-        this.itemMapper = new ItemMapper();
+        objectMapper = Jackson.newObjectMapper();
     }
 
     @Override
     public Record map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+        List<Item> items = new ArrayList<>();
+
+        String[] itemHashes = (String[]) r.getArray("sha256hex").getArray();
+        String[] itemContent = (String[]) r.getArray("content").getArray();
+
+        if (itemHashes.length != itemContent.length) {
+            throw new RuntimeException("Number of item hashes not equal to number of item content");
+        }
+
+        for (int i = 0; i < itemHashes.length; i++) {
+            try {
+                items.add(new Item(new HashValue(HashingAlgorithm.SHA256, itemHashes[i]), objectMapper.readValue(itemContent[i], JsonNode.class)));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
         return new Record(
                 entryMapper.map(index, r, ctx),
-                itemMapper.map(index, r, ctx)
+                items
         );
     }
 }

--- a/src/main/java/uk/gov/register/util/EntryItemPair.java
+++ b/src/main/java/uk/gov/register/util/EntryItemPair.java
@@ -1,0 +1,19 @@
+package uk.gov.register.util;
+
+public class EntryItemPair {
+    private final int entryNumber;
+    private final HashValue sha256hex;
+
+    public EntryItemPair(int entryNumber, HashValue sha256hex) {
+        this.entryNumber = entryNumber;
+        this.sha256hex = sha256hex;
+    }
+
+    public int getEntryNumber() {
+        return entryNumber;
+    }
+
+    public String getSha256hex() {
+        return sha256hex.getValue();
+    }
+}

--- a/src/main/resources/sql/V3__Support_multiple_entries_per_item.sql
+++ b/src/main/resources/sql/V3__Support_multiple_entries_per_item.sql
@@ -1,0 +1,10 @@
+create table if not exists entry_item
+(
+    entry_number    integer,
+    sha256hex       varchar
+);
+
+insert into     entry_item (entry_number, sha256hex)
+select          entry_number,
+                sha256hex
+from            entry;

--- a/src/test/java/uk/gov/register/db/InMemoryEntryDAO.java
+++ b/src/test/java/uk/gov/register/db/InMemoryEntryDAO.java
@@ -11,7 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
-public class InMemoryEntryDAO implements EntryQueryDAO, EntryDAO {
+public class InMemoryEntryDAO implements EntryQueryDAO, EntryItemDAO, EntryDAO {
     private final List<Entry> entries;
     private int currentEntryNumber = 0;
 
@@ -68,7 +68,9 @@ public class InMemoryEntryDAO implements EntryQueryDAO, EntryDAO {
     @Override
     public void insertInBatch(@BindEntry Iterable<Entry> entries) {
         for (Entry entry : entries) {
-            this.entries.add(entry);
+            if (!this.entries.contains(entry)) {
+                this.entries.add(entry);
+            }
         }
     }
 

--- a/src/test/java/uk/gov/register/db/InMemoryEntryDAO.java
+++ b/src/test/java/uk/gov/register/db/InMemoryEntryDAO.java
@@ -11,7 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
-public class InMemoryEntryDAO implements EntryQueryDAO, EntryItemDAO, EntryDAO {
+public class InMemoryEntryDAO implements EntryQueryDAO, EntryDAO {
     private final List<Entry> entries;
     private int currentEntryNumber = 0;
 

--- a/src/test/java/uk/gov/register/db/TransactionalEntryLogTest.java
+++ b/src/test/java/uk/gov/register/db/TransactionalEntryLogTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
 import static uk.gov.register.core.HashingAlgorithm.SHA256;
 
 public class TransactionalEntryLogTest {
@@ -31,7 +32,7 @@ public class TransactionalEntryLogTest {
     public void setUp() throws Exception {
         entries = new ArrayList<>();
         entryQueryDAO = new InMemoryEntryDAO(entries);
-        entryLog = new TransactionalEntryLog(new DoNothing(), entryQueryDAO, entryQueryDAO, entryQueryDAO);
+        entryLog = new TransactionalEntryLog(new DoNothing(), entryQueryDAO, entryQueryDAO, mock(EntryItemDAO.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/db/TransactionalEntryLogTest.java
+++ b/src/test/java/uk/gov/register/db/TransactionalEntryLogTest.java
@@ -31,7 +31,7 @@ public class TransactionalEntryLogTest {
     public void setUp() throws Exception {
         entries = new ArrayList<>();
         entryQueryDAO = new InMemoryEntryDAO(entries);
-        entryLog = new TransactionalEntryLog(new DoNothing(), entryQueryDAO, entryQueryDAO);
+        entryLog = new TransactionalEntryLog(new DoNothing(), entryQueryDAO, entryQueryDAO, entryQueryDAO);
     }
 
     @Test

--- a/src/test/java/uk/gov/register/db/TransactionalRecordIndexTest.java
+++ b/src/test/java/uk/gov/register/db/TransactionalRecordIndexTest.java
@@ -7,7 +7,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Record;
-import uk.gov.register.core.RegisterName;
 
 import java.util.*;
 
@@ -71,7 +70,7 @@ public class TransactionalRecordIndexTest {
     public void findAllEntriesOfRecordBy_shouldCauseCheckpoint() {
         recordIndex.updateRecordIndex("foo", 5);
 
-        Collection<Entry> ignored = recordIndex.findAllEntriesOfRecordBy(new RegisterName("foo"), "bar");
+        Collection<Entry> ignored = recordIndex.findAllEntriesOfRecordBy("bar");
 
         // ignore the result, but check that we flushed out to currentKeys
         assertThat(currentKeys.get("foo"), is(5));

--- a/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
+++ b/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
@@ -4,12 +4,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 import uk.gov.register.core.Entry;
+import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.db.EntryQueryDAO;
 import uk.gov.register.functional.app.WipeDatabaseRule;
+import uk.gov.register.util.HashValue;
 
 import java.time.Instant;
 import java.util.Collection;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -33,5 +37,53 @@ public class EntryMapperTest {
 
         assertThat(allEntriesNoPagination.size(), equalTo(1));
         assertThat(allEntriesNoPagination.iterator().next().getTimestamp(), equalTo(expectedInstant));
+    }
+
+    @Test
+    public void map_returnsSingleItemHashForEntry() {
+        DBI dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java_address?user=postgres&ApplicationName=EntryMapperTest");
+
+        Collection<Entry> allEntriesNoPagination = dbi.withHandle(h -> {
+            h.execute("insert into entry(entry_number, timestamp, sha256hex) values(5, :timestamp, 'abcdef')", Instant.now().getEpochSecond());
+            h.execute("insert into entry_item(entry_number, sha256hex) values(5, 'ghijkl')");
+            return h.attach(EntryQueryDAO.class).getAllEntriesNoPagination();
+        });
+
+        Entry entry = allEntriesNoPagination.iterator().next();
+
+        assertThat(allEntriesNoPagination.size(), equalTo(1));
+        assertThat(entry.getItemHashes(), contains(new HashValue(HashingAlgorithm.SHA256, "ghijkl")));
+    }
+
+    @Test
+    public void map_returnsMultipleItemHashesForEntry() {
+        DBI dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java_address?user=postgres&ApplicationName=EntryMapperTest");
+
+        Collection<Entry> allEntriesNoPagination = dbi.withHandle(h -> {
+            h.execute("insert into entry(entry_number, timestamp, sha256hex) values(5, :timestamp, 'abcdef')", Instant.now().getEpochSecond());
+            h.execute("insert into entry_item(entry_number, sha256hex) values(5, 'abcdef')");
+            h.execute("insert into entry_item(entry_number, sha256hex) values(5, 'ghijkl')");
+            return h.attach(EntryQueryDAO.class).getAllEntriesNoPagination();
+        });
+
+        Entry entry = allEntriesNoPagination.iterator().next();
+
+        assertThat(allEntriesNoPagination.size(), equalTo(1));
+        assertThat(entry.getItemHashes(), containsInAnyOrder(new HashValue(HashingAlgorithm.SHA256, "abcdef"), new HashValue(HashingAlgorithm.SHA256, "ghijkl")));
+    }
+
+    @Test
+    public void map_returnsNoItemHashesForEntry() {
+        DBI dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java_address?user=postgres&ApplicationName=EntryMapperTest");
+
+        Collection<Entry> allEntriesNoPagination = dbi.withHandle(h -> {
+            h.execute("insert into entry(entry_number, timestamp, sha256hex) values(5, :timestamp, 'abcdef')", Instant.now().getEpochSecond());
+            return h.attach(EntryQueryDAO.class).getAllEntriesNoPagination();
+        });
+
+        Entry entry = allEntriesNoPagination.iterator().next();
+
+        assertThat(allEntriesNoPagination.size(), equalTo(1));
+        assertThat(entry.getItemHashes().size(), equalTo(0));
     }
 }

--- a/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
+++ b/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
@@ -25,7 +25,8 @@ public class EntryMapperTest {
         DBI dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java_address?user=postgres&ApplicationName=EntryMapperTest");
 
         Collection<Entry> allEntriesNoPagination = dbi.withHandle(h -> {
-            h.execute("insert into entry(entry_number, sha256hex, timestamp) values(5, 'abcdef', :timestamp)", expectedInstant.getEpochSecond());
+            h.execute("insert into entry(entry_number, timestamp, sha256hex) values(5, :timestamp, 'abcdef')", expectedInstant.getEpochSecond());
+            h.execute("insert into entry_item(entry_number, sha256hex) values(5, 'abcdef')");
             // this method implicitly invokes EntryMapper
             return h.attach(EntryQueryDAO.class).getAllEntriesNoPagination();
         });

--- a/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
@@ -131,12 +131,11 @@ public class DataUploadFunctionalTest {
         JsonNode canonicalItem = canonicalJsonMapper.readFromBytes(item1.getBytes());
 
         List<Entry> entries = testEntryDAO.getAllEntries();
-        Instant timestamp = entries.get(0).getTimestamp();
 
         assertThat(entries,
                 contains(
-                        new Entry(1, Item.itemHash(canonicalItem), timestamp, "register1"),
-                        new Entry(2, Item.itemHash(canonicalItem), timestamp, "register1")
+                        new Entry(1, Item.itemHash(canonicalItem), entries.get(0).getTimestamp(), "register1"),
+                        new Entry(2, Item.itemHash(canonicalItem), entries.get(1).getTimestamp(), "register1")
                 )
         );
 

--- a/src/test/java/uk/gov/register/functional/db/TestEntryDAO.java
+++ b/src/test/java/uk/gov/register/functional/db/TestEntryDAO.java
@@ -10,7 +10,6 @@ import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.HashingAlgorithm;
-import uk.gov.register.db.mappers.EntryMapper;
 import uk.gov.register.util.HashValue;
 
 import java.sql.ResultSet;
@@ -20,15 +19,16 @@ import java.util.List;
 
 public interface TestEntryDAO {
     @SqlUpdate("delete from entry;" +
+            "delete from entry_item;" +
             "delete from current_entry_number;" +
             "insert into current_entry_number values(0);")
     void wipeData();
 
     @RegisterMapper(EntryMapper.class)
-    @SqlQuery("select entry_number, sha256hex, timestamp, key from entry")
+    @SqlQuery("select e.entry_number, ei.sha256hex, e.timestamp, e.key from entry e join entry_item ei on ei.entry_number = e.entry_number")
     List<Entry> getAllEntries();
 
-    @SqlQuery("SELECT * FROM entry WHERE entry_number >= :entryNumber ORDER BY entry_number")
+    @SqlQuery("SELECT e.entry_number, ei.sha256hex, e.timestamp, e.key from entry e join entry_item ei on ei.entry_number = e.entry_number WHERE e.entry_number >= :entryNumber ORDER BY e.entry_number")
     @RegisterMapper(EntryMapper.class)
     @FetchSize(262144) // Has to be non-zero to enable cursor mode https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
     ResultIterator<Entry> entriesIteratorFrom(@Bind("entryNumber") int entryNumber);

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -146,7 +146,7 @@ public class PostgresRegisterTransactionalFunctionalTest {
     }
 
     private PostgresRegister getPostgresRegister(Handle handle) {
-        TransactionalEntryLog entryLog = new TransactionalEntryLog(new DoNothing(), handle.attach(EntryQueryDAO.class), handle.attach(EntryDAO.class));
+        TransactionalEntryLog entryLog = new TransactionalEntryLog(new DoNothing(), handle.attach(EntryQueryDAO.class), handle.attach(EntryDAO.class), handle.attach(EntryItemDAO.class));
         TransactionalItemStore itemStore = new TransactionalItemStore(handle.attach(ItemDAO.class), handle.attach(ItemQueryDAO.class),
                 mock(ItemValidator.class));
         RegisterMetadata registerData = mock(RegisterMetadata.class);


### PR DESCRIPTION
This PR adds a migration to create a new table `entry_item` and insert into it using data currently stored in `entry`. Specifically, it is a join table linking an entry's `entry_number` to an item's `sha256hex`, and this version does not remove `sha256hex` from the entry table - this will happen in a future version.

I've also refactored some of the existing SQL queries to remove stuff like `select`s within `select`s to instead use joins, which should give us better performance and hopefully make it easier to understand what's going on.

`ItemQueryDAO` has also had to change to reflect the addition of the `entry_item` table, and so at the moment `getIterator()` has a `distinct` in the query to only return the unique set of items, rather than the possibility of returning duplicates if an entry references the same item twice or more. This may need to be removed when `download-rsf` supports multiple items per entry.