### PR TITLE
Force use of v 1.2.1 of log back.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,12 @@ dependencies {
     compile(postgresClient) {
         exclude group: 'org.slf4j'
     }
+    compile(logbackClassic){
+        force = true
+    }
+    compile(logbackAccess){
+        force = true
+    }
 
     testCompile junit, mockito, dropwizardTest, wiremock
     testCompile dropwizardTest, jsoup, jsonAssert

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -44,6 +44,10 @@ ext {
 
     thymeleaf = 'org.thymeleaf:thymeleaf:2.1.5.RELEASE'
 
+    logbackClassic = 'ch.qos.logback:logback-classic:1.2.1'
+
+    logbackAccess = 'ch.qos.logback:logback-access:1.2.1'
+
     // test dependencies
     dropwizardTest = "io.dropwizard:dropwizard-testing:${dropwizard_version}"
     junit = ['junit:junit:4.12','org.hamcrest:hamcrest-library:1.3']


### PR DESCRIPTION
Version 1.1.7 of logback is getting flagged as having security vulnerabilities. This forces the application to use v1.2.1. 