### PR TITLE
Fix index query integration tests

### DIFF
--- a/src/test/java/uk/gov/register/functional/app/WipeDatabaseRule.java
+++ b/src/test/java/uk/gov/register/functional/app/WipeDatabaseRule.java
@@ -4,6 +4,7 @@ import org.junit.rules.ExternalResource;
 import org.skife.jdbi.v2.DBI;
 import uk.gov.register.db.SchemaRewriter;
 import uk.gov.register.functional.db.TestEntryDAO;
+import uk.gov.register.functional.db.TestIndexDAO;
 import uk.gov.register.functional.db.TestItemCommandDAO;
 import uk.gov.register.functional.db.TestRecordDAO;
 
@@ -31,6 +32,7 @@ public class WipeDatabaseRule extends ExternalResource {
                 handle.attach(TestEntryDAO.class).wipeData();
                 handle.attach(TestItemCommandDAO.class).wipeData();
                 handle.attach(TestRecordDAO.class).wipeData();
+                handle.attach(TestIndexDAO.class).wipeData();
             });
         }
     }

--- a/src/test/java/uk/gov/register/functional/db/TestIndexDAO.java
+++ b/src/test/java/uk/gov/register/functional/db/TestIndexDAO.java
@@ -1,0 +1,11 @@
+package uk.gov.register.functional.db;
+
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.OverrideStatementLocatorWith;
+import uk.gov.register.db.SchemaRewriter;
+
+@OverrideStatementLocatorWith(SchemaRewriter.class)
+public interface TestIndexDAO {
+    @SqlUpdate("delete from :schema.index;")
+    void wipeData();
+}

--- a/src/test/java/uk/gov/register/integration/IndexQueryDaoIntegrationTest.java
+++ b/src/test/java/uk/gov/register/integration/IndexQueryDaoIntegrationTest.java
@@ -5,6 +5,7 @@ import org.apache.log4j.MDC;
 import org.assertj.core.util.Lists;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
@@ -12,6 +13,7 @@ import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
 import uk.gov.register.db.IndexQueryDAO;
+import uk.gov.register.functional.app.WipeDatabaseRule;
 import uk.gov.register.util.HashValue;
 
 import java.time.Instant;
@@ -70,11 +72,13 @@ import static uk.gov.register.util.HashValue.decode;
  * entry7 - 97,96,[xxxbdc,xxx509],MD
  */
 public class IndexQueryDaoIntegrationTest {
-
     private DBI dbi;
     private Handle handle;
     private IndexQueryDAO dao;
     private Instant timestamp = Instant.ofEpochMilli(1490610633L * 1000L);
+
+    @Rule
+    public WipeDatabaseRule wipeDatabaseRule = new WipeDatabaseRule("address");
 
     @Before
     public void setup() {
@@ -87,10 +91,6 @@ public class IndexQueryDaoIntegrationTest {
 
     @After
     public void teardown() {
-        handle.execute("delete from address.item where sha256hex like 'xxx%' ");
-        handle.execute("delete from address.entry where sha256hex like 'xxx%' ");
-        handle.execute("delete from address.entry_item where sha256hex like 'xxx%' ");
-        handle.execute("delete from address.index where name = 'by-type' ");
         dbi.close(handle);
     }
 


### PR DESCRIPTION
This PR fixes the index query integration tests (which break when run individually), and uses the `WipeDatabaseRule` to reduce duplication.