### PR TITLE
Record should support entries with multiple items

### DIFF
--- a/src/main/java/uk/gov/register/core/Record.java
+++ b/src/main/java/uk/gov/register/core/Record.java
@@ -1,17 +1,37 @@
 package uk.gov.register.core;
 
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import uk.gov.register.util.HashValue;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 public class Record {
-    public final Entry entry;
-    public final Item item;
+    private final Entry entry;
+    private final Map<HashValue, Item> items = new HashMap<>();
 
     public Record(Entry entry, Item item) {
         this.entry = entry;
-        this.item = item;
+        this.items.put(item.getSha256hex(), item);
+    }
+
+    public Record(Entry entry, Iterable<Item> items) {
+        this.entry = entry;
+        items.forEach(i -> this.items.put(i.getSha256hex(), i));
+    }
+
+    public Entry getEntry() {
+        return entry;
+    }
+
+    public Item getItem() {
+        return items.get(entry.getSha256hex());
+    }
+
+    public Map<HashValue, Item> getItems() {
+        return items;
     }
 
     public static CsvSchema csvSchema(Iterable<String> fields) {
@@ -32,13 +52,13 @@ public class Record {
         Record record = (Record) o;
 
         if (!entry.equals(record.entry)) return false;
-        return item.equals(record.item);
+        return items.equals(record.items);
     }
 
     @Override
     public int hashCode() {
         int result = entry.hashCode();
-        result = 31 * result + item.hashCode();
+        result = 31 * result + items.hashCode();
         return result;
     }
 }

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -53,10 +53,6 @@ public class RecordResource {
                 .orElseThrow(NotFoundException::new);
     }
 
-    public Map<String, FieldValue> itemContent(Record record) {
-        return itemConverter.convertItem(record.item);
-    }
-
     @GET
     @Path("/record/{record-key}/entries")
     @Produces(ExtraMediaType.TEXT_HTML)

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -135,7 +135,7 @@ public class ViewFactory {
     }
 
     public RecordView getRecordMediaView(Record record) {
-        return new RecordView(record.entry, getItemMediaView(record.item), getFields());
+        return new RecordView(record.getEntry(), getItemMediaView(record.getItem()), getFields());
     }
 
     public RecordsView getRecordsMediaView(List<RecordView> recordViews) {

--- a/src/test/java/uk/gov/register/core/RecordTest.java
+++ b/src/test/java/uk/gov/register/core/RecordTest.java
@@ -1,0 +1,102 @@
+package uk.gov.register.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import uk.gov.register.util.HashValue;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
+
+public class RecordTest {
+    private final HashValue hash1 = new HashValue(HashingAlgorithm.SHA256, "hash1");
+    private final HashValue hash2 = new HashValue(HashingAlgorithm.SHA256, "hash2");
+
+    private final Item item1 = getItem("{\"key1\":\"value1\"}");
+    private final Item item2 = getItem("{\"key2\":\"value2\"}");
+    private final Item item3 = getItem("{\"key3\":\"value3\"}");
+
+    @Test
+    public void recordsShouldBeEqualWithSameEntryAndItems() throws IOException {
+        Record record1 = new Record(
+                new Entry(1, Arrays.asList(hash1, hash2), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item1, item2));
+        Record record2 = new Record(
+                new Entry(1, Arrays.asList(hash2, hash1), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item2, item1));
+
+        assertThat(record1.equals(record2), is(true));
+    }
+
+    @Test
+    public void recordsShouldHaveSameHashCodeWithSameEntryAndItems() throws IOException {
+        Record record1 = new Record(
+                new Entry(1, Arrays.asList(hash1, hash2), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item1, item2));
+        Record record2 = new Record(
+                new Entry(1, Arrays.asList(hash2, hash1), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item2, item1));
+
+        assertThat(record1.hashCode(), is(record2.hashCode()));
+    }
+
+    @Test
+    public void recordsShouldNotBeEqualWithDifferentEntry() throws IOException {
+        Record record1 = new Record(
+                new Entry(1, Arrays.asList(hash1, hash2), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item1, item2));
+        Record record2 = new Record(
+                new Entry(2, Arrays.asList(hash2, hash1), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item2, item1));
+
+        assertThat(record1.equals(record2), is(false));
+    }
+
+    @Test
+    public void recordsShouldHaveDifferentHashCodesWithDifferentEntry() throws IOException {
+        Record record1 = new Record(
+                new Entry(1, Arrays.asList(hash1, hash2), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item1, item2));
+        Record record2 = new Record(
+                new Entry(2, Arrays.asList(hash2, hash1), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item2, item1));
+
+        assertThat(record1.hashCode(), not(record2.hashCode()));
+    }
+
+    @Test
+    public void recordsShouldNotBeEqualWithDifferentItems() throws IOException {
+        Record record1 = new Record(
+                new Entry(1, Arrays.asList(hash1, hash2), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item1, item2));
+        Record record2 = new Record(
+                new Entry(1, Arrays.asList(hash2, hash1), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item2, item1, item3));
+
+        assertThat(record1.equals(record2), is(false));
+    }
+
+    @Test
+    public void recordsShouldHaveDifferentHashCodeWithDifferentItems() throws IOException {
+        Record record1 = new Record(
+                new Entry(1, Arrays.asList(hash1, hash2), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item1, item2));
+        Record record2 = new Record(
+                new Entry(1, Arrays.asList(hash2, hash1), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                Arrays.asList(item2, item1, item3));
+
+        assertThat(record1.hashCode(), not(record2.hashCode()));
+    }
+
+    private Item getItem(String json) {
+        try {
+            return new Item(new ObjectMapper().readTree(json));
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
We will remove the getters and constructors that allow single items later.
It may also be worth refactoring this record structure at some point as it does
not really represent a domain object - it is more of a view/structure.