### PR TITLE
Make container build use idiomatic gradle

### DIFF
--- a/run-application.sh
+++ b/run-application.sh
@@ -7,7 +7,7 @@ then
     --volume "$PWD":/usr/src/openregister-java \
     --workdir /usr/src/openregister-java \
     openjdk:8 \
-      bash -c "./gradlew stage"
+      bash -c "./gradlew assemble"
 fi
 
 docker-compose up


### PR DESCRIPTION
The `stage` task seems to be related to deploying to Heroku. It adds
nothing to the `assemble` task. The `assemble` task seems to be a more
commonly used task name for assembling a `.jar`.