### PR TITLE
Generate and publish artifact with the same name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,16 +44,6 @@ deploy:
   bucket: openregister.app.artifacts
   region: eu-west-1
   skip_cleanup: true
-  on: &2
+  on:
     branch: master
     condition: $DEPLOY=true
-- provider: codedeploy
-  access_key_id: AKIAINSAHPOLGXFFYGMQ
-  secret_access_key: *1
-  bucket: openregister.app.artifacts
-  key: openregister-java-$TRAVIS_BRANCH-$TRAVIS_BUILD_NUMBER-$TRAVIS_COMMIT.zip
-  bundle_type: zip
-  application: openregister-app
-  deployment_group: test
-  region: eu-west-1
-  on: *2

--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ clean.doFirst {
 
 task createDeployableBundle(type: Zip) {
     Map env = System.getenv()
-    baseName("openregister-java-${env.'TRAVIS_BRANCH'}-${env.'TRAVIS_BUILD_NUMBER'}-${env.'TRAVIS_COMMIT'}")
+    baseName('openregister-java')
     from('deploy/')
     include('*')
     include('scripts/*')


### PR DESCRIPTION
This requires [https://github.com/openregister/deployment/pull/329](this) to be deployed first.

CodePipeline seems to require an S3 artifact with a known, constant name. It relies on S3 versioning to reference the different builds of the artifact.

As we're using CodePipeline to trigger CodeDeploy we no longer need to do this from Travis.