### PR TITLE
Use TLS where we can

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group 'openregister'
 buildscript {
     repositories {
         jcenter()
-        maven { url "http://dl.bintray.com/robfletcher/gradle-plugins" }
+        maven { url "https://dl.bintray.com/robfletcher/gradle-plugins" }
     }
     dependencies {
         classpath "com.github.ben-manes:gradle-versions-plugin:0.13.0"


### PR DESCRIPTION
For what it is worth this doesn't to change what protocol is actually
used--it appears to use HTTPS anyway (global default somewhere?). Either
way it seems better to be explicit about using a secure HTTP connection.