### PR TITLE
Use the full key ID for Postgres's Debian repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 - sudo /etc/init.d/postgresql stop
 - sudo apt-get -y remove --purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4
 - sudo apt-get -y autoremove
-- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7FCC7D46ACCC4CF8
+- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
 - sudo apt-get update
 - sudo apt-get -y install postgresql-9.5


### PR DESCRIPTION
This doesn't really add very much but I suppose it prevents against
some theoretical collisions with 16 hex-digit key IDs.