### PR TITLE
Revert "Temporarily increase the deploy timeout"

### DIFF
--- a/deploy/appspec.yml
+++ b/deploy/appspec.yml
@@ -18,5 +18,5 @@ hooks:
       runas: root
   ValidateService:
     - location: scripts/validate.sh
-      timeout: 600
+      timeout: 300
       runas: root


### PR DESCRIPTION
We fixed the problem that meant we had to increase this timeout as part
of `9f2daaa6c52541a4c81f99fc707b07db9f76731d` on
`openregister/deployment`.

This reverts commit 80be73aef1349cc65e457c64f30f07d914bb0ca7.