### PR TITLE
Suppress jackson security vulnerability

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -14,4 +14,13 @@
         <gav regex="true">^org\.apache\.commons:commons-collections4:.*$</gav>
         <cve>CVE-2015-6420</cve>
     </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+       Suppress CVE-2016-7051 in all Jackson jar files
+   ]]></notes>
+        <gav regex="true">^com\.fasterxml\.jackson.*$</gav>
+        <cve>CVE-2016-7051</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
This PR fixes the currently breaking build by suppressing vulnerability `CVE-2016-7051` from the dependency check task. `CVE-2016-7051` regards the use of Jackson's `XmlMapper` class, which is not being used either in ORJ or in DropWizard (the latter also has a dependency on Jackson).

The dependency check report generated by this vulnerability is attached to this PR.
[Dependency-Check-Report.pdf](https://github.com/openregister/openregister-java/files/958486/Dependency-Check-Report.pdf)

Note: the various versions of jackson that are being used will hopefully be consolidated once we have upgraded DropWizard from 1.0.2 to 1.1.0.
