### PR TITLE
Redirect HTTP to HTTPS if application is behind a load balancer

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -22,6 +22,7 @@ import uk.gov.register.configuration.*;
 import uk.gov.register.core.*;
 import uk.gov.register.db.Factories;
 import uk.gov.register.filters.CorsBundle;
+import uk.gov.register.filters.HttpToHttpsRedirectFilter;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.resources.SchemeContext;
 import uk.gov.register.serialization.RSFCreator;
@@ -42,7 +43,9 @@ import uk.gov.register.util.ObjectReconstructor;
 import uk.gov.register.views.ViewFactory;
 
 import javax.inject.Singleton;
+import javax.servlet.DispatcherType;
 import javax.ws.rs.client.Client;
+import java.util.EnumSet;
 import java.util.Optional;
 
 public class RegisterApplication extends Application<RegisterConfiguration> {
@@ -101,6 +104,10 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         rsfCreator.register(new ItemToCommandMapper());
         rsfCreator.register(new EntryToCommandMapper());
         rsfCreator.register(new RootHashCommandMapper());
+
+        environment.servlets()
+                .addFilter("HttpToHttpsRedirectFilter", new HttpToHttpsRedirectFilter())
+                .addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");
 
         jersey.register(new AbstractBinder() {
             @Override

--- a/src/main/java/uk/gov/register/filters/HttpToHttpsRedirectFilter.java
+++ b/src/main/java/uk/gov/register/filters/HttpToHttpsRedirectFilter.java
@@ -1,0 +1,44 @@
+package uk.gov.register.filters;
+
+import com.google.common.net.HttpHeaders;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+public class HttpToHttpsRedirectFilter implements javax.servlet.Filter {
+
+   @Override
+   public void init(FilterConfig filterConfig) throws ServletException { }
+
+   @Override
+   public void destroy() { }
+
+   @Override
+   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+      HttpServletRequest httpRequest = (HttpServletRequest)request;
+
+      if ("http".equals(httpRequest.getHeader(HttpHeaders.X_FORWARDED_PROTO))) {
+         StringBuilder location = new StringBuilder();
+         location.append("https://");
+         location.append(httpRequest.getServerName());
+         location.append(httpRequest.getRequestURI());
+
+         String queryString = httpRequest.getQueryString();
+         if (queryString != null) {
+            location.append('?');
+            location.append(queryString);
+         }
+
+         HttpServletResponse httpResponse = (HttpServletResponse)response;
+         httpResponse.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+         httpResponse.setHeader(HttpHeaders.LOCATION, location.toString());
+         return;
+      }
+
+      chain.doFilter(request, response);
+   }
+}


### PR DESCRIPTION
If the application is running behind a load balancer and forwards the
original protocol the user used in the `X-Forwarded-Proto` header and
the original protocol is HTTP then upgrade to HTTPS.