### PR TITLE
Resolve permission issue for development database

### DIFF
--- a/go
+++ b/go
@@ -3,7 +3,7 @@
 set -ue
 
 function ensure_db_exists {
-  psql -lqt | grep -wq $1 || createdb $1
+  psql -lqt | grep -wq $1 || createdb -O postgres $1
 }
 
 function ensure_user_exists {

--- a/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
+++ b/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
@@ -1,11 +1,13 @@
 package uk.gov.register.db.mappers;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.db.EntryQueryDAO;
+import uk.gov.register.functional.app.MigrateDatabaseRule;
 import uk.gov.register.functional.app.WipeDatabaseRule;
 import uk.gov.register.util.HashValue;
 
@@ -16,6 +18,9 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class EntryMapperTest {
+    @ClassRule
+    public static MigrateDatabaseRule migrateDatabaseRule = new MigrateDatabaseRule("address");
+
     @Rule
     public WipeDatabaseRule wipeDatabaseRule = new WipeDatabaseRule("address");
 

--- a/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
+++ b/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
@@ -16,20 +16,20 @@ import java.util.Collection;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
+import static uk.gov.register.functional.app.TestRegister.address;
 
 public class EntryMapperTest {
-    @ClassRule
-    public static MigrateDatabaseRule migrateDatabaseRule = new MigrateDatabaseRule("address");
+    private final DBI dbi = new DBI(address.getDatabaseConnectionString("EntryMapperTest"));
 
+    @ClassRule
+    public static MigrateDatabaseRule migrateDatabaseRule = new MigrateDatabaseRule(address);
     @Rule
-    public WipeDatabaseRule wipeDatabaseRule = new WipeDatabaseRule("address");
+    public WipeDatabaseRule wipeDatabaseRule = new WipeDatabaseRule(address);
 
     @Test
     public void map_returnsSameDateAndTimeInUTC() throws Exception {
         String expected = "2016-07-15T10:00:00Z";
         Instant expectedInstant = Instant.parse(expected);
-
-        DBI dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=EntryMapperTest");
 
         Collection<Entry> allEntriesNoPagination = dbi.withHandle(h -> {
             h.execute("insert into address.entry(entry_number, timestamp, sha256hex) values(5, :timestamp, 'abcdef')", expectedInstant.getEpochSecond());
@@ -44,8 +44,6 @@ public class EntryMapperTest {
 
     @Test
     public void map_returnsSingleItemHashForEntry() {
-        DBI dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=EntryMapperTest");
-
         Collection<Entry> allEntriesNoPagination = dbi.withHandle(h -> {
             h.execute("insert into address.entry(entry_number, timestamp, sha256hex) values(5, :timestamp, 'abcdef')", Instant.now().getEpochSecond());
             h.execute("insert into address.entry_item(entry_number, sha256hex) values(5, 'ghijkl')");
@@ -60,8 +58,6 @@ public class EntryMapperTest {
 
     @Test
     public void map_returnsMultipleItemHashesForEntry() {
-        DBI dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=EntryMapperTest");
-
         Collection<Entry> allEntriesNoPagination = dbi.withHandle(h -> {
             h.execute("insert into address.entry(entry_number, timestamp, sha256hex) values(5, :timestamp, 'abcdef')", Instant.now().getEpochSecond());
             h.execute("insert into address.entry_item(entry_number, sha256hex) values(5, 'abcdef')");
@@ -77,8 +73,6 @@ public class EntryMapperTest {
 
     @Test
     public void map_returnsNoItemHashesForEntry() {
-        DBI dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=EntryMapperTest");
-
         Collection<Entry> allEntriesNoPagination = dbi.withHandle(h -> {
             h.execute("insert into address.entry(entry_number, timestamp, sha256hex) values(5, :timestamp, 'abcdef')", Instant.now().getEpochSecond());
             return h.attach(EntryQueryDAO.class).getAllEntriesNoPagination();

--- a/src/test/java/uk/gov/register/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/functional/FindEntityTest.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.register.functional.app.TestRegister.address;
+import static uk.gov.register.views.representations.ExtraMediaType.TEXT_HTML;
 
 public class FindEntityTest {
 
@@ -41,7 +42,7 @@ public class FindEntityTest {
 
     @Test
     public void find_returnsTheCorrectTotalRecordsInPaginationHeader() {
-        Response response = register.getRequest(address, "/records/street/ellis");
+        Response response = register.getRequest(address, "/records/street/ellis", TEXT_HTML);
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
 

--- a/src/test/java/uk/gov/register/functional/app/MigrateDatabaseRule.java
+++ b/src/test/java/uk/gov/register/functional/app/MigrateDatabaseRule.java
@@ -1,0 +1,50 @@
+package uk.gov.register.functional.app;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.flyway.FlywayFactory;
+import org.flywaydb.core.Flyway;
+import org.junit.rules.ExternalResource;
+
+import javax.sql.DataSource;
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+public class MigrateDatabaseRule extends ExternalResource {
+    private final List<String> registers;
+
+    public MigrateDatabaseRule(String... registers) {
+        this.registers = newArrayList(registers);
+    }
+
+    private String postgresConnectionString() {
+        return "jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=MigrateDatabaseRule";
+    }
+
+    @Override
+    protected void before() {
+        for (String register : registers) {
+            FlywayFactory flywayFactory = getFlywayFactory(register);
+            Flyway flyway = flywayFactory.build(getDataSource());
+            flyway.setSchemas(register);
+            flyway.migrate();
+        }
+    }
+
+    private FlywayFactory getFlywayFactory(String registerName) {
+        FlywayFactory flywayFactory = new FlywayFactory();
+        flywayFactory.setLocations(Collections.singletonList("/sql"));
+        flywayFactory.setPlaceholders(Collections.singletonMap("registerName", registerName));
+        flywayFactory.setOutOfOrder(true);
+        return flywayFactory;
+    }
+
+    private DataSource getDataSource() {
+        DataSourceFactory dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass("org.postgresql.Driver");
+        dataSourceFactory.setUrl(postgresConnectionString());
+        return dataSourceFactory.build(new MetricRegistry(), "ft_openregister_java_multi");
+    }
+}

--- a/src/test/java/uk/gov/register/functional/app/MigrateDatabaseRule.java
+++ b/src/test/java/uk/gov/register/functional/app/MigrateDatabaseRule.java
@@ -13,22 +13,18 @@ import java.util.List;
 import static com.google.common.collect.Lists.newArrayList;
 
 public class MigrateDatabaseRule extends ExternalResource {
-    private final List<String> registers;
+    private final List<TestRegister> registers;
 
-    public MigrateDatabaseRule(String... registers) {
+    public MigrateDatabaseRule(TestRegister... registers) {
         this.registers = newArrayList(registers);
-    }
-
-    private String postgresConnectionString() {
-        return "jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=MigrateDatabaseRule";
     }
 
     @Override
     protected void before() {
-        for (String register : registers) {
-            FlywayFactory flywayFactory = getFlywayFactory(register);
-            Flyway flyway = flywayFactory.build(getDataSource());
-            flyway.setSchemas(register);
+        for (TestRegister register : registers) {
+            FlywayFactory flywayFactory = getFlywayFactory(register.name());
+            Flyway flyway = flywayFactory.build(getDataSource(register.getDatabaseConnectionString("MigrateDatabaseRule")));
+            flyway.setSchemas(register.name());
             flyway.migrate();
         }
     }
@@ -41,10 +37,10 @@ public class MigrateDatabaseRule extends ExternalResource {
         return flywayFactory;
     }
 
-    private DataSource getDataSource() {
+    private DataSource getDataSource(String databaseConnectionString) {
         DataSourceFactory dataSourceFactory = new DataSourceFactory();
         dataSourceFactory.setDriverClass("org.postgresql.Driver");
-        dataSourceFactory.setUrl(postgresConnectionString());
+        dataSourceFactory.setUrl(databaseConnectionString);
         return dataSourceFactory.build(new MetricRegistry(), "ft_openregister_java_multi");
     }
 }

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -21,7 +21,6 @@ import javax.ws.rs.core.Response;
 import java.net.InetAddress;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static javax.ws.rs.client.Entity.entity;
@@ -39,10 +38,7 @@ public class RegisterRule implements TestRule {
     public RegisterRule() {
         this.appRule = new DropwizardAppRule<>(RegisterApplication.class,
                 ResourceHelpers.resourceFilePath("test-app-config.yaml"));
-        String[] registers = Arrays.stream(TestRegister.values())
-                .map(TestRegister::name)
-                .toArray(String[]::new);
-        wipeRule = new WipeDatabaseRule(registers);
+        wipeRule = new WipeDatabaseRule(TestRegister.values());
         wholeRule = RuleChain
                 .outerRule(appRule)
                 .around(wipeRule);
@@ -117,12 +113,8 @@ public class RegisterRule implements TestRule {
      * the handle will automatically be closed by the RegisterRule
      */
     public Handle handleFor(TestRegister register) {
-        Handle handle = new DBI(postgresConnectionString(register)).open();
+        Handle handle = new DBI(register.getDatabaseConnectionString("RegisterRule")).open();
         handles.add(handle);
         return handle;
-    }
-
-    private String postgresConnectionString(TestRegister register) {
-        return String.format("jdbc:postgresql://localhost:5432/ft_openregister_java_%s?user=postgres&ApplicationName=RegisterRule", "multi");
     }
 }

--- a/src/test/java/uk/gov/register/functional/app/TestRegister.java
+++ b/src/test/java/uk/gov/register/functional/app/TestRegister.java
@@ -9,6 +9,7 @@ public enum TestRegister {
     private final String hostname = name() + "." + REGISTER_DOMAIN;
     private final String username;
     private final String password;
+    private final String databaseConnectionString = "jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=%s";
 
     TestRegister(String username, String password) {
         this.username = username;
@@ -23,5 +24,9 @@ public enum TestRegister {
         return HttpAuthenticationFeature.basicBuilder()
                 .credentials(username, password)
                 .build();
+    }
+
+    public String getDatabaseConnectionString(String applicationName) {
+        return String.format(databaseConnectionString, applicationName);
     }
 }

--- a/src/test/java/uk/gov/register/functional/app/WipeDatabaseRule.java
+++ b/src/test/java/uk/gov/register/functional/app/WipeDatabaseRule.java
@@ -13,21 +13,17 @@ import java.util.List;
 import static com.google.common.collect.Lists.newArrayList;
 
 public class WipeDatabaseRule extends ExternalResource {
-    private final List<String> registers;
+    private final List<TestRegister> registers;
 
-    public WipeDatabaseRule(String... registers) {
+    public WipeDatabaseRule(TestRegister... registers) {
         this.registers = newArrayList(registers);
-    }
-
-    private String postgresConnectionString() {
-        return "jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=WipeDatabaseRule";
     }
 
     @Override
     protected void before() {
-        for (String register : registers) {
-            SchemaRewriter.schema.set(register);
-            DBI dbi = new DBI(postgresConnectionString());
+        for (TestRegister register : registers) {
+            SchemaRewriter.schema.set(register.name());
+            DBI dbi = new DBI(register.getDatabaseConnectionString("WipeDatabaseRule"));
             dbi.useHandle(handle -> {
                 handle.attach(TestEntryDAO.class).wipeData();
                 handle.attach(TestItemCommandDAO.class).wipeData();

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.register.functional.app.TestRegister.address;
 
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
 import uk.gov.register.core.Entry;
@@ -54,7 +55,7 @@ import org.skife.jdbi.v2.Handle;
 public class PostgresRegisterTransactionalFunctionalTest {
 
     @Rule
-    public TestRule wipe = new WipeDatabaseRule("address");
+    public TestRule wipe = new WipeDatabaseRule(address);
     private TestItemCommandDAO testItemDAO;
     private DBI dbi;
     private TestEntryDAO testEntryDAO;
@@ -63,7 +64,7 @@ public class PostgresRegisterTransactionalFunctionalTest {
 
     @Before
     public void setUp() throws Exception {
-        dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=PGRegisterTxnFT");
+        dbi = new DBI(address.getDatabaseConnectionString("PGRegisterTxnFT"));
         dbi.registerContainerFactory(new OptionalContainerFactory());
         handle = dbi.open();
         testItemDAO = handle.attach(TestItemCommandDAO.class);

--- a/src/test/java/uk/gov/register/integration/IndexQueryDaoIntegrationTest.java
+++ b/src/test/java/uk/gov/register/integration/IndexQueryDaoIntegrationTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.*;
 import static uk.gov.register.core.HashingAlgorithm.SHA256;
+import static uk.gov.register.functional.app.TestRegister.address;
 import static uk.gov.register.util.HashValue.decode;
 
 /**
@@ -78,12 +79,12 @@ public class IndexQueryDaoIntegrationTest {
     private Instant timestamp = Instant.ofEpochMilli(1490610633L * 1000L);
 
     @Rule
-    public WipeDatabaseRule wipeDatabaseRule = new WipeDatabaseRule("address");
+    public WipeDatabaseRule wipeDatabaseRule = new WipeDatabaseRule(address);
 
     @Before
     public void setup() {
         MDC.put("register", "address");
-        dbi = new DBI("jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=PGRegisterTxnFT");
+        dbi = new DBI(address.getDatabaseConnectionString("PGRegisterTxnFT"));
         dbi.registerContainerFactory(new OptionalContainerFactory());
         handle = dbi.open();
         dao = handle.attach(IndexQueryDAO.class);


### PR DESCRIPTION
See individual commit messages for details.

The gist is that the `go` script created databases in a way that the `postgres` user did not have permission to create new schemas, which the app now needs to be able to do. 

There is also the introduction of a new test rule that performs database migrations for tests that require certain tables to exist. Before this change, whole classes of test would fail intermittently on a fresh database. This should mean hopefully mean that anyone coming to the project for the first time should not see test failures.