### PR TITLE
Fix config to add schema name

### DIFF
--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -22,6 +22,8 @@ registerDomain: openregister.dev:8080
 
 register: school
 
+schema: school
+
 enableDownloadResource: true
 
 historyPageUrl: https://registers-history.herokuapp.com/school-eng


### PR DESCRIPTION
This PR updates `config.docker.yaml` to include schema name, which was added as part of the blitz story to merge databases.