### PR TITLE
Change download-rsf to support multi-item entries

### DIFF
--- a/src/main/java/uk/gov/register/serialization/mappers/EntryToCommandMapper.java
+++ b/src/main/java/uk/gov/register/serialization/mappers/EntryToCommandMapper.java
@@ -3,13 +3,21 @@ package uk.gov.register.serialization.mappers;
 import uk.gov.register.core.Entry;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.serialization.RegisterCommandMapper;
+import uk.gov.register.util.HashValue;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 public class EntryToCommandMapper extends RegisterCommandMapper<Entry,RegisterCommand> {
     @Override
     public RegisterCommand apply(Entry entry) {
-        return new RegisterCommand("append-entry", Arrays.asList(entry.getTimestampAsISOFormat(), entry.getSha256hex().encode(), entry.getKey()));
+        return new RegisterCommand("append-entry", Arrays.asList(entry.getTimestampAsISOFormat(), toDelimited(entry.getItemHashes()), entry.getKey()));
     }
+
+    private String toDelimited(Collection<HashValue> hashValues) {
+        return hashValues.stream().map(HashValue::encode).collect(Collectors.joining(";"));
+    }
+
 }
 

--- a/src/test/java/uk/gov/register/serialization/mappers/EntryToCommandMapperTest.java
+++ b/src/test/java/uk/gov/register/serialization/mappers/EntryToCommandMapperTest.java
@@ -1,7 +1,8 @@
 package uk.gov.register.serialization.mappers;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.serialization.RegisterCommand;
@@ -10,8 +11,8 @@ import uk.gov.register.util.HashValue;
 import java.time.Instant;
 import java.util.Arrays;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import org.junit.Before;
+import org.junit.Test;
 
 public class EntryToCommandMapperTest {
     private EntryToCommandMapper sutMapper;
@@ -29,5 +30,18 @@ public class EntryToCommandMapperTest {
 
         assertThat(mapResult.getCommandName(), equalTo("append-entry"));
         assertThat(mapResult.getCommandArguments(), equalTo(Arrays.asList("2016-07-24T16:55:00Z", "sha-256:item-sha", "entry1-field-1-value")));
+    }
+
+    @Test
+    public void apply_returnsAppendEntryCommandForEntryWithMultipleItems() {
+        Entry entryToMap = new Entry(1, Arrays.asList(
+                new HashValue(HashingAlgorithm.SHA256, "item-sha"),
+                new HashValue(HashingAlgorithm.SHA256, "item-sha2")),
+                Instant.parse("2016-07-24T16:55:00Z"), "entry1-field-1-value");
+
+        RegisterCommand mapResult = sutMapper.apply(entryToMap);
+
+        assertThat(mapResult.getCommandName(), equalTo("append-entry"));
+        assertThat(mapResult.getCommandArguments(), equalTo(Arrays.asList("2016-07-24T16:55:00Z", "sha-256:item-sha;sha-256:item-sha2", "entry1-field-1-value")));
     }
 }


### PR DESCRIPTION
Previously when you downloaded the RSF it would only include the first SHA. This update renders item SHA's individually separated by a ; for each entry.