### PR TITLE
Use Travis's Postgres addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: java
 jdk:
 - oraclejdk8
 services: 
+  - postgresql
 addons:
   postgresql: '9.5'
   apt:
@@ -17,16 +18,6 @@ cache:
   - $HOME/.gradle/wrapper
   - $HOME/.m2
 before_script:
-- sudo /etc/init.d/postgresql stop
-- sudo apt-get -y remove --purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4
-- sudo apt-get -y autoremove
-- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7FCC7D46ACCC4CF8
-- sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
-- sudo apt-get update
-- sudo apt-get -y install postgresql-9.5
-- sudo sh -c 'echo "local all postgres trust" > /etc/postgresql/9.5/main/pg_hba.conf'
-- sudo sh -c 'echo -n "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
-- sudo service postgresql restart 9.5
 - psql --version
 - psql -c 'create database ft_openregister_java_address;' -U postgres
 - psql -c 'create database ft_openregister_java_postcode;' -U postgres


### PR DESCRIPTION
Previously, Travis did not provide Postgres 9.5 as an addon. In order to
use this we had to install a version manually (see commit
`e05a0323ec67b65eb2551611c7562afb6d2cd519`).

[Travis now provide Postgres 9.5 as an addon](https://github.com/travis-ci/travis-ci/issues/4264#issuecomment-263550556).

I have a feeling that we should be able to use Travis containers
(setting `sudo: false`) but it appeared to fail silently when I tried
it:

```
$ ./gradlew check
:dependencyCheck
Verifying dependencies for project openregister-java
Checking for updates and analyzing vulnerabilities for dependencies
/home/travis/.travis/job_stages: line 53:  3800 Killed                ./gradlew check
```

The builds also appeared to be slower.