### PR TITLE
TransactionalRecordIndex should allow for removal of current keys

### DIFF
--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -43,7 +43,13 @@ public class PostgresRegister implements Register {
     @Override
     public void appendEntry(Entry entry) {
         entryLog.appendEntry(entry);
-        recordIndex.updateRecordIndex(entry.getKey(), entry.getEntryNumber());
+
+        if (!entry.getItemHashes().isEmpty()) {
+            recordIndex.updateRecordIndex(entry.getKey(), entry.getEntryNumber());
+        }
+        else {
+            recordIndex.removeRecordIndex(entry.getKey());
+        }
     }
 
     public void commit() {

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -43,13 +43,7 @@ public class PostgresRegister implements Register {
     @Override
     public void appendEntry(Entry entry) {
         entryLog.appendEntry(entry);
-
-        if (!entry.getItemHashes().isEmpty()) {
-            recordIndex.updateRecordIndex(entry.getKey(), entry.getEntryNumber());
-        }
-        else {
-            recordIndex.removeRecordIndex(entry.getKey());
-        }
+        recordIndex.updateRecordIndex(entry);
     }
 
     public void commit() {

--- a/src/main/java/uk/gov/register/core/RecordIndex.java
+++ b/src/main/java/uk/gov/register/core/RecordIndex.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 public interface RecordIndex {
     void updateRecordIndex(String key, Integer entryNumber);
 
+    void removeRecordIndex(String key);
+
     Optional<Record> getRecord(String key);
 
     int getTotalRecords();

--- a/src/main/java/uk/gov/register/core/RecordIndex.java
+++ b/src/main/java/uk/gov/register/core/RecordIndex.java
@@ -5,9 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface RecordIndex {
-    void updateRecordIndex(String key, Integer entryNumber);
-
-    void removeRecordIndex(String key);
+    void updateRecordIndex(Entry entry);
 
     Optional<Record> getRecord(String key);
 

--- a/src/main/java/uk/gov/register/db/TransactionalRecordIndex.java
+++ b/src/main/java/uk/gov/register/db/TransactionalRecordIndex.java
@@ -3,31 +3,51 @@ package uk.gov.register.db;
 import com.google.common.collect.Iterables;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 public class TransactionalRecordIndex extends AbstractRecordIndex {
-    private final HashMap<String, Integer> stagedCurrentKeys;
+    private final Set<String> stagedCurrentKeysForRemoval;
+    private final HashMap<String, Integer> stagedCurrentKeysForAddition;
     private final CurrentKeysUpdateDAO currentKeysDAO;
 
     public TransactionalRecordIndex(RecordQueryDAO recordQueryDAO, CurrentKeysUpdateDAO currentKeysDAO) {
         super(recordQueryDAO);
         this.currentKeysDAO = currentKeysDAO;
-        stagedCurrentKeys = new HashMap<>();
+        stagedCurrentKeysForAddition = new HashMap<>();
+        stagedCurrentKeysForRemoval = new HashSet<>();
     }
 
     @Override
     public void updateRecordIndex(String key, Integer entryNumber) {
-        stagedCurrentKeys.put(key, entryNumber);
+        stagedCurrentKeysForAddition.put(key, entryNumber);
+    }
+
+    @Override
+    public void removeRecordIndex(String key) {
+        if (stagedCurrentKeysForAddition.containsKey(key)) {
+            stagedCurrentKeysForAddition.remove(key);
+        }
+        else {
+            stagedCurrentKeysForRemoval.add(key);
+        }
     }
 
     @Override
     public void checkpoint() {
-        int[] noOfRecordsDeletedPerBatch = currentKeysDAO.removeRecordWithKeys(stagedCurrentKeys.keySet());
-        int noOfRecordsDeleted = IntStream.of(noOfRecordsDeletedPerBatch).sum();
-        currentKeysDAO.writeCurrentKeys(Iterables.transform(stagedCurrentKeys.entrySet(),
+        int noOfRecordsDeleted = removeRecordsWithKeys(stagedCurrentKeysForAddition.keySet()) + removeRecordsWithKeys(stagedCurrentKeysForRemoval);
+
+        currentKeysDAO.writeCurrentKeys(Iterables.transform(stagedCurrentKeysForAddition.entrySet(),
                 keyValue -> new CurrentKey(keyValue.getKey(), keyValue.getValue()))
         );
-        currentKeysDAO.updateTotalRecords(stagedCurrentKeys.size() - noOfRecordsDeleted);
-        stagedCurrentKeys.clear();
+        currentKeysDAO.updateTotalRecords(stagedCurrentKeysForAddition.size() - noOfRecordsDeleted);
+        stagedCurrentKeysForAddition.clear();
+        stagedCurrentKeysForRemoval.clear();
+    }
+
+    private int removeRecordsWithKeys(Iterable<String> keySet) {
+        int[] noOfRecordsDeletedPerBatch = currentKeysDAO.removeRecordWithKeys(keySet);
+        return IntStream.of(noOfRecordsDeletedPerBatch).sum();
     }
 }

--- a/src/main/java/uk/gov/register/db/UnmodifiableRecordIndex.java
+++ b/src/main/java/uk/gov/register/db/UnmodifiableRecordIndex.java
@@ -1,5 +1,7 @@
 package uk.gov.register.db;
 
+import uk.gov.register.core.Entry;
+
 import javax.inject.Inject;
 
 public class UnmodifiableRecordIndex extends AbstractRecordIndex {
@@ -9,12 +11,7 @@ public class UnmodifiableRecordIndex extends AbstractRecordIndex {
     }
 
     @Override
-    public void updateRecordIndex(String key, Integer entryNumber) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void removeRecordIndex(String key) {
+    public void updateRecordIndex(Entry entry) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/uk/gov/register/db/UnmodifiableRecordIndex.java
+++ b/src/main/java/uk/gov/register/db/UnmodifiableRecordIndex.java
@@ -14,6 +14,11 @@ public class UnmodifiableRecordIndex extends AbstractRecordIndex {
     }
 
     @Override
+    public void removeRecordIndex(String key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void checkpoint() {
         // do nothing
     }

--- a/src/test/java/uk/gov/register/db/TransactionalRecordIndexTest.java
+++ b/src/test/java/uk/gov/register/db/TransactionalRecordIndexTest.java
@@ -117,4 +117,51 @@ public class TransactionalRecordIndexTest {
         assertThat(currentKeys.size(), is(4));
         assertThat(currentKeysUpdateDAO.getTotalRecords(), is(4));
     }
+
+    @Test
+    public void removeRecordIndex_shouldUpdateCurrentKeysAndTotalRecords_whenKeyExistsInDatabase() {
+        recordIndex.updateRecordIndex("DE", 1);
+        recordIndex.updateRecordIndex("VA", 2);
+        recordIndex.updateRecordIndex("DE", 3);
+        recordIndex.checkpoint();
+
+        assertThat(currentKeys.size(), is(2));
+        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
+
+        recordIndex.removeRecordIndex("DE");
+        recordIndex.checkpoint();
+
+        assertThat(currentKeys.size(), is(1));
+        assertThat(currentKeys.containsKey("DE"), is(false));
+        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(1));
+    }
+
+    @Test
+    public void removeRecordIndex_shouldNotUpdateCurrentKeysAndTotalRecords_whenKeyExistsInStagedData() {
+        recordIndex.updateRecordIndex("DE", 1);
+        recordIndex.updateRecordIndex("VA", 2);
+        recordIndex.removeRecordIndex("DE");
+        recordIndex.checkpoint();
+
+        assertThat(currentKeys.size(), is(1));
+        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(1));
+        assertThat(currentKeys.containsKey("DE"), is(false));
+    }
+
+    @Test
+    public void removeRecordIndex_shouldNotUpdateCurrentKeysAndTotalRecords_whenKeyDoesNotExistInStagedDataOrDatabase() {
+        recordIndex.updateRecordIndex("DE", 1);
+        recordIndex.updateRecordIndex("VA", 2);
+        recordIndex.checkpoint();
+
+        assertThat(currentKeys.size(), is(2));
+        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
+
+        recordIndex.removeRecordIndex("CZ");
+        recordIndex.checkpoint();
+
+        assertThat(currentKeys.size(), is(2));
+        assertThat(currentKeys.containsKey("CZ"), is(false));
+        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
+    }
 }

--- a/src/test/java/uk/gov/register/db/TransactionalRecordIndexTest.java
+++ b/src/test/java/uk/gov/register/db/TransactionalRecordIndexTest.java
@@ -6,8 +6,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.core.Entry;
+import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Record;
+import uk.gov.register.util.HashValue;
 
+import java.time.Instant;
 import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,14 +34,14 @@ public class TransactionalRecordIndexTest {
 
     @Test
     public void updateRecordIndex_shouldNotCommitChanges() throws Exception {
-        recordIndex.updateRecordIndex("foo", 5);
+        recordIndex.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo"));
 
         assertThat(currentKeys.entrySet(), is(empty()));
     }
 
     @Test
     public void getRecord_shouldCauseCheckpoint() {
-        recordIndex.updateRecordIndex("foo", 5);
+        recordIndex.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo"));
 
         Optional<Record> ignored = recordIndex.getRecord("foo");
 
@@ -48,7 +51,7 @@ public class TransactionalRecordIndexTest {
 
     @Test
     public void getRecords_shouldCauseCheckpoint() {
-        recordIndex.updateRecordIndex("foo", 5);
+        recordIndex.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo"));
 
         List<Record> ignored = recordIndex.getRecords(1,0);
 
@@ -58,7 +61,7 @@ public class TransactionalRecordIndexTest {
 
     @Test
     public void findMax100RecordsByKeyValue_shouldCauseCheckpoint() {
-        recordIndex.updateRecordIndex("foo", 5);
+        recordIndex.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo"));
 
         List<Record> ignored = recordIndex.findMax100RecordsByKeyValue("foo", "bar");
 
@@ -68,7 +71,7 @@ public class TransactionalRecordIndexTest {
 
     @Test
     public void findAllEntriesOfRecordBy_shouldCauseCheckpoint() {
-        recordIndex.updateRecordIndex("foo", 5);
+        recordIndex.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo"));
 
         Collection<Entry> ignored = recordIndex.findAllEntriesOfRecordBy("bar");
 
@@ -78,7 +81,7 @@ public class TransactionalRecordIndexTest {
 
     @Test
     public void getTotalRecords_shouldCauseCheckpoint() {
-        recordIndex.updateRecordIndex("foo", 5);
+        recordIndex.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo"));
 
         int ignored = recordIndex.getTotalRecords();
 
@@ -88,9 +91,9 @@ public class TransactionalRecordIndexTest {
 
     @Test
     public void insertRecordWithSameKeyValueDoesNotStageBothCurrentKeys() {
-        recordIndex.updateRecordIndex("DE", 1);
-        recordIndex.updateRecordIndex("VA", 2);
-        recordIndex.updateRecordIndex("DE", 3);
+        recordIndex.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE"));
+        recordIndex.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "va"), Instant.now(), "VA"));
+        recordIndex.updateRecordIndex(new Entry(3, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE"));
 
         assertThat(currentKeys.entrySet(), is(empty()));
 
@@ -103,15 +106,15 @@ public class TransactionalRecordIndexTest {
 
     @Test
     public void whenInserting_shouldUpdateRecordCount() throws Exception {
-        recordIndex.updateRecordIndex("DE", 1);
-        recordIndex.updateRecordIndex("VA", 2);
-        recordIndex.updateRecordIndex("DE", 3);
+        recordIndex.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE"));
+        recordIndex.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "va"), Instant.now(), "VA"));
+        recordIndex.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE"));
         recordIndex.checkpoint(); // force writing staged data
 
         assertThat(currentKeys.size(), is(2));
         assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
-        recordIndex.updateRecordIndex("CZ", 4);
-        recordIndex.updateRecordIndex("TV", 5);
+        recordIndex.updateRecordIndex(new Entry(4, new HashValue(HashingAlgorithm.SHA256, "cz"), Instant.now(), "CZ"));
+        recordIndex.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "tv"), Instant.now(), "TV"));
         recordIndex.checkpoint();
 
         assertThat(currentKeys.size(), is(4));
@@ -119,49 +122,66 @@ public class TransactionalRecordIndexTest {
     }
 
     @Test
-    public void removeRecordIndex_shouldUpdateCurrentKeysAndTotalRecords_whenKeyExistsInDatabase() {
-        recordIndex.updateRecordIndex("DE", 1);
-        recordIndex.updateRecordIndex("VA", 2);
-        recordIndex.updateRecordIndex("DE", 3);
+    public void updateRecordIndex_shouldUpdateTotalRecords_whenKeyExistsInDatabaseAndEntryContainsNoItems() {
+        recordIndex.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE"));
+        recordIndex.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cz"), Instant.now(), "CZ"));
         recordIndex.checkpoint();
 
         assertThat(currentKeys.size(), is(2));
         assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
 
-        recordIndex.removeRecordIndex("DE");
+        recordIndex.updateRecordIndex(new Entry(3, Collections.emptyList(), Instant.now(), "DE"));
         recordIndex.checkpoint();
 
-        assertThat(currentKeys.size(), is(1));
-        assertThat(currentKeys.containsKey("DE"), is(false));
+        assertThat(currentKeys.size(), is(2));
+        assertThat(currentKeys.containsKey("DE"), is(true));
         assertThat(currentKeysUpdateDAO.getTotalRecords(), is(1));
     }
 
     @Test
-    public void removeRecordIndex_shouldNotUpdateCurrentKeysAndTotalRecords_whenKeyExistsInStagedData() {
-        recordIndex.updateRecordIndex("DE", 1);
-        recordIndex.updateRecordIndex("VA", 2);
-        recordIndex.removeRecordIndex("DE");
-        recordIndex.checkpoint();
-
-        assertThat(currentKeys.size(), is(1));
-        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(1));
-        assertThat(currentKeys.containsKey("DE"), is(false));
-    }
-
-    @Test
-    public void removeRecordIndex_shouldNotUpdateCurrentKeysAndTotalRecords_whenKeyDoesNotExistInStagedDataOrDatabase() {
-        recordIndex.updateRecordIndex("DE", 1);
-        recordIndex.updateRecordIndex("VA", 2);
+    public void updateRecordIndex_shouldUpdateCurrentKeysAndTotalRecords_whenKeyExistsInDatabase() {
+        recordIndex.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE"));
+        recordIndex.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "va"), Instant.now(), "VA"));
+        recordIndex.updateRecordIndex(new Entry(3, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE"));
         recordIndex.checkpoint();
 
         assertThat(currentKeys.size(), is(2));
         assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
 
-        recordIndex.removeRecordIndex("CZ");
+        recordIndex.updateRecordIndex(new Entry(4, Collections.emptyList(), Instant.now(), "DE"));
         recordIndex.checkpoint();
 
         assertThat(currentKeys.size(), is(2));
-        assertThat(currentKeys.containsKey("CZ"), is(false));
+        assertThat(currentKeys.containsKey("DE"), is(true));
+        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(1));
+    }
+
+    @Test
+    public void updateRecordIndex_shouldNotUpdateCurrentKeysAndTotalRecords_whenKeyExistsInStagedData() {
+        recordIndex.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE"));
+        recordIndex.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "va"), Instant.now(), "VA"));
+        recordIndex.updateRecordIndex(new Entry(3, Collections.emptyList(), Instant.now(), "DE"));
+        recordIndex.checkpoint();
+
+        assertThat(currentKeys.size(), is(2));
+        assertThat(currentKeys.containsKey("DE"), is(true));
+        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(1));
+    }
+
+    @Test
+    public void updateRecordIndex_shouldNotUpdateCurrentKeysAndTotalRecords_whenKeyDoesNotExistInStagedDataOrDatabase() {
+        recordIndex.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE"));
+        recordIndex.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "va"), Instant.now(), "VA"));
+        recordIndex.checkpoint();
+
+        assertThat(currentKeys.size(), is(2));
+        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
+
+        recordIndex.updateRecordIndex(new Entry(3, Collections.emptyList(), Instant.now(), "CZ"));
+        recordIndex.checkpoint();
+
+        assertThat(currentKeys.size(), is(3));
+        assertThat(currentKeys.containsKey("CZ"), is(true));
         assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
     }
 }


### PR DESCRIPTION
This PR modifies `TransactionalRecordIndex` to allow current keys to be removed and the total record count decremented accordingly. This is to support the feature commonly known as 'tomb-stoning', which may be useful in the context where a register's main dataset is the result of a previous derivation (for example, local authorities by local authority type), where the items stored may change groups over time.