### PR TITLE
Make openregister-java container mounts writeable

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -43,7 +43,7 @@ docker run \
     --publish 80:8080 \
     --publish 8081:8081 \
     --restart "unless-stopped" \
-    --volume /srv/openregister-java:/srv/openregister-java:ro \
+    --volume /srv/openregister-java:/srv/openregister-java \
     --network openregisters \
     --log-driver=fluentd \
     --log-opt fluentd-async-connect=true \


### PR DESCRIPTION
Turns out these need to be writeable. After deploying this changes we
see errors of the shape:

```
{ "source":"stderr","log":"/srv/openregister-java/registers.yaml: Read-only file system" }
```

I'm not entirely convinced this should be the case but for the sake of
expediency we'll just make it writeable.