### PR TITLE
Time all Dropwizard Resource methods

### DIFF
--- a/src/main/java/uk/gov/register/resources/DataDownload.java
+++ b/src/main/java/uk/gov/register/resources/DataDownload.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.views.View;
 import uk.gov.register.configuration.ResourceConfiguration;
 import uk.gov.register.core.*;
@@ -45,6 +46,7 @@ public class DataDownload {
     @Path("/download-register")
     @Produces({MediaType.APPLICATION_OCTET_STREAM, ExtraMediaType.TEXT_HTML})
     @DownloadNotAvailable
+    @Timed
     public Response downloadRegister() {
         Collection<Entry> entries = register.getAllEntries();
         Collection<Item> items = register.getAllItems();
@@ -70,6 +72,7 @@ public class DataDownload {
     @Path("/download-rsf")
     @Produces({ExtraMediaType.APPLICATION_RSF, ExtraMediaType.TEXT_HTML})
     @DownloadNotAvailable
+    @Timed
     public Response downloadRSF() {
         String rsfFileName = String.format("attachment; filename=rsf-%d.%s", System.currentTimeMillis(), rsfFormatter.getFileExtension());
         return Response
@@ -81,6 +84,7 @@ public class DataDownload {
     @Path("/download-rsf/{total-entries-1}/{total-entries-2}")
     @Produces({ExtraMediaType.APPLICATION_RSF, ExtraMediaType.TEXT_HTML})
     @DownloadNotAvailable
+    @Timed
     public Response downloadPartialRSF(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) {
         if (totalEntries1 < 0) {
             throw new BadRequestException("total-entries-1 must be 0 or greater");
@@ -105,6 +109,7 @@ public class DataDownload {
     @GET
     @Path("/download")
     @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
     public View download() {
         return viewFactory.downloadPageView(resourceConfiguration.getEnableDownloadResource());
     }

--- a/src/main/java/uk/gov/register/resources/DataUpload.java
+++ b/src/main/java/uk/gov/register/resources/DataUpload.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
@@ -54,6 +55,7 @@ public class DataUpload {
     @POST
     @PermitAll
     @Path("/load")
+    @Timed
     public void load(String payload) {
         try {
             Iterable<JsonNode> objects = objectReconstructor.reconstructWithCanonicalization(payload.split("\n"));
@@ -69,6 +71,7 @@ public class DataUpload {
     @Consumes(ExtraMediaType.APPLICATION_RSF)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/load-rsf")
+    @Timed
     public Response loadRsf(InputStream inputStream) {
         RegisterResult loadResult;
         try {

--- a/src/main/java/uk/gov/register/resources/DeleteRegisterDataResource.java
+++ b/src/main/java/uk/gov/register/resources/DeleteRegisterDataResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.RegisterContext;
 import uk.gov.register.exceptions.NoSuchConfigException;
 
@@ -23,6 +24,7 @@ public class DeleteRegisterDataResource {
     @PermitAll
     @Path("/delete-register-data")
     @DataDeleteNotAllowed
+    @Timed
     public Response deleteRegisterData() throws NoSuchConfigException, IOException {
         registerContext.resetRegister();
 

--- a/src/main/java/uk/gov/register/resources/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/EntryResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.jersey.params.IntParam;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.RegisterName;
@@ -38,6 +39,7 @@ public class EntryResource {
     @GET
     @Path("/entry/{entry-number}")
     @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
     public AttributionView<Entry> findByEntryNumberHtml(@PathParam("entry-number") int entryNumber) {
         Optional<Entry> entry = findByEntryNumber(entryNumber);
         return entry.map(viewFactory::getEntryView).orElseThrow(NotFoundException::new);
@@ -46,6 +48,7 @@ public class EntryResource {
     @GET
     @Path("/entry/{entry-number}")
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Timed
     public Optional<Entry> findByEntryNumber(@PathParam("entry-number") int entryNumber) {
         return register.getEntry(entryNumber);
     }
@@ -53,6 +56,7 @@ public class EntryResource {
     @GET
     @Path("/entries")
     @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
     public PaginatedView<EntryListView> entriesHtml(@QueryParam("start") Optional<IntegerParam> optionalStart, @QueryParam("limit") Optional<IntegerParam> optionalLimit) {
         int totalEntries = register.getTotalEntries();
         StartLimitPagination startLimitPagination = new StartLimitPagination(optionalStart.map(IntParam::get), optionalLimit.map(IntParam::get), totalEntries);
@@ -67,6 +71,7 @@ public class EntryResource {
     @GET
     @Path("/entries")
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Timed
     public EntryListView entries(@QueryParam("start") Optional<IntegerParam> optionalStart, @QueryParam("limit") Optional<IntegerParam> optionalLimit) {
         int totalEntries = register.getTotalEntries();
         StartLimitPagination startLimitPagination = new StartLimitPagination(optionalStart.map(IntParam::get), optionalLimit.map(IntParam::get), totalEntries);

--- a/src/main/java/uk/gov/register/resources/HomePageResource.java
+++ b/src/main/java/uk/gov/register/resources/HomePageResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.views.View;
 import uk.gov.register.configuration.RegisterTrackingConfiguration;
 import uk.gov.register.core.RegisterReadOnly;
@@ -13,6 +14,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/")
+@Timed
 public class HomePageResource {
     private final RegisterReadOnly register;
     private final ViewFactory viewFactory;
@@ -27,6 +29,7 @@ public class HomePageResource {
 
     @GET
     @Produces({ExtraMediaType.TEXT_HTML})
+    @Timed
     public View home() {
         return viewFactory.homePageView(
                 register.getTotalRecords(),
@@ -38,6 +41,7 @@ public class HomePageResource {
     @GET
     @Path("/robots.txt")
     @Produces(MediaType.TEXT_PLAIN)
+    @Timed
     public String robots() {
         return "User-agent: *\n" +
                 "Disallow: /\n";
@@ -46,6 +50,7 @@ public class HomePageResource {
     @GET
     @Path("/analytics-code.js")
     @Produces(ExtraMediaType.APPLICATION_JAVASCRIPT)
+    @Timed
     public String analyticsTrackingId() {
         return config.getRegisterTrackingId().map(
                 trackingId -> "var gaTrackingId = \"" + trackingId + "\";\n"

--- a/src/main/java/uk/gov/register/resources/ItemResource.java
+++ b/src/main/java/uk/gov/register/resources/ItemResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.*;
 import uk.gov.register.service.ItemConverter;
 import uk.gov.register.util.HashValue;
@@ -28,6 +29,7 @@ public class ItemResource {
     @GET
     @Path("/sha-256:{item-hash}")
     @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
     public AttributionView<ItemView> getItemWebViewByHex(@PathParam("item-hash") String itemHash) {
         return getItem(itemHash).map(viewFactory::getItemView)
                 .orElseThrow(() -> new NotFoundException("No item found with item hash: " + itemHash));
@@ -36,6 +38,7 @@ public class ItemResource {
     @GET
     @Path("/sha-256:{item-hash}")
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_TTL, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV})
+    @Timed
     public ItemView getItemDataByHex(@PathParam("item-hash") String itemHash) {
         return getItem(itemHash).map(viewFactory::getItemMediaView)
                 .orElseThrow(() -> new NotFoundException("No item found with item hash: " + itemHash));

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.jersey.params.IntParam;
 import uk.gov.register.core.*;
 import uk.gov.register.providers.params.IntegerParam;
@@ -39,6 +40,7 @@ public class RecordResource {
     @GET
     @Path("/record/{record-key}")
     @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
     public AttributionView<RecordView> getRecordByKeyHtml(@PathParam("record-key") String key) {
         return viewFactory.getRecordView(getRecordByKey(key));
     }
@@ -46,6 +48,7 @@ public class RecordResource {
     @GET
     @Path("/record/{record-key}")
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Timed
     public RecordView getRecordByKey(@PathParam("record-key") String key) {
         httpServletResponseAdapter.addLinkHeader("version-history", String.format("/record/%s/entries", key));
 
@@ -56,6 +59,7 @@ public class RecordResource {
     @GET
     @Path("/record/{record-key}/entries")
     @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
     public PaginatedView<EntryListView> getAllEntriesOfARecordHtml(@PathParam("record-key") String key) {
         Collection<Entry> allEntries = register.allEntriesOfRecord(key);
         if (allEntries.isEmpty()) {
@@ -70,6 +74,7 @@ public class RecordResource {
     @GET
     @Path("/record/{record-key}/entries")
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Timed
     public EntryListView getAllEntriesOfARecord(@PathParam("record-key") String key) {
         Collection<Entry> allEntries = register.allEntriesOfRecord(key);
         if (allEntries.isEmpty()) {
@@ -81,6 +86,7 @@ public class RecordResource {
     @GET
     @Path("/records/{key}/{value}")
     @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
     public PaginatedView<RecordsView> facetedRecordsHtml(@PathParam("key") String key, @PathParam("value") String value) {
         List<Record> records = register.max100RecordsFacetedByKeyValue(key, value);
         Pagination pagination
@@ -91,6 +97,7 @@ public class RecordResource {
     @GET
     @Path("/records/{key}/{value}")
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Timed
     public RecordsView facetedRecords(@PathParam("key") String key, @PathParam("value") String value) {
         List<Record> records = register.max100RecordsFacetedByKeyValue(key, value);
         List<RecordView> recordViews = records.stream().map(viewFactory::getRecordMediaView).collect(toList());
@@ -100,6 +107,7 @@ public class RecordResource {
     @GET
     @Path("/records")
     @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
     public PaginatedView<RecordsView> recordsHtml(@QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntegerParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntegerParam> pageSize) {
         IndexSizePagination pagination = setUpPagination(pageIndex, pageSize);
         setContentDisposition();
@@ -110,6 +118,7 @@ public class RecordResource {
     @GET
     @Path("/records")
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Timed
     public RecordsView records(@QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntegerParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntegerParam> pageSize) {
         IndexSizePagination pagination = setUpPagination(pageIndex, pageSize);
         setContentDisposition();

--- a/src/main/java/uk/gov/register/resources/RegisterResource.java
+++ b/src/main/java/uk/gov/register/resources/RegisterResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.views.RegisterDetailView;
 import uk.gov.register.views.ViewFactory;
@@ -25,6 +26,7 @@ public class RegisterResource {
     @GET
     @Path("/register")
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML})
+    @Timed
     public RegisterDetailView getRegisterDetail() {
         return viewFactory.registerDetailView(
                 register.getTotalRecords(),

--- a/src/main/java/uk/gov/register/resources/SearchResource.java
+++ b/src/main/java/uk/gov/register/resources/SearchResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
 import uk.gov.register.core.RegisterName;
 import uk.gov.register.views.representations.ExtraMediaType;
@@ -29,6 +30,7 @@ public class SearchResource {
     @GET
     @Path("/{key}/{value}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Timed
     public Object find(@PathParam("key") String key, @PathParam("value") String value) throws Exception {
         if (!key.equals(registerPrimaryKey.value()) && !registerFieldsConfiguration.containsField(key)) {
             throw new NotFoundException();

--- a/src/main/java/uk/gov/register/resources/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/VerifiableLogResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
@@ -21,6 +22,7 @@ public class VerifiableLogResource {
     @GET
     @Path("/register/merkle:sha-256")
     @Produces(MediaType.APPLICATION_JSON)
+    @Timed
     public RegisterProof registerProof() {
         return register.getRegisterProof();
     }
@@ -28,6 +30,7 @@ public class VerifiableLogResource {
     @GET
     @Path("/entry/{entry-number}/{total-entries}/merkle:sha-256")
     @Produces(MediaType.APPLICATION_JSON)
+    @Timed
     public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) {
         validateEntryProofParams(entryNumber, totalEntries);
         return register.getEntryProof(entryNumber, totalEntries);
@@ -36,6 +39,7 @@ public class VerifiableLogResource {
     @GET
     @Path("/consistency/{total-entries-1}/{total-entries-2}/merkle:sha-256")
     @Produces(MediaType.APPLICATION_JSON)
+    @Timed
     public ConsistencyProof consistencyProof(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) {
         validateConsistencyProofParams(totalEntries1, totalEntries2);
         return register.getConsistencyProof(totalEntries1, totalEntries2);


### PR DESCRIPTION
This means we output some metrics for each resource, for example for
the `/robots.txt` path we'll start generating metrics that look like the
following:

```
uk.gov.register.resources.HomePageResource.robots
             count = 15
         mean rate = 1.21 calls/second
     1-minute rate = 0.05 calls/second
     5-minute rate = 0.01 calls/second
    15-minute rate = 0.00 calls/second
               min = 0.10 milliseconds
               max = 7.64 milliseconds
              mean = 0.61 milliseconds
            stddev = 1.85 milliseconds
            median = 0.12 milliseconds
              75% <= 0.14 milliseconds
              95% <= 7.64 milliseconds
              98% <= 7.64 milliseconds
              99% <= 7.64 milliseconds
            99.9% <= 7.64 milliseconds
```

At the moment this won't provide a per-register time for these
resources. If we want to do that we'll probably need to change the way
Dropwizard behaves when reflecting over methods with the `Timed`
annotation. Probably will have to look at:

```
com.codahale.metrics.jersey2.InstrumentedResourceMethodApplicationListener
```