### PR TITLE
Fix passing tenancy group into container environment

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -24,7 +24,7 @@ docker run \
     --restart "unless-stopped" \
     --volume /srv/openregister-java/telegraf.conf:/etc/telegraf/telegraf.conf:ro \
     --network openregisters \
-    --env REGISTER_NAME \
+    --env REGISTER_NAME=${REGISTER_NAME} \
     telegraf
 
 docker run \


### PR DESCRIPTION
We don't `export` the variable `REGISTER_NAME` so it isn't possible to
pass it into the telegraf container using Docker's short-hand for
already defined variables.