### PR TITLE
Add scripts to deregister/register instances from ELB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ task createDeployableBundle(type: Zip) {
     baseName('openregister-java')
     from('deploy/')
     include('*')
-    include('scripts/*')
+    include('scripts/**/*.sh')
     destinationDir file('deployable_bundle') // directory that you want your archive to be placed in
 }
 

--- a/deploy/appspec.yml
+++ b/deploy/appspec.yml
@@ -5,6 +5,7 @@ files:
     destination: /srv/openregister-java
 hooks:
   ApplicationStop:
+    - location: scripts/aws/deregister_from_elb.sh
     - location: scripts/stop-service.sh
       timeout: 60
       runas: root
@@ -14,6 +15,7 @@ hooks:
       runas: root
   ApplicationStart:
     - location: scripts/start-service.sh
+    - location: scripts/aws/register_with_elb.sh
       timeout: 60
       runas: root
   ValidateService:

--- a/deploy/scripts/aws/README.md
+++ b/deploy/scripts/aws/README.md
@@ -1,0 +1,3 @@
+# AWS ELB scripts
+
+The scripts contained in this directory are slightly modified versions of the [templates provided by AWS](https://github.com/awslabs/aws-codedeploy-samples).

--- a/deploy/scripts/aws/common_functions.sh
+++ b/deploy/scripts/aws/common_functions.sh
@@ -1,0 +1,660 @@
+#!/bin/bash
+#
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+INSTANCE_ID=$(curl 169.254.169.254/2014-11-05/meta-data/instance-id)
+REGISTER_NAME=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Register --region eu-west-1 --query 'Tags[0].Value' --output text)
+ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Environment --region eu-west-1 --query 'Tags[0].Value' --output text)
+
+# ELB_LIST defines which Elastic Load Balancers this instance should be part of.
+# The elements in ELB_LIST should be separated by space. Safe default is "".
+# Set to "_all_" to automatically find all load balancers the instance is registered to.
+# Set to "_any_" will work as "_all_" but will not fail if instance is not attached to
+# any ASG or ELB, giving flexibility.
+ELB_LIST="$ENV--$REGISTER_NAME"
+
+# Under normal circumstances, you shouldn't need to change anything below this line.
+# -----------------------------------------------------------------------------
+
+export PATH="$PATH:/usr/bin:/usr/local/bin"
+
+# If true, all messages will be printed. If false, only fatal errors are printed.
+DEBUG=true
+
+# Number of times to check for a resouce to be in the desired state.
+WAITER_ATTEMPTS=60
+
+# Number of seconds to wait between attempts for resource to be in a state.
+WAITER_INTERVAL=1
+
+# AutoScaling Standby features at minimum require this version to work.
+MIN_CLI_VERSION='1.3.25'
+
+# Create a flagfile for each deployment
+FLAGFILE="/tmp/asg_codedeploy_flags-$DEPLOYMENT_GROUP_ID-$DEPLOYMENT_ID"
+
+# Handle ASG processes
+HANDLE_PROCS=false
+
+# Usage: get_instance_region
+#
+#   Writes to STDOUT the AWS region as known by the local instance.
+get_instance_region() {
+    if [ -z "$AWS_REGION" ]; then
+        AWS_REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document \
+            | grep -i region \
+            | awk -F\" '{print $4}')
+    fi
+
+    echo $AWS_REGION
+}
+
+AWS_CLI="aws --region $(get_instance_region)"
+
+# Usage: set_flag <flag> <value>
+#
+#   Writes <flag>=<value> to FLAGFILE
+set_flag() {
+  if echo "$1=$2" >> $FLAGFILE; then
+    return 0
+  else
+    error_exit "Unable to write flag \"$1=$2\" to $FLAGFILE"
+  fi
+}
+
+# Usage: get_flag <flag>
+#
+#   Checks for <flag> in FLAGFILE. Echoes it's value and returns 0 on success or non-zero if it fails to read the file.
+get_flag() {
+  if [ -r $FLAGFILE ]; then
+    local result=$(awk -F= -v flag="$1" '{if ( $1 == flag ) {print $2}}' $FLAGFILE)
+    echo "${result}"
+    return 0
+  else
+    # FLAGFILE doesn't exist
+    return 1
+  fi
+}
+
+# Usage: check_suspended_processes
+#
+#   Checks processes suspended on the ASG before beginning and store them in
+#   the FLAGFILE to avoid resuming afterwards. Also abort if Launch process
+#   is suspended.
+check_suspended_processes() {
+  # Get suspended processes in an array
+  local suspended=($($AWS_CLI autoscaling describe-auto-scaling-groups \
+      --auto-scaling-group-name "${asg_name}" \
+      --query 'AutoScalingGroups[].SuspendedProcesses' \
+      --output text | awk '{printf $1" "}'))
+
+  if [ ${#suspended[@]} -eq 0 ]; then
+    msg "No processes were suspended on the ASG before starting."
+  else
+    msg "This processes were suspended on the ASG before starting: ${suspended[*]}"
+  fi
+
+  # If "Launch" process is suspended abort because we will not be able to recover from StandBy. Note the "[[ ... =~" bashism.
+  if [[ "${suspended[@]}" =~ "Launch" ]]; then
+    error_exit "'Launch' process of AutoScaling is suspended which will not allow us to recover the instance from StandBy. Aborting."
+  fi
+
+  for process in ${suspended[@]}; do
+    set_flag "$process" "true"
+  done
+}
+
+# Usage: suspend_processes
+#
+#   Suspend processes known to cause problems during deployments.
+#   The API call is idempotent so it doesn't matter if any were previously suspended.
+suspend_processes() {
+  local -a processes=(AZRebalance AlarmNotification ScheduledActions ReplaceUnhealthy)
+
+  msg "Suspending ${processes[*]} processes"
+  $AWS_CLI autoscaling suspend-processes \
+    --auto-scaling-group-name "${asg_name}" \
+    --scaling-processes ${processes[@]}
+  if [ $? != 0 ]; then
+    error_exit "Failed to suspend ${processes[*]} processes for ASG ${asg_name}. Aborting as this may cause issues."
+  fi
+}
+
+# Usage: resume_processes
+#
+#   Resume processes suspended, except for the one suspended before deployment.
+resume_processes() {
+  local -a processes=(AZRebalance AlarmNotification ScheduledActions ReplaceUnhealthy)
+  local -a to_resume
+
+  for p in ${processes[@]}; do
+    if ! local tmp_flag_value=$(get_flag "$p"); then
+        error_exit "$FLAGFILE doesn't exist or is unreadable"
+    elif [ ! "$tmp_flag_value" = "true" ] ; then
+      to_resume=("${to_resume[@]}" "$p")
+    fi
+  done
+
+  msg "Resuming ${to_resume[*]} processes"
+  $AWS_CLI autoscaling resume-processes \
+    --auto-scaling-group-name "${asg_name}" \
+    --scaling-processes ${to_resume[@]}
+  if [ $? != 0 ]; then
+    error_exit "Failed to resume ${to_resume[*]} processes for ASG ${asg_name}. Aborting as this may cause issues."
+  fi
+}
+
+# Usage: remove_flagfile
+#
+#   Removes FLAGFILE. Returns non-zero if failure.
+remove_flagfile() {
+  if rm $FLAGFILE; then
+      msg "Successfully removed flagfile $FLAGFILE"
+      return 0
+  else
+      msg "WARNING: Failed to remove flagfile $FLAGFILE."
+  fi
+}
+
+# Usage: finish_msg
+#
+#   Prints some finishing statistics
+finish_msg() {
+  msg "Finished $(basename $0) at $(/bin/date "+%F %T")"
+  
+  end_sec=$(/bin/date +%s.%N)
+  elapsed_seconds=$(echo "$end_sec" "$start_sec" | awk '{ print $1 - $2 }')
+  
+  msg "Elapsed time: $elapsed_seconds"
+}
+
+# Usage: autoscaling_group_name <EC2 instance ID>
+#
+#    Prints to STDOUT the name of the AutoScaling group this instance is a part of and returns 0. If
+#    it is not part of any groups, then it prints nothing. On error calling autoscaling, returns
+#    non-zero.
+autoscaling_group_name() {
+    local instance_id=$1
+
+    # This operates under the assumption that instances are only ever part of a single ASG.
+    local autoscaling_name=$($AWS_CLI autoscaling describe-auto-scaling-instances \
+        --instance-ids $instance_id \
+        --output text \
+        --query AutoScalingInstances[0].AutoScalingGroupName)
+
+    if [ $? != 0 ]; then
+        return 1
+    elif [ "$autoscaling_name" == "None" ]; then
+        echo ""
+    else
+        echo "${autoscaling_name}"
+    fi
+
+    return 0
+}
+
+# Usage: autoscaling_enter_standby <EC2 instance ID> <ASG name>
+#
+#   Move <EC2 instance ID> into the Standby state in AutoScaling group <ASG name>. Doing so will
+#   pull it out of any Elastic Load Balancer that might be in front of the group.
+#
+#   Returns 0 if the instance was successfully moved to standby. Non-zero otherwise.
+autoscaling_enter_standby() {
+    local instance_id=$1
+    local asg_name=${2}
+
+    msg "Checking if this instance has already been moved in the Standby state"
+    local instance_state=$(get_instance_state_asg $instance_id)
+    if [ $? != 0 ]; then
+        msg "Unable to get this instance's lifecycle state."
+        return 1
+    fi
+
+    if [ "$instance_state" == "Standby" ]; then
+        msg "Instance is already in Standby; nothing to do."
+        return 0
+    fi
+
+    if [ "$instance_state" == "Pending:Wait" ]; then
+        msg "Instance is Pending:Wait; nothing to do."
+        return 0
+    fi
+
+    if [ "$HANDLE_PROCS" = "true" ]; then
+        msg "Checking ASG ${asg_name} suspended processes"
+        check_suspended_processes
+
+        # Suspend troublesome processes while deploying
+        suspend_processes
+    fi
+
+    msg "Checking to see if ASG ${asg_name} will let us decrease desired capacity"
+    local min_desired=$($AWS_CLI autoscaling describe-auto-scaling-groups \
+        --auto-scaling-group-name "${asg_name}" \
+        --query 'AutoScalingGroups[0].[MinSize, DesiredCapacity]' \
+        --output text)
+
+    local min_cap=$(echo $min_desired | awk '{print $1}')
+    local desired_cap=$(echo $min_desired | awk '{print $2}')
+
+    if [ -z "$min_cap" -o -z "$desired_cap" ]; then
+        msg "Unable to determine minimum and desired capacity for ASG ${asg_name}."
+        msg "Attempting to put this instance into standby regardless."
+        set_flag "asgmindecremented" "false"
+    elif [ $min_cap == $desired_cap -a $min_cap -gt 0 ]; then
+        local new_min=$(($min_cap - 1))
+        msg "Decrementing ASG ${asg_name}'s minimum size to $new_min"
+        msg $($AWS_CLI autoscaling update-auto-scaling-group \
+            --auto-scaling-group-name "${asg_name}" \
+            --min-size $new_min)
+        if [ $? != 0 ]; then
+            msg "Failed to reduce ASG ${asg_name}'s minimum size to $new_min. Cannot put this instance into Standby."
+            return 1
+        else
+            msg "ASG ${asg_name}'s minimum size has been decremented, creating flag in file $FLAGFILE"
+            # Create a "flag" denote that the ASG min has been decremented
+            set_flag "asgmindecremented" "true"
+        fi
+    else
+        msg "No need to decrement ASG ${asg_name}'s minimum size"
+        set_flag "asgmindecremented" "false"
+    fi
+
+    msg "Putting instance $instance_id into Standby"
+    $AWS_CLI autoscaling enter-standby \
+        --instance-ids $instance_id \
+        --auto-scaling-group-name "${asg_name}" \
+        --should-decrement-desired-capacity
+    if [ $? != 0 ]; then
+        msg "Failed to put instance $instance_id into Standby for ASG ${asg_name}."
+        return 1
+    fi
+
+    msg "Waiting for move to Standby to finish"
+    wait_for_state "autoscaling" $instance_id "Standby"
+    if [ $? != 0 ]; then
+        local wait_timeout=$(($WAITER_INTERVAL * $WAITER_ATTEMPTS))
+        msg "Instance $instance_id did not make it to standby after $wait_timeout seconds"
+        return 1
+    fi
+
+    return 0
+}
+
+# Usage: autoscaling_exit_standby <EC2 instance ID> <ASG name>
+#
+#   Attempts to move instance <EC2 instance ID> out of Standby and into InService. Returns 0 if
+#   successful.
+autoscaling_exit_standby() {
+    local instance_id=$1
+    local asg_name=${2}
+
+    msg "Checking if this instance has already been moved out of Standby state"
+    local instance_state=$(get_instance_state_asg $instance_id)
+    if [ $? != 0 ]; then
+        msg "Unable to get this instance's lifecycle state."
+        return 1
+    fi
+
+    if [ "$instance_state" == "InService" ]; then
+        msg "Instance is already InService; nothing to do."
+        return 0
+    fi
+
+    if [ "$instance_state" == "Pending:Wait" ]; then
+        msg "Instance is Pending:Wait; nothing to do."
+        return 0
+    fi
+
+    msg "Moving instance $instance_id out of Standby"
+    $AWS_CLI autoscaling exit-standby \
+        --instance-ids $instance_id \
+        --auto-scaling-group-name "${asg_name}"
+    if [ $? != 0 ]; then
+        msg "Failed to put instance $instance_id back into InService for ASG ${asg_name}."
+        return 1
+    fi
+
+    msg "Waiting for exit-standby to finish"
+    wait_for_state "autoscaling" $instance_id "InService"
+    if [ $? != 0 ]; then
+        local wait_timeout=$(($WAITER_INTERVAL * $WAITER_ATTEMPTS))
+        msg "Instance $instance_id did not make it to InService after $wait_timeout seconds"
+        return 1
+    fi
+    
+    if ! local tmp_flag_value=$(get_flag "asgmindecremented"); then
+        error_exit "$FLAGFILE doesn't exist or is unreadable"
+    elif [ "$tmp_flag_value" = "true" ]; then
+        local min_desired=$($AWS_CLI autoscaling describe-auto-scaling-groups \
+            --auto-scaling-group-name "${asg_name}" \
+            --query 'AutoScalingGroups[0].[MinSize, DesiredCapacity]' \
+            --output text)
+
+        local min_cap=$(echo $min_desired | awk '{print $1}')
+
+        local new_min=$(($min_cap + 1))
+        msg "Incrementing ASG ${asg_name}'s minimum size to $new_min"
+        msg $($AWS_CLI autoscaling update-auto-scaling-group \
+            --auto-scaling-group-name "${asg_name}" \
+            --min-size $new_min)
+        if [ $? != 0 ]; then
+            msg "Failed to increase ASG ${asg_name}'s minimum size to $new_min."
+            remove_flagfile
+            return 1
+        else
+            msg "Successfully incremented ASG ${asg_name}'s minimum size"
+        fi
+    else
+        msg "Auto scaling group was not decremented previously, not incrementing min value"
+    fi
+
+    if [ "$HANDLE_PROCS" = "true" ]; then
+        # Resume processes, except for the ones suspended before deployment
+        resume_processes
+    fi
+
+    # Clean up the FLAGFILE
+    remove_flagfile
+    return 0
+}
+
+# Usage: get_instance_state_asg <EC2 instance ID>
+#
+#    Gets the state of the given <EC2 instance ID> as known by the AutoScaling group it's a part of.
+#    Health is printed to STDOUT and the function returns 0. Otherwise, no output and return is
+#    non-zero.
+get_instance_state_asg() {
+    local instance_id=$1
+
+    local state=$($AWS_CLI autoscaling describe-auto-scaling-instances \
+        --instance-ids $instance_id \
+        --query "AutoScalingInstances[?InstanceId == \`$instance_id\`].LifecycleState | [0]" \
+        --output text)
+    if [ $? != 0 ]; then
+        return 1
+    else
+        echo $state
+        return 0
+    fi
+}
+
+# Usage: reset_waiter_timeout <ELB name> <state name>
+#
+#    Resets the timeout value to account for the ELB timeout and also connection draining.
+reset_waiter_timeout() {
+    local elb=$1
+    local state_name=$2
+
+    if [ "$state_name" == "InService" ]; then
+
+        # Wait for a health check to succeed
+        local timeout=$($AWS_CLI elb describe-load-balancers \
+            --load-balancer-name $elb \
+            --query 'LoadBalancerDescriptions[0].HealthCheck.Timeout')
+
+    elif [ "$state_name" == "OutOfService" ]; then
+
+        # If connection draining is enabled, wait for connections to drain
+        local draining_values=$($AWS_CLI elb describe-load-balancer-attributes \
+            --load-balancer-name $elb \
+            --query 'LoadBalancerAttributes.ConnectionDraining.[Enabled,Timeout]' \
+            --output text)
+        local draining_enabled=$(echo $draining_values | awk '{print $1}')
+        local timeout=$(echo $draining_values | awk '{print $2}')
+
+        if [ "$draining_enabled" != "True" ]; then
+            timeout=0
+        fi
+
+    else
+        msg "Unknown state name, '$state_name'";
+        return 1;
+    fi
+
+    # Base register/deregister action may take up to about 30 seconds
+    timeout=$((timeout + 30))
+
+    WAITER_ATTEMPTS=$((timeout / WAITER_INTERVAL))
+}
+
+# Usage: wait_for_state <service> <EC2 instance ID> <state name> [ELB name]
+#
+#    Waits for the state of <EC2 instance ID> to be in <state> as seen by <service>. Returns 0 if
+#    it successfully made it to that state; non-zero if not. By default, checks $WAITER_ATTEMPTS
+#    times, every $WAITER_INTERVAL seconds. If giving an [ELB name] to check under, these are reset
+#    to that ELB's timeout values.
+wait_for_state() {
+    local service=$1
+    local instance_id=$2
+    local state_name=$3
+    local elb=$4
+
+    local instance_state_cmd
+    if [ "$service" == "elb" ]; then
+        instance_state_cmd="get_instance_health_elb $instance_id $elb"
+        reset_waiter_timeout $elb $state_name
+        if [ $? != 0 ]; then
+            error_exit "Failed resetting waiter timeout for $elb"
+        fi
+    elif [ "$service" == "autoscaling" ]; then
+        instance_state_cmd="get_instance_state_asg $instance_id"
+    else
+        msg "Cannot wait for instance state; unknown service type, '$service'"
+        return 1
+    fi
+
+    msg "Checking $WAITER_ATTEMPTS times, every $WAITER_INTERVAL seconds, for instance $instance_id to be in state $state_name"
+
+    local instance_state=$($instance_state_cmd)
+    local count=1
+
+    msg "Instance is currently in state: $instance_state"
+    while [ "$instance_state" != "$state_name" ]; do
+        if [ $count -ge $WAITER_ATTEMPTS ]; then
+            local timeout=$(($WAITER_ATTEMPTS * $WAITER_INTERVAL))
+            msg "Instance failed to reach state, $state_name within $timeout seconds"
+            return 1
+        fi
+
+        sleep $WAITER_INTERVAL
+
+        instance_state=$($instance_state_cmd)
+        count=$(($count + 1))
+        msg "Instance is currently in state: $instance_state"
+    done
+
+    return 0
+}
+
+# Usage: get_instance_health_elb <EC2 instance ID> <ELB name>
+#
+#    Gets the health of the given <EC2 instance ID> as known by <ELB name>. If it's a valid health
+#    status (one of InService|OutOfService|Unknown), then the health is printed to STDOUT and the
+#    function returns 0. Otherwise, no output and return is non-zero.
+get_instance_health_elb() {
+    local instance_id=$1
+    local elb_name=$2
+
+    msg "Checking status of instance '$instance_id' in load balancer '$elb_name'"
+
+    # If describe-instance-health for this instance returns an error, then it's not part of
+    # this ELB. But, if the call was successful let's still double check that the status is
+    # valid.
+    local instance_status=$($AWS_CLI elb describe-instance-health \
+        --load-balancer-name $elb_name \
+        --instances $instance_id \
+        --query 'InstanceStates[].State' \
+        --output text 2>/dev/null)
+
+    if [ $? == 0 ]; then
+        case "$instance_status" in
+            InService|OutOfService|Unknown)
+                echo -n $instance_status
+                return 0
+                ;;
+            *)
+                msg "Instance '$instance_id' not part of ELB '$elb_name'"
+                return 1
+        esac
+    fi
+}
+
+# Usage: validate_elb <EC2 instance ID> <ELB name>
+#
+#    Validates that the Elastic Load Balancer with name <ELB name> exists, is describable, and
+#    contains <EC2 instance ID> as one of its instances.
+#
+#    If any of these checks are false, the function returns non-zero.
+validate_elb() {
+    local instance_id=$1
+    local elb_name=$2
+
+    # Get the list of active instances for this LB.
+    local elb_instances=$($AWS_CLI elb describe-load-balancers \
+        --load-balancer-name $elb_name \
+        --query 'LoadBalancerDescriptions[*].Instances[*].InstanceId' \
+        --output text)
+    if [ $? != 0 ]; then
+        msg "Couldn't describe ELB instance named '$elb_name'"
+        return 1
+    fi
+
+    msg "Checking health of '$instance_id' as known by ELB '$elb_name'"
+    local instance_health=$(get_instance_health_elb $instance_id $elb_name)
+    if [ $? != 0 ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+# Usage: get_elb_list <EC2 instance ID>
+#
+#   Finds all the ELBs that this instance is registered to. After execution, the variable
+#   "ELB_LIST" will contain the list of load balancers for the given instance.
+#
+#   If the given instance ID isn't found registered to any ELBs, the function returns non-zero
+get_elb_list() {
+    local instance_id=$1
+
+    local elb_list=""
+
+    elb_list=$($AWS_CLI elb describe-load-balancers \
+      --query $'LoadBalancerDescriptions[].[join(`,`,Instances[?InstanceId==`'$instance_id'`].InstanceId),LoadBalancerName]' \
+      --output text | grep $instance_id | awk '{ORS=" ";print $2}')
+
+    if [ -z "$elb_list" ]; then
+        return 1
+    else
+        msg "Got load balancer list of: $elb_list"
+        ELB_LIST=$elb_list
+        return 0
+    fi
+}
+
+# Usage: deregister_instance <EC2 instance ID> <ELB name>
+#
+#   Deregisters <EC2 instance ID> from <ELB name>.
+deregister_instance() {
+    local instance_id=$1
+    local elb_name=$2
+
+    $AWS_CLI elb deregister-instances-from-load-balancer \
+        --load-balancer-name $elb_name \
+        --instances $instance_id 1> /dev/null
+
+    return $?
+}
+
+# Usage: register_instance <EC2 instance ID> <ELB name>
+#
+#   Registers <EC2 instance ID> to <ELB name>.
+register_instance() {
+    local instance_id=$1
+    local elb_name=$2
+
+    $AWS_CLI elb register-instances-with-load-balancer \
+        --load-balancer-name $elb_name \
+        --instances $instance_id 1> /dev/null
+
+    return $?
+}
+
+# Usage: check_cli_version [version-to-check] [desired version]
+#
+#   Without any arguments, checks that the installed version of the AWS CLI is at least at version
+#   $MIN_CLI_VERSION. Returns non-zero if the version is not high enough.
+check_cli_version() {
+    if [ -z $1 ]; then
+        version=$($AWS_CLI --version 2>&1 | cut -f1 -d' ' | cut -f2 -d/)
+    else
+        version=$1
+    fi
+
+    if [ -z "$2" ]; then
+        min_version=$MIN_CLI_VERSION
+    else
+        min_version=$2
+    fi
+
+    x=$(echo $version | cut -f1 -d.)
+    y=$(echo $version | cut -f2 -d.)
+    z=$(echo $version | cut -f3 -d.)
+
+    min_x=$(echo $min_version | cut -f1 -d.)
+    min_y=$(echo $min_version | cut -f2 -d.)
+    min_z=$(echo $min_version | cut -f3 -d.)
+
+    msg "Checking minimum required CLI version (${min_version}) against installed version ($version)"
+
+    if [ $x -lt $min_x ]; then
+        return 1
+    elif [ $y -lt $min_y ]; then
+        return 1
+    elif [ $y -gt $min_y ]; then
+        return 0
+    elif [ $z -ge $min_z ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Usage: msg <message>
+#
+#   Writes <message> to STDERR only if $DEBUG is true, otherwise has no effect.
+msg() {
+    local message=$1
+    $DEBUG && echo $message 1>&2
+}
+
+# Usage: error_exit <message>
+#
+#   Writes <message> to STDERR as a "fatal" and immediately exits the currently running script.
+error_exit() {
+    local message=$1
+
+    echo "[FATAL] $message" 1>&2
+    exit 1
+}
+
+# Usage: get_instance_id
+#
+#   Writes to STDOUT the EC2 instance ID for the local instance. Returns non-zero if the local
+#   instance metadata URL is inaccessible.
+get_instance_id() {
+    curl -s http://169.254.169.254/latest/meta-data/instance-id
+    return $?
+}

--- a/deploy/scripts/aws/deregister_from_elb.sh
+++ b/deploy/scripts/aws/deregister_from_elb.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+#
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+. $(dirname $0)/common_functions.sh
+
+msg "Running AWS CLI with region: $(get_instance_region)"
+
+# get this instance's ID
+INSTANCE_ID=$(get_instance_id)
+if [ $? != 0 -o -z "$INSTANCE_ID" ]; then
+    error_exit "Unable to get this instance's ID; cannot continue."
+fi
+
+# Get current time
+msg "Started $(basename $0) at $(/bin/date "+%F %T")"
+start_sec=$(/bin/date +%s.%N)
+
+msg "Checking if instance $INSTANCE_ID is part of an AutoScaling group"
+asg=$(autoscaling_group_name $INSTANCE_ID)
+if [ $? == 0 -a -n "${asg}" ]; then
+    msg "Found AutoScaling group for instance $INSTANCE_ID: ${asg}"
+    
+    msg "Checking that installed CLI version is at least at version required for AutoScaling Standby"
+    check_cli_version
+    if [ $? != 0 ]; then
+        error_exit "CLI must be at least version ${MIN_CLI_X}.${MIN_CLI_Y}.${MIN_CLI_Z} to work with AutoScaling Standby"
+    fi
+
+    msg "Attempting to put instance into Standby"
+    autoscaling_enter_standby $INSTANCE_ID "${asg}"
+    if [ $? != 0 ]; then
+        error_exit "Failed to move instance into standby"
+    else
+        msg "Instance is in standby"
+        finish_msg
+        exit 0
+    fi
+fi
+
+msg "Instance is not part of an ASG, trying with ELB..."
+
+set_flag "dereg" "true"
+
+if [ -z "$ELB_LIST" ]; then
+    error_exit "ELB_LIST is empty. Must have at least one load balancer to deregister from, or \"_all_\", \"_any_\" values."
+elif [ "${ELB_LIST}" = "_all_" ]; then
+    msg "Automatically finding all the ELBs that this instance is registered to..."
+    get_elb_list $INSTANCE_ID
+    if [ $? != 0 ]; then
+        error_exit "Couldn't find any. Must have at least one load balancer to deregister from."
+    fi
+    set_flag "ELBs" "$ELB_LIST"
+elif [ "${ELB_LIST}" = "_any_" ]; then
+    msg "Automatically finding all the ELBs that this instance is registered to..."
+    get_elb_list $INSTANCE_ID
+    if [ $? != 0 ]; then
+        msg "Couldn't find any, but ELB_LIST=any so finishing successfully without deregistering."
+        set_flag "ELBs" ""
+        finish_msg
+        exit 0
+    fi
+    set_flag "ELBs" "$ELB_LIST"
+fi
+
+# Loop through all LBs the user set, and attempt to deregister this instance from them.
+for elb in $ELB_LIST; do
+    msg "Checking validity of load balancer named '$elb'"
+    validate_elb $INSTANCE_ID $elb
+    if [ $? != 0 ]; then
+        msg "Error validating $elb; cannot continue with this LB"
+        continue
+    fi
+
+    msg "Deregistering $INSTANCE_ID from $elb"
+    deregister_instance $INSTANCE_ID $elb
+
+    if [ $? != 0 ]; then
+        error_exit "Failed to deregister instance $INSTANCE_ID from ELB $elb"
+    fi
+done
+
+# Wait for all deregistrations to finish
+msg "Waiting for instance to de-register from its load balancers"
+for elb in $ELB_LIST; do
+    wait_for_state "elb" $INSTANCE_ID "OutOfService" $elb
+    if [ $? != 0 ]; then
+        error_exit "Failed waiting for $INSTANCE_ID to leave $elb"
+    fi
+done
+
+finish_msg

--- a/deploy/scripts/aws/register_with_elb.sh
+++ b/deploy/scripts/aws/register_with_elb.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+. $(dirname $0)/common_functions.sh
+
+msg "Running AWS CLI with region: $(get_instance_region)"
+
+# get this instance's ID
+INSTANCE_ID=$(get_instance_id)
+if [ $? != 0 -o -z "$INSTANCE_ID" ]; then
+    error_exit "Unable to get this instance's ID; cannot continue."
+fi
+
+# Get current time
+msg "Started $(basename $0) at $(/bin/date "+%F %T")"
+start_sec=$(/bin/date +%s.%N)
+
+msg "Checking if instance $INSTANCE_ID is part of an AutoScaling group"
+asg=$(autoscaling_group_name $INSTANCE_ID)
+if [ $? == 0 -a -n "${asg}" ]; then
+    msg "Found AutoScaling group for instance $INSTANCE_ID: ${asg}"
+
+    msg "Checking that installed CLI version is at least at version required for AutoScaling Standby"
+    check_cli_version
+    if [ $? != 0 ]; then
+        error_exit "CLI must be at least version ${MIN_CLI_X}.${MIN_CLI_Y}.${MIN_CLI_Z} to work with AutoScaling Standby"
+    fi
+
+    msg "Attempting to move instance out of Standby"
+    autoscaling_exit_standby $INSTANCE_ID "${asg}"
+    if [ $? != 0 ]; then
+        error_exit "Failed to move instance out of standby"
+    else
+        msg "Instance is no longer in Standby"
+        finish_msg
+        exit 0
+    fi
+fi
+
+msg "Instance is not part of an ASG, continuing with ELB"
+
+if [ -z "$ELB_LIST" ]; then
+    error_exit "ELB_LIST is empty. Must have at least one load balancer to register to, or \"_all_\", \"_any_\" values."
+elif [ "${ELB_LIST}" = "_all_" ]; then
+    if [ "$(get_flag "dereg")" = "true" ]; then
+        msg "Finding all the ELBs that this instance was previously registered to"
+        if ! ELB_LIST=$(get_flag "ELBs"); then
+          error_exit "$FLAGFILE doesn't exist or is unreadble"
+        elif [ -z $ELB_LIST ]; then
+          error_exit "Couldn't find any. Must have at least one load balancer to register to."
+        fi
+    else
+        msg "Assuming this is the first deployment and ELB_LIST=_all_ so finishing successfully without registering."
+        finish_msg
+        exit 0
+    fi
+elif [ "${ELB_LIST}" = "_any_" ]; then
+    if [ "$(get_flag "dereg")" = "true" ]; then
+        msg "Finding all the ELBs that this instance was previously registered to"
+        if ! ELB_LIST=$(get_flag "ELBs"); then
+            error_exit "$FLAGFILE doesn't exist or is unreadble"
+        elif [ -z $ELB_LIST ]; then
+            msg "Couldn't find any, but ELB_LIST=_any_ so finishing successfully without registering."
+            remove_flagfile
+            finish_msg
+            exit 0
+        fi
+    else
+        msg "Assuming this is the first deployment and ELB_LIST=_any_ so finishing successfully without registering."
+        finish_msg
+        exit 0
+    fi
+fi
+
+# Loop through all LBs the user set, and attempt to register this instance to them.
+for elb in $ELB_LIST; do
+    msg "Checking validity of load balancer named '$elb'"
+    validate_elb $INSTANCE_ID $elb
+    if [ $? != 0 ]; then
+        msg "Error validating $elb; cannot continue with this LB"
+        continue
+    fi
+
+    msg "Registering $INSTANCE_ID to $elb"
+    register_instance $INSTANCE_ID $elb
+
+    if [ $? != 0 ]; then
+        error_exit "Failed to register instance $INSTANCE_ID from ELB $elb"
+    fi
+done
+
+# Wait for all registrations to finish
+msg "Waiting for instance to register to its load balancers"
+for elb in $ELB_LIST; do
+    wait_for_state "elb" $INSTANCE_ID "InService" $elb
+    if [ $? != 0 ]; then
+        error_exit "Failed waiting for $INSTANCE_ID to return to $elb"
+    fi
+done
+
+remove_flagfile
+
+finish_msg

--- a/deploy/scripts/validate.sh
+++ b/deploy/scripts/validate.sh
@@ -8,15 +8,5 @@ do
     sleep 5
 done
 
-echo "Service is up."
-echo "Wait for instance to be added to ELB..."
-
-# A hack to make sure the instance is back in the ELB before attempting
-# to deploy to the next instance. This should only exist for as long as
-# we don't have "proper" zero-downtime deploys.
-ELB_INTERVAL=10
-ELB_HEALTHY_THRESHOLD=4
-sleep $(($ELB_INTERVAL * ($ELB_HEALTHY_THRESHOLD + 1)))
-
 echo "Done."
 exit 0;


### PR DESCRIPTION
The scripts to deregister/register instances from the ELB are slightly modified versions of the templates provided by AWS:

https://github.com/awslabs/aws-codedeploy-samples

We will need to deploy https://github.com/openregister/deployment/pull/332 first but these changes should mean we will have zero-downtime deploys provided that no single request lasts longer than the ELB draining TTL.