### PR TITLE
Record resource should now return a result set

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 csvvalidator==1.2
 jsonschema==2.5.1
--e git+https://github.com/openregister/conformance-test.git@cae6120c78b0bda41005c726438287635541dc41#egg=openregister_conformance-master
+-e git+https://github.com/openregister/conformance-test.git@9957c858530075729f96cc2505fc2087dd328c1c#egg=openregister_conformance-master
 py==1.4.31
 pytest==2.9.0
 PyYAML==3.11

--- a/src/main/java/uk/gov/register/views/RecordView.java
+++ b/src/main/java/uk/gov/register/views/RecordView.java
@@ -1,9 +1,11 @@
 package uk.gov.register.views;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.dropwizard.jackson.Jackson;
 import uk.gov.register.core.Entry;
@@ -38,13 +40,13 @@ public class RecordView implements CsvRepresentationView {
 
     @SuppressWarnings("unused, used to create the json representation of this class")
     @JsonValue
-    public ObjectNode getRecordJson() {
+    public Map<String, JsonNode> getRecordJson() {
         ObjectMapper objectMapper = Jackson.newObjectMapper();
         ObjectNode jsonNodes = objectMapper.convertValue(entry, ObjectNode.class);
         jsonNodes.remove("item-hash");
         ArrayNode items = jsonNodes.putArray("item");
         itemViews.forEach( iv -> items.add(objectMapper.convertValue(iv, ObjectNode.class)));
-        return jsonNodes;
+        return ImmutableMap.of(entry.getKey(), jsonNodes);
     }
 
     ArrayNode getFlatRecordJson() {

--- a/src/main/java/uk/gov/register/views/RecordsView.java
+++ b/src/main/java/uk/gov/register/views/RecordsView.java
@@ -1,6 +1,7 @@
 package uk.gov.register.views;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.Iterables;
@@ -9,9 +10,9 @@ import uk.gov.register.core.Field;
 import uk.gov.register.core.Record;
 import uk.gov.register.views.representations.CsvRepresentation;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class RecordsView implements CsvRepresentationView {
     private List<RecordView> records;
@@ -31,8 +32,10 @@ public class RecordsView implements CsvRepresentationView {
     }
 
     @JsonValue
-    public Map<String, RecordView> recordsJson() {
-        return getRecords().stream().collect(Collectors.toMap(RecordView::getPrimaryKey, r -> r));
+    public Map<String, JsonNode> recordsJson() {
+        Map<String, JsonNode> records = new HashMap<>();
+        getRecords().forEach(recordView -> records.putAll(recordView.getRecordJson()));
+        return records;
     }
 
     ArrayNode getFlatRecordsJson() {

--- a/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
@@ -2,6 +2,7 @@ package uk.gov.register.functional;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
+import io.dropwizard.jackson.Jackson;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -73,7 +74,7 @@ public class DataUploadFunctionalTest {
         Response response = register.getRequest(TestRegister.register, "/record/ft_openregister_test.json");
 
         assertThat(response.getStatus(), equalTo(200));
-        Map actualJson = response.readEntity(Map.class);
+        Map actualJson = Jackson.newObjectMapper().convertValue(response.readEntity(JsonNode.class).get("ft_openregister_test"), Map.class);
         actualJson.remove("entry-timestamp"); // ignore the timestamp as we can't do exact match
         assertThat(actualJson.get("entry-number"), is("1"));
         List<Map<String,Object>> itemMaps = (List<Map<String,Object>>)actualJson.get("item");

--- a/src/test/java/uk/gov/register/functional/RecordMultiItemEntryFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordMultiItemEntryFunctionalTest.java
@@ -75,7 +75,7 @@ public class RecordMultiItemEntryFunctionalTest {
     public void shouldRenderListOfItems() throws IOException {
         Response response = register.getRequest(testRegister, "/record/government-digital-service.json");
         assertThat(response.getStatus(), equalTo(200));
-        JsonNode res = MAPPER.readValue(response.readEntity(String.class), JsonNode.class);
+        JsonNode res = MAPPER.readValue(response.readEntity(String.class), JsonNode.class).get("government-digital-service");
         ArrayNode items = (ArrayNode) res.get("item");
         assertThat(items.size(), Matchers.is(2));
     }

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -44,7 +44,7 @@ public class RecordResourceFunctionalTest {
 
         assertThat(response.getHeaderString("Link"), equalTo("</record/6789/entries>; rel=\"version-history\""));
 
-        JsonNode res = Jackson.newObjectMapper().readValue(response.readEntity(String.class), JsonNode.class);
+        JsonNode res = Jackson.newObjectMapper().readValue(response.readEntity(String.class), JsonNode.class).get("6789");
         assertThat(res.get("entry-number").textValue(), equalTo("2"));
         assertThat(res.get("key").textValue(), equalTo("6789"));
         assertTrue(res.get("entry-timestamp").textValue().matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"));

--- a/src/test/java/uk/gov/register/views/RecordViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordViewTest.java
@@ -29,12 +29,13 @@ public class RecordViewTest {
         String result = objectMapper.writeValueAsString(recordView);
 
         assertThat(result, equalTo("{" +
+                "\"b\":{" +
                 "\"index-entry-number\":\"1\"," +
                 "\"entry-number\":\"1\"," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:00Z\"," +
                 "\"key\":\"b\"," +
                 "\"item\":[{\"a\":\"b\"},{\"a\":\"d\"}]" +
-                "}"));
+                "}}"));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/views/RecordsViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordsViewTest.java
@@ -1,5 +1,6 @@
 package uk.gov.register.views;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -47,7 +48,7 @@ public class RecordsViewTest {
         );
         RecordsView recordsView = new RecordsView(records, fields);
 
-        Map<String, RecordView> result = recordsView.recordsJson();
+        Map<String, JsonNode> result = recordsView.recordsJson();
         assertThat(result.size(), equalTo(2));
 
 

--- a/src/test/resources/fixtures/record.json
+++ b/src/test/resources/fixtures/record.json
@@ -1,1 +1,1 @@
-{"index-entry-number":"1","entry-number":"1","entry-timestamp":"2016-03-01T01:02:03Z","key":"value1","item":[{"text":"The Entry 1","fields":["field1"],"register":"value1"}]}
+{"value1":{"index-entry-number":"1","entry-number":"1","entry-timestamp":"2016-03-01T01:02:03Z","key":"value1","item":[{"text":"The Entry 1","fields":["field1"],"register":"value1"}]}}

--- a/src/test/resources/fixtures/record.yaml
+++ b/src/test/resources/fixtures/record.yaml
@@ -1,10 +1,11 @@
 ---
-index-entry-number: "1"
-entry-number: "1"
-entry-timestamp: "2016-03-01T01:02:03Z"
-key: "value1"
-item:
-- text: "The Entry 1"
-  fields:
-  - "field1"
-  register: "value1"
+value1:
+  index-entry-number: "1"
+  entry-number: "1"
+  entry-timestamp: "2016-03-01T01:02:03Z"
+  key: "value1"
+  item:
+  - text: "The Entry 1"
+    fields:
+    - "field1"
+    register: "value1"


### PR DESCRIPTION
This makes it more consistent with the records resource and means that we can return
multiple records for this resource in the future if appropriate.

At some point we should refactor the record and records view code. It's likely that we can improve it now that both effectively use the same view.

Requires https://github.com/openregister/conformance-test/pull/23 to be merged first (and an update to `requirements.txt`.