### PR TITLE
Upgrade DropWizard to 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,12 +71,6 @@ dependencies {
     compile(postgresClient) {
         exclude group: 'org.slf4j'
     }
-    compile(logbackClassic){
-        force = true
-    }
-    compile(logbackAccess){
-        force = true
-    }
 
     testCompile junit, mockito, dropwizardTest, wiremock
     testCompile dropwizardTest, jsoup, jsonAssert

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -22,5 +22,39 @@
         <gav regex="true">^com\.fasterxml\.jackson.*$</gav>
         <cve>CVE-2016-7051</cve>
     </suppress>
-
+    <suppress>
+        <notes><![CDATA[
+   file name: javax.el-api-2.2.4.jar
+   ]]></notes>
+        <gav regex="true">^javax\.el:javax\.el-api:.*$</gav>
+        <cve>CVE-2015-2808</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: javax.el-api-2.2.4.jar
+   ]]></notes>
+        <gav regex="true">^javax\.el:javax\.el-api:.*$</gav>
+        <cve>CVE-2013-2566</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: javax.el-2.2.4.jar
+   ]]></notes>
+        <gav regex="true">^org\.glassfish\.web:javax\.el:.*$</gav>
+        <cve>CVE-2015-2808</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: javax.el-2.2.4.jar
+   ]]></notes>
+        <gav regex="true">^org\.glassfish\.web:javax\.el:.*$</gav>
+        <cve>CVE-2013-2566</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: tomcat-jdbc-8.5.9.jar
+   ]]></notes>
+        <sha1>3d34018a222959ca69e0e0da5bc9988741cbe7ba</sha1>
+        <cpe>cpe:/a:apache_tomcat:apache_tomcat</cpe>
+    </suppress>
 </suppressions>

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -1,8 +1,8 @@
 ext {
-    dropwizard_version = '1.0.2'
+    dropwizard_version = '1.1.0'
     dropwizard_metrics_version = '3.1.0'
-    jersey_version = '2.23.2'
-    jackson_version = '2.8.3'
+    jersey_version = '2.25.1'
+    jackson_version = '2.8.7'
 
     verifiableLog = 'verifiable-log:verifiable-log:0.2.77'
 
@@ -31,7 +31,7 @@ ext {
     // force AWS's dependency on dataformat-cbor to match our jackson_version
     awsS3 = ['com.amazonaws:aws-java-sdk-s3:1.11.77', "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"]
 
-    jdbi = 'org.jdbi:jdbi:2.77'
+    jdbi = 'org.jdbi:jdbi:2.78'
     jersey_client = "org.glassfish.jersey.core:jersey-client:${jersey_version}"
 
     jacksonCsv = "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:${jackson_version}"
@@ -53,6 +53,6 @@ ext {
     junit = ['junit:junit:4.12','org.hamcrest:hamcrest-library:1.3']
     jsoup = 'org.jsoup:jsoup:1.9.2'
     jsonAssert ='org.skyscreamer:jsonassert:1.3.0'
-    mockito = 'org.mockito:mockito-core:1.9.5'
+    mockito = 'org.mockito:mockito-core:2.7.8'
     wiremock = 'com.github.tomakehurst:wiremock:2.1.12'
 }

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -44,10 +44,6 @@ ext {
 
     thymeleaf = 'org.thymeleaf:thymeleaf:2.1.5.RELEASE'
 
-    logbackClassic = 'ch.qos.logback:logback-classic:1.2.1'
-
-    logbackAccess = 'ch.qos.logback:logback-access:1.2.1'
-
     // test dependencies
     dropwizardTest = "io.dropwizard:dropwizard-testing:${dropwizard_version}"
     junit = ['junit:junit:4.12','org.hamcrest:hamcrest-library:1.3']

--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -114,7 +114,7 @@ public class EntryResourceFunctionalTest {
 
     @Test
     public void return404ResponseWhenEntryNotExist() {
-        assertThat(register.getRequest(address, "/entry/5001").getStatus(), equalTo(404));
+        assertThat(register.getRequest(address, "/entry/5001", MediaType.TEXT_HTML).getStatus(), equalTo(404));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
@@ -115,8 +115,6 @@ public class RSFExecutorTest {
     public void execute_failsForOrphanAppendEntry() {
         HashValue entry1hashValue = new HashValue(HashingAlgorithm.SHA256, "3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c");
 
-        when(appendEntryHandler.execute(any(), eq(register))).thenReturn(RegisterResult.createSuccessResult());
-        when(addItemHandler.execute(any(), eq(register))).thenReturn(RegisterResult.createSuccessResult());
         when(register.getItemBySha256(entry1hashValue)).thenReturn(Optional.empty());
 
         RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(asList(
@@ -136,7 +134,6 @@ public class RSFExecutorTest {
         HashValue entry1hashValue = new HashValue(HashingAlgorithm.SHA256, "3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c");
 
         when(appendEntryHandler.execute(any(), eq(register))).thenReturn(RegisterResult.createSuccessResult());
-        when(addItemHandler.execute(any(), eq(register))).thenReturn(RegisterResult.createSuccessResult());
         when(register.getItemBySha256(entry1hashValue)).thenReturn(Optional.of(item1));
 
         RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(singletonList(appendEntry1Command).iterator());
@@ -222,7 +219,6 @@ public class RSFExecutorTest {
         RegisterCommand appendEntry = new RegisterCommand("append-entry",
                 asList("2016-07-24T16:55:00Z", itemHash1 + ";" + itemHash2, "entry1-field-1-value"));
 
-        when(assertRootHashHandler.execute(any(), eq(register))).thenReturn(RegisterResult.createSuccessResult());
         when(addItemHandler.execute(any(), eq(register))).thenReturn(RegisterResult.createSuccessResult());
         when(appendEntryHandler.execute(any(), eq(register))).thenReturn(RegisterResult.createSuccessResult());
 

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -49,8 +49,6 @@ public class RegisterSerialisationFormatServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        when(registerContext.buildOnDemandRegister()).thenReturn(register);
-
         doAnswer(new Answer<Void>() {
             public Void answer(InvocationOnMock invocation) {
                 Consumer<Register> callback = (Consumer<Register>) invocation.getArguments()[0];

--- a/src/test/java/uk/gov/register/views/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/views/HomePageViewTest.java
@@ -86,8 +86,6 @@ public class HomePageViewTest {
     public void getLinkToRegisterRegister_returnsTheLinkOfRegisterRegister(){
         Instant instant = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543).toInstant(ZoneOffset.UTC);
 
-        when(mockRequestContext.getScheme()).thenReturn("https");
-
         RegisterMetadata registerMetadata = mock(RegisterMetadata.class);
 
         RegisterReadOnly register = mock(RegisterReadOnly.class);


### PR DESCRIPTION
This PR upgrades DropWizard from version 1.0.2 to 1.1.0 and some of its related dependencies. Certain tests have been modified to remove setup statements that triggered a newly introduced `UnnecessaryStubbingException` in Mockito.

Vulnerabilities `CVE-2015-2808` and `CVE-2013-2566` have been suppressed, as DropWizard uses TLSv1.2 by default and will only include the RC4 cipher if it is explicitly specified in `config.yaml` under an `excludedCipherSuites` property (see https://github.com/dropwizard/dropwizard/blob/9a311914295a5cc81a59f6dc5981286a57b0284f/docs/source/manual/core.rst under heading `SSL`). All vulnerabilities in `tomcat-jdbc-8.5.9.jar` have been suppressed as we do not use Tomcat.