### PR TITLE
Write to index on append entry

### DIFF
--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -84,8 +84,9 @@ public class RegisterContext implements
                 getRegisterFieldsConfiguration(),
                 new UnmodifiableEntryLog(memoizationStore.get(), dbi.onDemand(EntryQueryDAO.class)),
                 new UnmodifiableItemStore(dbi.onDemand(ItemQueryDAO.class)),
-                new UnmodifiableRecordIndex(dbi.onDemand(RecordQueryDAO.class))
-        );
+                new UnmodifiableRecordIndex(dbi.onDemand(RecordQueryDAO.class)),
+                dbi.onDemand(IndexDAO.class),
+                dbi.onDemand(IndexQueryDAO.class));
     }
 
     private Register buildTransactionalRegister(Handle handle, TransactionalMemoizationStore memoizationStore) {
@@ -101,8 +102,9 @@ public class RegisterContext implements
                         new ItemValidator(configManager, registerName)),
                 new TransactionalRecordIndex(
                         handle.attach(RecordQueryDAO.class),
-                        handle.attach(CurrentKeysUpdateDAO.class))
-        );
+                        handle.attach(CurrentKeysUpdateDAO.class)),
+                handle.attach(IndexDAO.class),
+                handle.attach(IndexQueryDAO.class));
     }
 
     public void transactionalRegisterOperation(Consumer<Register> consumer) {

--- a/src/main/java/uk/gov/register/db/IndexDAO.java
+++ b/src/main/java/uk/gov/register/db/IndexDAO.java
@@ -1,0 +1,12 @@
+package uk.gov.register.db;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+public interface IndexDAO {
+    @SqlUpdate("insert into index (name, key, sha256hex, start_entry_number, start_index_entry_number) values (:name, :key, :sha256hex, :start_entry_number, :start_index_entry_number)")
+    void start(@Bind("name") String indexName, @Bind("key") String key, @Bind("sha256hex") String itemHash, @Bind("start_entry_number") int startEntryNumber, @Bind("start_index_entry_number") int startIndexEntryNumber);
+
+    @SqlUpdate("update index set end_entry_number = :end_entry_number, end_index_entry_number = :end_index_entry_number where name = :name and key = :key and sha256hex = :sha256hex")
+    void end(@Bind("name") String indexName, @Bind("key") String key, @Bind("sha256hex") String itemHash, @Bind("end_entry_number") int endEntryNumber, @Bind("end_index_entry_number") int endIndexEntryNumber);
+}

--- a/src/main/java/uk/gov/register/db/IndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/IndexQueryDAO.java
@@ -1,0 +1,9 @@
+package uk.gov.register.db;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+
+public interface IndexQueryDAO {
+    @SqlQuery("select max(r.index_entry_number) from (select greatest(start_index_entry_number, end_index_entry_number) as index_entry_number from index where name = :name) r")
+    int getCurrentIndexEntryNumber(@Bind("name") String indexName);
+}

--- a/src/main/java/uk/gov/register/indexer/IndexDriver.java
+++ b/src/main/java/uk/gov/register/indexer/IndexDriver.java
@@ -1,0 +1,85 @@
+package uk.gov.register.indexer;
+
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.Record;
+import uk.gov.register.core.Register;
+import uk.gov.register.db.IndexDAO;
+import uk.gov.register.db.IndexQueryDAO;
+import uk.gov.register.indexer.function.IndexFunction;
+
+import java.util.*;
+
+public class IndexDriver {
+    private final Register register;
+    private final IndexDAO indexDAO;
+    private final IndexQueryDAO indexQueryDAO;
+
+    public IndexDriver(Register register, IndexDAO indexDAO, IndexQueryDAO indexQueryDAO) {
+        this.indexDAO = indexDAO;
+        this.register = register;
+        this.indexQueryDAO = indexQueryDAO;
+    }
+
+    public void indexEntry(Entry entry, IndexFunction indexFunction) {
+        register.commit();
+        Optional<Record> currentRecord = register.getRecord(entry.getKey());
+        Set<IndexValueItemPair> currentIndexValueItemPairs = new HashSet<>();
+        if (currentRecord.isPresent()) {
+            currentIndexValueItemPairs.addAll(indexFunction.execute(currentRecord.get().getEntry()));
+        }
+
+        Set<IndexValueItemPair> newIndexValueItemPairs = indexFunction.execute(entry);
+
+        List<IndexValueItemPairEvent> pairEvents = getEndIndices(currentIndexValueItemPairs, newIndexValueItemPairs);
+        pairEvents.addAll(getStartIndices(currentIndexValueItemPairs, newIndexValueItemPairs));
+
+        TreeMap<String, List<IndexValueItemPairEvent>> sortedEvents = new TreeMap<>();
+        pairEvents.forEach(e -> {
+            if (!sortedEvents.containsKey(e.getIndexValue())) {
+                sortedEvents.put(e.getIndexValue(), new ArrayList<>());
+            }
+
+            sortedEvents.get(e.getIndexValue()).add(e);
+        });
+
+        int currentIndexEntryNumber = indexQueryDAO.getCurrentIndexEntryNumber(indexFunction.getName());
+        int currentEntryNumber = entry.getEntryNumber();
+
+        for (Map.Entry<String, List<IndexValueItemPairEvent>> keyValuePair : sortedEvents.entrySet()) {
+            currentIndexEntryNumber++;
+
+            for (IndexValueItemPairEvent p : keyValuePair.getValue()) {
+                if (p.isStart()) {
+                    indexDAO.start(indexFunction.getName(), p.getIndexValue(), p.getItemHash().getValue(), currentEntryNumber, currentIndexEntryNumber);
+                }
+                else {
+                    indexDAO.end(indexFunction.getName(), p.getIndexValue(), p.getItemHash().getValue(), currentEntryNumber, currentIndexEntryNumber);
+                }
+            }
+        }
+    }
+
+    protected List<IndexValueItemPairEvent> getEndIndices(Set<IndexValueItemPair> existingPairs, Set<IndexValueItemPair> newPairs) {
+        List<IndexValueItemPairEvent> pairs = new ArrayList<>();
+
+        existingPairs.forEach(existingPair -> {
+            if (!newPairs.contains(existingPair)) {
+                pairs.add(new IndexValueItemPairEvent(existingPair, false));
+            }
+        });
+
+        return pairs;
+    }
+
+    protected List<IndexValueItemPairEvent> getStartIndices(Set<IndexValueItemPair> existingPairs, Set<IndexValueItemPair> newPairs) {
+        List<IndexValueItemPairEvent> pairs = new ArrayList<>();
+
+        newPairs.forEach(newPair -> {
+            if (!existingPairs.contains(newPair)) {
+                pairs.add(new IndexValueItemPairEvent(newPair, true));
+            }
+        });
+
+        return pairs;
+    }
+}

--- a/src/main/java/uk/gov/register/indexer/IndexValueItemPairEvent.java
+++ b/src/main/java/uk/gov/register/indexer/IndexValueItemPairEvent.java
@@ -1,0 +1,44 @@
+package uk.gov.register.indexer;
+
+import uk.gov.register.util.HashValue;
+
+public class IndexValueItemPairEvent {
+    private final IndexValueItemPair pair;
+    private final boolean isStart;
+
+    public IndexValueItemPairEvent(IndexValueItemPair pair, boolean isStart) {
+        this.pair = pair;
+        this.isStart = isStart;
+    }
+
+    public HashValue getItemHash() {
+        return pair.getItemHash();
+    }
+
+    public String getIndexValue() {
+        return pair.getValue();
+    }
+
+    public boolean isStart() {
+        return isStart;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        IndexValueItemPairEvent that = (IndexValueItemPairEvent) o;
+
+        if (isStart != that.isStart) return false;
+        return pair.equals(that.pair);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = pair.hashCode();
+        result = 31 * result + (isStart ? 1 : 0);
+        return result;
+    }
+}

--- a/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
+++ b/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
@@ -4,6 +4,8 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
 import uk.gov.register.db.InMemoryEntryDAO;
+import uk.gov.register.db.IndexDAO;
+import uk.gov.register.db.IndexQueryDAO;
 import uk.gov.register.exceptions.NoSuchFieldException;
 import uk.gov.register.service.ItemValidator;
 
@@ -17,25 +19,29 @@ public class PostgresRegisterTest {
     private final InMemoryEntryDAO entryDAO = new InMemoryEntryDAO(new ArrayList<>());
     private RecordIndex recordIndex;
     private ItemValidator itemValidator;
+    private IndexDAO indexDAO;
+    private IndexQueryDAO indexQueryDAO;
     private RegisterFieldsConfiguration registerFieldsConfiguration;
 
     @Before
     public void setup() {
         recordIndex = mock(RecordIndex.class);
         itemValidator = mock(ItemValidator.class);
+        indexDAO = mock(IndexDAO.class);
+        indexQueryDAO = mock(IndexQueryDAO.class);
         registerFieldsConfiguration = mock(RegisterFieldsConfiguration.class);
     }
 
     @Test(expected = NoSuchFieldException.class)
     public void findMax100RecordsByKeyValueShouldFailWhenKeyDoesNotExist() {
-        PostgresRegister register = new PostgresRegister(registerMetadata("register"), registerFieldsConfiguration, inMemoryEntryLog(entryDAO), inMemoryItemStore(itemValidator, entryDAO), recordIndex);
+        PostgresRegister register = new PostgresRegister(registerMetadata("register"), registerFieldsConfiguration, inMemoryEntryLog(entryDAO), inMemoryItemStore(itemValidator, entryDAO), recordIndex, indexDAO, indexQueryDAO);
         register.max100RecordsFacetedByKeyValue("citizen-name", "British");
     }
 
     @Test
     public void findMax100RecordsByKeyValueShouldReturnValueWhenKeyExists() {
         when(registerFieldsConfiguration.containsField("name")).thenReturn(true);
-        PostgresRegister register = new PostgresRegister(registerMetadata("register"), registerFieldsConfiguration, inMemoryEntryLog(entryDAO), inMemoryItemStore(itemValidator, entryDAO), recordIndex);
+        PostgresRegister register = new PostgresRegister(registerMetadata("register"), registerFieldsConfiguration, inMemoryEntryLog(entryDAO), inMemoryItemStore(itemValidator, entryDAO), recordIndex, indexDAO, indexQueryDAO);
         register.max100RecordsFacetedByKeyValue("name", "United Kingdom");
         verify(recordIndex, times(1)).findMax100RecordsByKeyValue("name", "United Kingdom");
     }

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -151,7 +151,7 @@ public class PostgresRegisterTransactionalFunctionalTest {
                 mock(ItemValidator.class));
         RegisterMetadata registerData = mock(RegisterMetadata.class);
         when(registerData.getRegisterName()).thenReturn(new RegisterName("address"));
-        return new PostgresRegister(registerData, new RegisterFieldsConfiguration(emptyList()), entryLog, itemStore, new TransactionalRecordIndex(handle.attach(RecordQueryDAO.class), handle.attach(CurrentKeysUpdateDAO.class)));
+        return new PostgresRegister(registerData, new RegisterFieldsConfiguration(emptyList()), entryLog, itemStore, new TransactionalRecordIndex(handle.attach(RecordQueryDAO.class), handle.attach(CurrentKeysUpdateDAO.class)), handle.attach(IndexDAO.class), handle.attach(IndexQueryDAO.class));
     }
 }
 

