### PR TITLE
Simplify running app locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,37 @@ A java implementation of a register
 
 [![Build Status](https://travis-ci.org/openregister/openregister-java.svg?branch=master)](https://travis-ci.org/openregister/openregister-java)
 
-# Requirements
+## Running locally
+
+You can spin up a local copy of `openregister-java` using Docker with the following:
+
+    ./run-application.sh
+
+This will build the application from source (inside a container), start and configure Postgres, and run the application (listens on `127.0.0.1:8080`). To load some sample data:
+
+    ./load-school-data.sh
+
+## Development
+
+### Requirements
 
 - Java 1.8+
 - Postgres DB 9.5+
 - Python 3 (and in particular the `pyvenv` script needs to be on your
   path)
 
-# Build and Run project
+### Build and Run project
 
 - Install and run postgres db
 - Checkout project
 - Run the `./go` script to set everything up
 - Build project using command `./gradlew clean build`
 
-# Working on the frontend
+### Working on the frontend
 
 [![Standard - JavaScript Style Guide](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
-## Updating the styles
+### Updating the styles
 
 Recompile the `.scss` files to `.css` via Gradle task:
 
@@ -35,16 +47,7 @@ task to automatically update a running app with scss changes:
 While compassWatch is running, any changed `.scss` file will
 automatically be compiled to `.css` and picked up by the running app.
 
-## Running the server
 
-Run a local server with:
-
-    ./run-application.sh
-
-To load some sample data:
-
-    ./load-school-data.sh
-
-# Update the govuk_frontend_toolkit and govuk_template
+### Update the govuk_frontend_toolkit and govuk_template
 
     $ git submodule update

--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -1,6 +1,6 @@
 database:
   driverClass: org.postgresql.Driver
-  url: jdbc:postgresql://localhost:5432/openregister_java
+  url: jdbc:postgresql://postgres:5432/openregister_java
   user: postgres
   password:
 
@@ -11,26 +11,6 @@ database:
 
   properties:
     charSet: UTF-8
-
-registers:
-  register:
-    database:
-      driverClass: org.postgresql.Driver
-      url: jdbc:postgresql://localhost:5432/register
-      user: postgres
-      password:
-
-      #db connection properties
-      initialSize: 1
-      minSize: 1
-      maxSize: 4
-
-      properties:
-        charSet: UTF-8
-    credentials:
-      user: sasine
-      password: inhibition
-    custodianName: Government Digital Service
 
 server:
   registerDefaultExceptionMappers: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  openregister:
+    image: openjdk:8-jre
+    # hack so that we wait for postgres to be available not just started
+    command: bash -c '/srv/openregister-java/wait-for-it.sh postgres:5432 -- java -jar /srv/openregister-java/openregister-java.jar server /srv/openregister-java/config.yaml'
+    ports:
+      - 127.0.0.1:8080:8080
+    volumes:
+      - ./wait-for-it.sh:/srv/openregister-java/wait-for-it.sh:ro
+      - ./config.docker.yaml:/srv/openregister-java/config.yaml:ro
+      - ./deploy/openregister-java.jar:/srv/openregister-java/openregister-java.jar:ro
+    links:
+      - postgres
+    depends_on:
+      - postgres
+
+  postgres:
+    image: postgres:alpine
+    expose:
+      - 5432
+    environment:
+      - POSTGRES_DB=openregister_java

--- a/run-application.sh
+++ b/run-application.sh
@@ -1,3 +1,13 @@
 #!/usr/bin/env bash
 
-./gradlew run
+if [ ! -e "./deploy/openregister-java.jar" ]
+then
+  docker run \
+    --rm \
+    --volume "$PWD":/usr/src/openregister-java \
+    --workdir /usr/src/openregister-java \
+    openjdk:8 \
+      bash -c "./gradlew stage"
+fi
+
+docker-compose up

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
Assuming we have people that just want to quickly assess the suitability
of `openregister-java` but are put off because it requires compiling the
app, and installing and configuring Postgres. This simplifies the process
into just one command: `./run-application.sh`.