### PR TITLE
Add index to entry_item table

### DIFF
--- a/src/main/resources/sql/V4__Index_on_entry_item_table.sql
+++ b/src/main/resources/sql/V4__Index_on_entry_item_table.sql
@@ -1,0 +1,2 @@
+create index if not exists entry_item_entry_number_index on entry_item (entry_number);
+create index if not exists entry_item_sha256hex_index on entry_item (sha256hex);


### PR DESCRIPTION
This PR adds some missing indexes as a new migration to the `entry_item` table.