### PR TITLE
Fix ZDD deploys in discovery environment

### DIFF
--- a/deploy/scripts/aws/common_functions.sh
+++ b/deploy/scripts/aws/common_functions.sh
@@ -16,13 +16,14 @@
 INSTANCE_ID=$(curl 169.254.169.254/2014-11-05/meta-data/instance-id)
 REGISTER_NAME=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Register --region eu-west-1 --query 'Tags[0].Value' --output text)
 ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Environment --region eu-west-1 --query 'Tags[0].Value' --output text)
+LOADBALANCER_ENV_NAME=$(echo $ENV | sed -e s/discovery/disco/)
 
 # ELB_LIST defines which Elastic Load Balancers this instance should be part of.
 # The elements in ELB_LIST should be separated by space. Safe default is "".
 # Set to "_all_" to automatically find all load balancers the instance is registered to.
 # Set to "_any_" will work as "_all_" but will not fail if instance is not attached to
 # any ASG or ELB, giving flexibility.
-ELB_LIST="$ENV--$REGISTER_NAME"
+ELB_LIST="$LOADBALANCER_ENV_NAME--$REGISTER_NAME"
 
 # Under normal circumstances, you shouldn't need to change anything below this line.
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
There is a max length for the names of ELBs; if we have an ELB with the
name `$ENV--$REGISTER-NAME` then the max length is exceeded in the
discovery environment. We specifically deal with this case by trimming
`discovery` to `disco` in our Terraform configuration. We need to mirror
that trimming here too.