### PR TITLE
Read total number of index records for records view.

### DIFF
--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -216,4 +216,9 @@ public class PostgresRegister implements Register {
         return derivationRecordIndex.getRecords(limit, offset, derivationName);
     }
 
+    @Override
+    public int getTotalDerivationRecords(String derivationName) {
+        return derivationRecordIndex.getTotalRecords(derivationName);
+    }
+
 }

--- a/src/main/java/uk/gov/register/core/RegisterReadOnly.java
+++ b/src/main/java/uk/gov/register/core/RegisterReadOnly.java
@@ -51,4 +51,7 @@ public interface RegisterReadOnly {
     Optional<Record> getDerivationRecord(String key, String derivationName);
 
     List<Record> getDerivationRecords(int limit, int offset, String derivationName);
+
+    int getTotalDerivationRecords(String derivationName);
 }
+

--- a/src/main/java/uk/gov/register/db/DerivationRecordIndex.java
+++ b/src/main/java/uk/gov/register/db/DerivationRecordIndex.java
@@ -2,7 +2,6 @@ package uk.gov.register.db;
 
 import uk.gov.register.core.Record;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,5 +20,9 @@ public class DerivationRecordIndex {
 
     public List<Record> getRecords(int limit, int offset, String derivationName) {
         return indexQueryDAO.findRecords(limit, offset, derivationName);
+    }
+
+    public int getTotalRecords(String derivationName) {
+        return indexQueryDAO.getTotalRecords(derivationName);
     }
 }

--- a/src/main/java/uk/gov/register/db/IndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/IndexQueryDAO.java
@@ -39,6 +39,9 @@ public interface IndexQueryDAO {
     @SqlQuery("select count(1) from :schema.index where name = :name and key = :key and sha256hex = :sha256hex and end_entry_number is null")
     int getExistingIndexCountForItem(@Bind("name") String indexName, @Bind("key") String key, @Bind("sha256hex") String sha256hex);
 
+    @SqlQuery(recordCountQuery)
+    int getTotalRecords(@Bind("name") String indexName);
+
     String recordForKeyQuery = "select " +
             " entry_numbers.mien as index_entry_number, " +
             " entry_numbers.men as entry_number, " +
@@ -237,5 +240,14 @@ public interface IndexQueryDAO {
             "  index_entry.\"key\"  " +
             "order by  " +
             "  ien  ";
+    
+    String recordCountQuery = "select " +
+            "count( distinct key) " +
+            "from " +
+            " :schema.index " +
+            "where " +
+            " name = :name" +
+            " and end_index_entry_number is null";
+
 
 }

--- a/src/main/java/uk/gov/register/resources/DerivationRecordResource.java
+++ b/src/main/java/uk/gov/register/resources/DerivationRecordResource.java
@@ -67,7 +67,7 @@ public class DerivationRecordResource {
     public RecordsView records(@PathParam("index-name") String indexName, @QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntegerParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntegerParam> pageSize) {
         ensureIndexIsAccessible(indexName);
 
-        IndexSizePagination pagination = setUpPagination(pageIndex, pageSize);
+        IndexSizePagination pagination = setUpPagination(pageIndex, pageSize, indexName);
         setContentDisposition();
         return getRecordsView(pagination.pageSize(), pagination.offset(), indexName);
     }
@@ -79,7 +79,7 @@ public class DerivationRecordResource {
     public PaginatedView<RecordsView> recordsHtml(@PathParam("index-name") String indexName, @QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntegerParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntegerParam> pageSize) {
         ensureIndexIsAccessible(indexName);
 
-        IndexSizePagination pagination = setUpPagination(pageIndex, pageSize);
+        IndexSizePagination pagination = setUpPagination(pageIndex, pageSize, indexName);
         setContentDisposition();
         RecordsView recordsView = getRecordsView(pagination.pageSize(), pagination.offset(), indexName);
         return viewFactory.getRecordListView(pagination, recordsView);
@@ -91,8 +91,8 @@ public class DerivationRecordResource {
         }
     }
 
-    private IndexSizePagination setUpPagination(@QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntegerParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntegerParam> pageSize) {
-        IndexSizePagination pagination = new IndexSizePagination(pageIndex.map(IntParam::get), pageSize.map(IntParam::get), register.getTotalRecords());
+    private IndexSizePagination setUpPagination(@QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntegerParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntegerParam> pageSize, String indexName) {
+        IndexSizePagination pagination = new IndexSizePagination(pageIndex.map(IntParam::get), pageSize.map(IntParam::get), register.getTotalDerivationRecords(indexName));
 
         if (pagination.hasNextPage()) {
             httpServletResponseAdapter.addLinkHeader("next", pagination.getNextPageLink());

--- a/src/test/java/uk/gov/register/integration/IndexQueryDaoIntegrationTest.java
+++ b/src/test/java/uk/gov/register/integration/IndexQueryDaoIntegrationTest.java
@@ -258,6 +258,14 @@ public class IndexQueryDaoIntegrationTest {
     }
 
     @Test
+    public void shouldCountRecords() {
+        nameChangeAndGroupChangeScenario();
+        int totalRecords = dao.getTotalRecords("by-type");
+
+        assertThat(totalRecords, is(2));
+    }
+
+    @Test
     public void shouldFindZeroItemsRecordForUA() {
         zeroItemsEntryScenario();
 
@@ -281,10 +289,17 @@ public class IndexQueryDaoIntegrationTest {
         assertThat(entries.size(), is(3));
 
         Entry entry1 = entries.get(1);
-        Entry expectedEntry1 = new Entry(92, 92,
-                Collections.emptyList(), timestamp, "UA");
+        Entry expectedEntry1 = new Entry(92, 92, Collections.emptyList(), timestamp, "UA");
         assertThat(entry1, equalTo(expectedEntry1));
 
+    }
+
+    @Test
+    public void shouldNotCountRecordsWithNoItems() {
+        zeroItemsEntryScenario();
+        int totalRecords = dao.getTotalRecords("by-type");
+
+        assertThat(totalRecords, is(1));
     }
 
     private void nameChangeAndGroupChangeScenario() {


### PR DESCRIPTION
This adds a query to IndexQueryDao to count the records in a given index. The result shown for e.g. the local-authorities-by-type index is correct but still looks very strange given the way the index records are rendered. 