### PR TITLE
Change entry resource to return an array

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 csvvalidator==1.2
 jsonschema==2.5.1
--e git+https://github.com/openregister/conformance-test.git@f909d400bd6ce499ee2b85161423379ce1e0e877#egg=openregister_conformance-master
+-e git+https://github.com/openregister/conformance-test.git@cae6120c78b0bda41005c726438287635541dc41#egg=openregister_conformance-master
 py==1.4.31
 pytest==2.9.0
 PyYAML==3.11

--- a/src/main/java/uk/gov/register/resources/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/EntryResource.java
@@ -15,6 +15,7 @@ import uk.gov.register.views.representations.ExtraMediaType;
 import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -41,7 +42,7 @@ public class EntryResource {
     @Produces(ExtraMediaType.TEXT_HTML)
     @Timed
     public AttributionView<Entry> findByEntryNumberHtml(@PathParam("entry-number") int entryNumber) {
-        Optional<Entry> entry = findByEntryNumber(entryNumber);
+        Optional<Entry> entry = register.getEntry(entryNumber);
         return entry.map(viewFactory::getEntryView).orElseThrow(NotFoundException::new);
     }
 
@@ -49,8 +50,9 @@ public class EntryResource {
     @Path("/entry/{entry-number}")
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     @Timed
-    public Optional<Entry> findByEntryNumber(@PathParam("entry-number") int entryNumber) {
-        return register.getEntry(entryNumber);
+    public Optional<EntryListView> findByEntryNumber(@PathParam("entry-number") int entryNumber) {
+        Optional<Entry> entry = register.getEntry(entryNumber);
+        return entry.isPresent() ? Optional.of(new EntryListView(Arrays.asList(entry.get()))) : Optional.empty();
     }
 
     @GET

--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -94,7 +94,8 @@ public class EntryResourceFunctionalTest {
 
         assertThat(response.getStatus(), equalTo(200));
         JsonNode res = Jackson.newObjectMapper().readValue(response.readEntity(String.class), JsonNode.class);
-        assertEntryInJsonNode(res, 1, item1Hash);
+        assertThat(res.size(), equalTo(1));
+        assertEntryInJsonNode(res.get(0), 1, item1Hash);
     }
 
     @Test
@@ -126,7 +127,7 @@ public class EntryResourceFunctionalTest {
         Instant now = Instant.now();
 
         Response response = register.getRequest(address, "/entry/1.json");
-        Map<String, String> responseData = response.readEntity(Map.class);
+        Map<String, String> responseData = Jackson.newObjectMapper().convertValue(response.readEntity(JsonNode.class).get(0), Map.class);
         Instant entryTimestamp = Instant.parse(responseData.get("entry-timestamp"));
 
         assertThat(entryTimestamp, between(now.minus(30, SECONDS), now.plus(30, SECONDS)));

--- a/src/test/resources/fixtures/entry.json
+++ b/src/test/resources/fixtures/entry.json
@@ -1,1 +1,1 @@
-{"index-entry-number":"1","entry-number":"1","entry-timestamp":"2016-03-01T01:02:03Z","key":"value1","item-hash":["sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18"]}
+[{"index-entry-number":"1","entry-number":"1","entry-timestamp":"2016-03-01T01:02:03Z","key":"value1","item-hash":["sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18"]}]

--- a/src/test/resources/fixtures/entry.yaml
+++ b/src/test/resources/fixtures/entry.yaml
@@ -1,7 +1,7 @@
 ---
-index-entry-number: "1"
-entry-number: "1"
-entry-timestamp: "2016-03-01T01:02:03Z"
-key: "value1"
-item-hash:
-- "sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18"
+- index-entry-number: "1"
+  entry-number: "1"
+  entry-timestamp: "2016-03-01T01:02:03Z"
+  key: "value1"
+  item-hash:
+  - "sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18"


### PR DESCRIPTION
This makes the entry and entries resources more consistent and allows us to
possibly return multiple entries from this resource in future should it make sense.

We should refactor the view code at some point soon as this could probably be made simpler.

This requires https://github.com/openregister/conformance-test/pull/24 to be merged first and to update `requirements.txt`.