--- a/src/test/java/uk/gov/register/indexer/IndexDriverTest.java
+++ b/src/test/java/uk/gov/register/indexer/IndexDriverTest.java
@@ -1,0 +1,280 @@
+package uk.gov.register.indexer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import uk.gov.register.core.*;
+import uk.gov.register.db.IndexDAO;
+import uk.gov.register.db.IndexQueryDAO;
+import uk.gov.register.indexer.function.IndexFunction;
+import uk.gov.register.util.HashValue;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.mockito.Mockito.*;
+
+public class IndexDriverTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void getStartIndices_shouldReturnEmptyList_whenNoNewPairsExist() {
+        Register register = mock(Register.class);
+        IndexDAO indexDAO = mock(IndexDAO.class);
+        IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
+        IndexDriver indexDriver = new IndexDriver(register, indexDAO, indexQueryDAO);
+
+        Set<IndexValueItemPair> existingPairs = new HashSet<>(Arrays.asList(
+                new IndexValueItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa")),
+                new IndexValueItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
+        ));
+        Set<IndexValueItemPair> newPairs = new HashSet<>(Arrays.asList(
+                new IndexValueItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa")),
+                new IndexValueItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
+        ));
+
+        List<IndexValueItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs);
+
+        assertThat(pairsToStart, empty());
+    }
+
+    @Test
+    public void getStartIndices_shouldReturnNewPairs_whenNewPairsExist() {
+        Register register = mock(Register.class);
+        IndexDAO indexDAO = mock(IndexDAO.class);
+        IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
+        IndexDriver indexDriver = new IndexDriver(register, indexDAO, indexQueryDAO);
+
+        Set<IndexValueItemPair> existingPairs = new HashSet<>(Arrays.asList(
+                new IndexValueItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa")),
+                new IndexValueItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
+        ));
+        Set<IndexValueItemPair> newPairs = new HashSet<>(Arrays.asList(
+                new IndexValueItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa")),
+                new IndexValueItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb")),
+                new IndexValueItemPair("C", new HashValue(HashingAlgorithm.SHA256, "ccc"))
+        ));
+
+        List<IndexValueItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs);
+
+        assertThat(pairsToStart, contains(new IndexValueItemPairEvent(new IndexValueItemPair("C", new HashValue(HashingAlgorithm.SHA256, "ccc")), true)));
+    }
+
+    @Test
+    public void getEndIndices_shouldReturnEmptyList_whenNoNewPairsExist() {
+        Register register = mock(Register.class);
+        IndexDAO indexDAO = mock(IndexDAO.class);
+        IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
+        IndexDriver indexDriver = new IndexDriver(register, indexDAO, indexQueryDAO);
+
+        Set<IndexValueItemPair> existingPairs = new HashSet<>(Arrays.asList(
+                new IndexValueItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa")),
+                new IndexValueItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
+        ));
+        Set<IndexValueItemPair> newPairs = new HashSet<>(Arrays.asList(
+                new IndexValueItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb")),
+                new IndexValueItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa"))
+        ));
+
+        List<IndexValueItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs);
+
+        assertThat(pairsToEnd, empty());
+    }
+
+    @Test
+    public void getEndIndices_shouldReturnEndedPairs_whenEndedPairsExist() {
+        Register register = mock(Register.class);
+        IndexDAO indexDAO = mock(IndexDAO.class);
+        IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
+        IndexDriver indexDriver = new IndexDriver(register, indexDAO, indexQueryDAO);
+
+        Set<IndexValueItemPair> existingPairs = new HashSet<>(Arrays.asList(
+                new IndexValueItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa")),
+                new IndexValueItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
+        ));
+        Set<IndexValueItemPair> newPairs = new HashSet<>(Arrays.asList(
+                new IndexValueItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
+        ));
+
+        List<IndexValueItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs);
+
+        assertThat(pairsToEnd, contains(new IndexValueItemPairEvent(new IndexValueItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa")), false)));
+    }
+
+    @Test
+    public void indexEntry_shouldStartIndex_whenNewPairsExist() throws IOException {
+        Item item = new Item(new HashValue(HashingAlgorithm.SHA256, "aaa"), objectMapper.readTree("{\"x\":\"P\"}"));
+
+        Entry previousEntry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "A");
+        Entry newEntry = new Entry(2, Arrays.asList(new HashValue(HashingAlgorithm.SHA256, "aaa"), new HashValue(HashingAlgorithm.SHA256, "bbb")), Instant.now(), "A");
+
+        Register register = mock(Register.class);
+        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, item)));
+
+        IndexDAO indexDAO = mock(IndexDAO.class);
+        IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
+        when(indexQueryDAO.getCurrentIndexEntryNumber("by-x")).thenReturn(0);
+        IndexFunction indexFunction = mock(IndexFunction.class);
+        when(indexFunction.getName()).thenReturn("by-x");
+        when(indexFunction.execute(previousEntry))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")))));
+        when(indexFunction.execute(newEntry))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")), new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
+
+        IndexDriver indexDriver = new IndexDriver(register, indexDAO, indexQueryDAO);
+        indexDriver.indexEntry(newEntry, indexFunction);
+
+        verify(indexDAO, times(1)).start("by-x", "P", "bbb", 2, 1);
+        verifyNoMoreInteractions(indexDAO);
+    }
+
+    @Test
+    public void indexEntry_shouldEndIndex_whenEndedPairExists() throws IOException {
+        Item item = new Item(new HashValue(HashingAlgorithm.SHA256, "aaa"), objectMapper.readTree("{\"x\":\"P\"}"));
+
+        Entry previousEntry = new Entry(1, Arrays.asList(new HashValue(HashingAlgorithm.SHA256, "aaa"), new HashValue(HashingAlgorithm.SHA256, "bbb")), Instant.now(), "A");
+        Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A");
+
+        Register register = mock(Register.class);
+        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, item)));
+
+        IndexDAO indexDAO = mock(IndexDAO.class);
+        IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
+        when(indexQueryDAO.getCurrentIndexEntryNumber("by-x")).thenReturn(0);
+        IndexFunction indexFunction = mock(IndexFunction.class);
+        when(indexFunction.getName()).thenReturn("by-x");
+        when(indexFunction.execute(previousEntry))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")), new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
+        when(indexFunction.execute(newEntry))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
+
+        IndexDriver indexDriver = new IndexDriver(register, indexDAO, indexQueryDAO);
+        indexDriver.indexEntry(newEntry, indexFunction);
+
+        verify(indexDAO, times(1)).end("by-x", "P", "aaa", 2, 1);
+        verifyNoMoreInteractions(indexDAO);
+    }
+
+    @Test
+    public void indexEntry_shouldEndThenStartIndex_usingAlphabeticalKeyOrder_whenItemMovesFromOneGroupToAnother() throws IOException {
+        Item itemP = new Item(new HashValue(HashingAlgorithm.SHA256, "aaa"), objectMapper.readTree("{\"x\":\"P\"}"));
+        Item itemQ = new Item(new HashValue(HashingAlgorithm.SHA256, "bbb"), objectMapper.readTree("{\"x\":\"Q\"}"));
+
+        Entry previousEntry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "A");
+        Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A");
+
+        Register register = mock(Register.class);
+        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, itemP)));
+
+        IndexDAO indexDAO = mock(IndexDAO.class);
+        IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
+        when(indexQueryDAO.getCurrentIndexEntryNumber("by-x")).thenReturn(0);
+        IndexFunction indexFunction = mock(IndexFunction.class);
+        when(indexFunction.getName()).thenReturn("by-x");
+        when(indexFunction.execute(previousEntry))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")))));
+        when(indexFunction.execute(newEntry))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("Q", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
+
+
+        IndexDriver indexDriver = new IndexDriver(register, indexDAO, indexQueryDAO);
+        indexDriver.indexEntry(newEntry, indexFunction);
+
+        verify(indexDAO, times(1)).end("by-x", "P", "aaa", 2, 1);
+        verify(indexDAO, times(1)).start("by-x", "Q", "bbb", 2, 2);
+        verifyNoMoreInteractions(indexDAO);
+    }
+
+    @Test
+    public void indexEntry_shouldStartThenEndIndex_usingAlphabeticalKeyOrder_whenItemMovesFromOneGroupToAnother() throws IOException {
+        Item itemQ = new Item(new HashValue(HashingAlgorithm.SHA256, "bbb"), objectMapper.readTree("{\"x\":\"Q\"}"));
+        Item itemP = new Item(new HashValue(HashingAlgorithm.SHA256, "aaa"), objectMapper.readTree("{\"x\":\"P\"}"));
+
+        Entry previousEntry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A");
+        Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "A");
+
+        Register register = mock(Register.class);
+        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, itemQ)));
+
+        IndexDAO indexDAO = mock(IndexDAO.class);
+        IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
+        when(indexQueryDAO.getCurrentIndexEntryNumber("by-x")).thenReturn(0);
+        IndexFunction indexFunction = mock(IndexFunction.class);
+        when(indexFunction.getName()).thenReturn("by-x");
+        when(indexFunction.execute(previousEntry))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("Q", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
+        when(indexFunction.execute(newEntry))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")))));
+
+
+        IndexDriver indexDriver = new IndexDriver(register, indexDAO, indexQueryDAO);
+        indexDriver.indexEntry(newEntry, indexFunction);
+
+        verify(indexDAO, times(1)).start("by-x", "P", "aaa", 2, 1);
+        verify(indexDAO, times(1)).end("by-x", "Q", "bbb", 2, 2);
+        verifyNoMoreInteractions(indexDAO);
+    }
+
+    @Test
+    public void indexEntry_shouldEndAndStartIndex_whenItemChangesWithoutMovingGroup() throws IOException {
+        Item itemP = new Item(new HashValue(HashingAlgorithm.SHA256, "aaa"), objectMapper.readTree("{\"x\":\"P\",\"y\":\"S\"}"));
+        Item itemQ = new Item(new HashValue(HashingAlgorithm.SHA256, "bbb"), objectMapper.readTree("{\"x\":\"P\",\"y\":\"T\"}"));
+
+        Entry previousEntry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "A");
+        Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A");
+
+        Register register = mock(Register.class);
+        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, itemP)));
+
+        IndexDAO indexDAO = mock(IndexDAO.class);
+        IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
+        when(indexQueryDAO.getCurrentIndexEntryNumber("by-x")).thenReturn(0);
+        IndexFunction indexFunction = mock(IndexFunction.class);
+        when(indexFunction.getName()).thenReturn("by-x");
+        when(indexFunction.execute(previousEntry))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")))));
+        when(indexFunction.execute(newEntry))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
+
+
+        IndexDriver indexDriver = new IndexDriver(register, indexDAO, indexQueryDAO);
+        indexDriver.indexEntry(newEntry, indexFunction);
+
+        verify(indexDAO, times(1)).end("by-x", "P", "aaa", 2, 1);
+        verify(indexDAO, times(1)).start("by-x", "P", "bbb", 2, 1);
+        verifyNoMoreInteractions(indexDAO);
+    }
+
+    @Test
+    public void indexEntry_shouldStartIndexesWithIncreasingIndexNumbers_whenAddingItems() throws IOException {
+        Item itemP = new Item(new HashValue(HashingAlgorithm.SHA256, "aaa"), objectMapper.readTree("{\"x\":\"P\"}"));
+        Item itemQ = new Item(new HashValue(HashingAlgorithm.SHA256, "bbb"), objectMapper.readTree("{\"x\":\"Q\"}"));
+
+        Entry newEntry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "A");
+        Entry newEntry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "B");
+
+        Register register = mock(Register.class);
+        when(register.getRecord(anyString())).thenReturn(Optional.empty());
+
+        IndexDAO indexDAO = mock(IndexDAO.class);
+        IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
+        when(indexQueryDAO.getCurrentIndexEntryNumber("by-x")).thenReturn(0, 1);
+        IndexFunction indexFunction = mock(IndexFunction.class);
+        when(indexFunction.getName()).thenReturn("by-x");
+        when(indexFunction.execute(newEntry1))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")))));
+        when(indexFunction.execute(newEntry2))
+                .thenReturn(new HashSet<>(Arrays.asList(new IndexValueItemPair("Q", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
+
+        IndexDriver indexDriver = new IndexDriver(register, indexDAO, indexQueryDAO);
+        indexDriver.indexEntry(newEntry1, indexFunction);
+        indexDriver.indexEntry(newEntry2, indexFunction);
+
+        verify(indexDAO, times(1)).start("by-x", "P", "aaa", 1, 1);
+        verify(indexDAO, times(1)).start("by-x", "Q", "bbb", 2, 2);
+        verifyNoMoreInteractions(indexDAO);
+    }
+}


### PR DESCRIPTION
This PR writes to the new `index` table when entries are being appended to the register (currently `country` and `local-authority-eng` are the only registers which support an index).

Further iterations will specify index functions in config rather than in `PostgresRegister`, in addition to removing the hack from the `indexEntry` method of `IndexDriver` which runs a `commit` on the entire register for every call to it, in order to ensure that all entries are written from the staging list to the database so that we can get records.