### PR TITLE
Make record(s) rendering consistent for indexes and registers

### DIFF
--- a/src/main/java/uk/gov/register/core/Record.java
+++ b/src/main/java/uk/gov/register/core/Record.java
@@ -1,32 +1,28 @@
 package uk.gov.register.core;
 
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import uk.gov.register.util.HashValue;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
 public class Record {
     private final Entry entry;
-    private final Map<HashValue, Item> items = new HashMap<>();
+    private final List<Item> items = new ArrayList<>();
 
     public Record(Entry entry, Item item) {
         this.entry = entry;
-        this.items.put(item.getSha256hex(), item);
+        this.items.add(item);
     }
 
     public Record(Entry entry, Iterable<Item> items) {
         this.entry = entry;
-        items.forEach(i -> this.items.put(i.getSha256hex(), i));
+        items.forEach(i -> this.items.add(i));
     }
 
     public Entry getEntry() {
         return entry;
     }
 
-    public Map<HashValue, Item> getItems() {
+    public List<Item> getItems() {
         return items;
     }
 
@@ -47,14 +43,12 @@ public class Record {
 
         Record record = (Record) o;
 
-        if (!entry.equals(record.entry)) return false;
-        return items.equals(record.items);
+        return entry.equals(record.entry);
     }
 
     @Override
     public int hashCode() {
         int result = entry.hashCode();
-        result = 31 * result + items.hashCode();
         return result;
     }
 }

--- a/src/main/java/uk/gov/register/core/RegisterMetadata.java
+++ b/src/main/java/uk/gov/register/core/RegisterMetadata.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.base.Predicates.equalTo;
@@ -70,7 +71,16 @@ public class RegisterMetadata {
 
     @JsonIgnore
     public Iterable<String> getNonPrimaryFields() {
-        return Iterables.filter(fields, not(equalTo(registerName.value())));
+        if (!getPrimaryKeyField().isPresent()) {
+            return fields;
+        }
+
+        return Iterables.filter(fields, not(equalTo(getPrimaryKeyField().get())));
+    }
+
+    @JsonIgnore
+    public Optional<String> getPrimaryKeyField() {
+        return fields.stream().filter(this::isFieldPrimaryKey).findFirst();
     }
 
     public List<String> getFields() {
@@ -87,6 +97,10 @@ public class RegisterMetadata {
 
     public String getText() {
         return text;
+    }
+
+    private boolean isFieldPrimaryKey(String field) {
+        return field.equals(registerName.value());
     }
 
     @Override

--- a/src/main/java/uk/gov/register/resources/DerivationRecordResource.java
+++ b/src/main/java/uk/gov/register/resources/DerivationRecordResource.java
@@ -17,8 +17,6 @@ import javax.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.Optional;
 
-import static java.util.stream.Collectors.toList;
-
 @Path("/")
 public class DerivationRecordResource {
     private final HttpServletResponseAdapter httpServletResponseAdapter;
@@ -46,7 +44,7 @@ public class DerivationRecordResource {
         ensureIndexIsAccessible(indexName);
 
         return register.getDerivationRecord(key, indexName)
-                .map(r -> viewFactory.getDerivationRecordMediaView(r))
+                .map(r -> viewFactory.getRecordMediaView(r))
                 .orElseThrow(NotFoundException::new);
     }
 
@@ -82,7 +80,7 @@ public class DerivationRecordResource {
         IndexSizePagination pagination = setUpPagination(pageIndex, pageSize, indexName);
         setContentDisposition();
         RecordsView recordsView = getRecordsView(pagination.pageSize(), pagination.offset(), indexName);
-        return viewFactory.getRecordListView(pagination, recordsView);
+        return viewFactory.getRecordsView(pagination, recordsView);
     }
 
     protected void ensureIndexIsAccessible(String indexName) {
@@ -112,10 +110,6 @@ public class DerivationRecordResource {
 
     private RecordsView getRecordsView(int limit, int offset, String indexName) {
         List<Record> records = register.getDerivationRecords(limit, offset, indexName);
-        List<RecordView> recordViews = records.stream().map(r -> viewFactory.getDerivationRecordMediaView(r))
-                .collect(toList());
-        return viewFactory.getDerivationRecordsMediaView(recordViews);
+        return viewFactory.getIndexRecordsMediaView(records);
     }
-
-
 }

--- a/src/main/java/uk/gov/register/resources/DerivationRecordResource.java
+++ b/src/main/java/uk/gov/register/resources/DerivationRecordResource.java
@@ -46,7 +46,7 @@ public class DerivationRecordResource {
         ensureIndexIsAccessible(indexName);
 
         return register.getDerivationRecord(key, indexName)
-                .map(r -> viewFactory.getDerivationRecordMediaView(r, indexName))
+                .map(r -> viewFactory.getDerivationRecordMediaView(r))
                 .orElseThrow(NotFoundException::new);
     }
 
@@ -112,7 +112,7 @@ public class DerivationRecordResource {
 
     private RecordsView getRecordsView(int limit, int offset, String indexName) {
         List<Record> records = register.getDerivationRecords(limit, offset, indexName);
-        List<RecordView> recordViews = records.stream().map(r -> viewFactory.getDerivationRecordMediaView(r,indexName))
+        List<RecordView> recordViews = records.stream().map(r -> viewFactory.getDerivationRecordMediaView(r))
                 .collect(toList());
         return viewFactory.getDerivationRecordsMediaView(recordViews);
     }

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -22,7 +22,7 @@ public class RecordResource {
     private final RegisterName registerPrimaryKey;
 
     @Inject
-    public RecordResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext, ItemConverter itemConverter, RegisterMetadata registerMetadata) {
+    public RecordResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext) {
         this.register = register;
         this.viewFactory = viewFactory;
         this.requestContext = requestContext;

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -11,12 +11,7 @@ import uk.gov.register.views.representations.ExtraMediaType;
 import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static java.util.stream.Collectors.toList;
+import java.util.*;
 
 @Path("/")
 public class RecordResource {
@@ -25,7 +20,6 @@ public class RecordResource {
     private final RegisterReadOnly register;
     private final ViewFactory viewFactory;
     private final RegisterName registerPrimaryKey;
-    private final ItemConverter itemConverter;
 
     @Inject
     public RecordResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext, ItemConverter itemConverter, RegisterMetadata registerMetadata) {
@@ -34,7 +28,6 @@ public class RecordResource {
         this.requestContext = requestContext;
         this.httpServletResponseAdapter = new HttpServletResponseAdapter(requestContext.httpServletResponse);
         this.registerPrimaryKey = register.getRegisterName();
-        this.itemConverter = itemConverter;
     }
 
     @GET
@@ -91,7 +84,7 @@ public class RecordResource {
         List<Record> records = register.max100RecordsFacetedByKeyValue(key, value);
         Pagination pagination
                 = new IndexSizePagination(Optional.empty(), Optional.empty(), records.size());
-        return viewFactory.getRecordListView(pagination, facetedRecords(key, value));
+        return viewFactory.getRecordsView(pagination, facetedRecords(key, value));
     }
 
     @GET
@@ -100,8 +93,7 @@ public class RecordResource {
     @Timed
     public RecordsView facetedRecords(@PathParam("key") String key, @PathParam("value") String value) {
         List<Record> records = register.max100RecordsFacetedByKeyValue(key, value);
-        List<RecordView> recordViews = records.stream().map(viewFactory::getRecordMediaView).collect(toList());
-        return viewFactory.getRecordsMediaView(recordViews);
+        return viewFactory.getRecordsMediaView(records);
     }
 
     @GET
@@ -112,7 +104,7 @@ public class RecordResource {
         IndexSizePagination pagination = setUpPagination(pageIndex, pageSize);
         setContentDisposition();
         RecordsView recordsView = getRecordsView(pagination.pageSize(), pagination.offset());
-        return viewFactory.getRecordListView(pagination, recordsView);
+        return viewFactory.getRecordsView(pagination, recordsView);
     }
 
     @GET
@@ -146,7 +138,6 @@ public class RecordResource {
 
     private RecordsView getRecordsView(int limit, int offset) {
         List<Record> records = register.getRecords(limit, offset);
-        List<RecordView> recordViews = records.stream().map(viewFactory::getRecordMediaView).collect(toList());
-        return viewFactory.getRecordsMediaView(recordViews);
+        return viewFactory.getRecordsMediaView(records);
     }
 }

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
@@ -14,6 +14,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class ThymeleafView extends View {
@@ -75,6 +77,14 @@ public class ThymeleafView extends View {
         return Optional.ofNullable(getRegister().getCopyright()).map(
                 markdownProcessor::markdown
         );
+    }
+
+    @SuppressWarnings("unused, used by templates")
+    public List<String> getOrderedFieldNames() {
+        List<String> orderedFieldNames = new ArrayList<>();
+        getRegister().getPrimaryKeyField().ifPresent(orderedFieldNames::add);
+        getRegister().getNonPrimaryFields().forEach(orderedFieldNames::add);
+        return orderedFieldNames;
     }
 
     public ServletContext getServletContext() {

--- a/src/main/java/uk/gov/register/views/RecordView.java
+++ b/src/main/java/uk/gov/register/views/RecordView.java
@@ -21,26 +21,14 @@ public class RecordView implements CsvRepresentationView {
     private final Entry entry;
     private final Collection<ItemView> itemViews;
     private final Iterable<Field> fields;
-    private final boolean isRegister;
-    private final String path;
 
     public RecordView(Entry entry, Collection<ItemView> itemViews, Iterable<Field> fields) {
         this.entry = entry;
         this.itemViews = itemViews;
         this.fields = fields;
-        this.isRegister = true;
-        this.path = "/record/";
     }
 
-    public RecordView(Entry entry, Collection<ItemView> itemViews, Iterable<Field> fields, String indexName) {
-        this.entry = entry;
-        this.itemViews = itemViews;
-        this.fields = fields;
-        this.isRegister = false;
-        this.path = partialPath(indexName);
-    }
-
-    public String getPrimaryKey() {
+    public String getEntryKey() {
         return entry.getKey();
     }
 
@@ -72,10 +60,6 @@ public class RecordView implements CsvRepresentationView {
         return itemViews.stream().map(iv -> iv.getContent()).collect(Collectors.toSet());
     }
 
-    public String getPath() {
-        return path;
-    }
-
     public List<RecordView> asList(){
         return Arrays.asList(this);
     }
@@ -98,13 +82,11 @@ public class RecordView implements CsvRepresentationView {
         return fields;
     }
 
-    public boolean isRegister() {
-        return isRegister;
+    @SuppressWarnings("unused, used by template")
+    public boolean displayEntryKey() {
+        return false;
     }
 
-    private String partialPath(String indexName){
-        StringJoiner joiner = new StringJoiner("/","/","/");
-        joiner.add("index").add(indexName).add("record");
-        return joiner.toString();
-    }
+    @SuppressWarnings("unused, used by template")
+    public boolean resolveLinks() { return true; }
 }

--- a/src/main/java/uk/gov/register/views/RecordView.java
+++ b/src/main/java/uk/gov/register/views/RecordView.java
@@ -1,92 +1,23 @@
 package uk.gov.register.views;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import io.dropwizard.jackson.Jackson;
+import com.google.common.collect.ImmutableList;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Field;
-import uk.gov.register.core.FieldValue;
 import uk.gov.register.core.Record;
-import uk.gov.register.views.representations.CsvRepresentation;
+import uk.gov.register.service.ItemConverter;
 
-import java.util.*;
-import java.util.stream.Collectors;
+public class RecordView extends RecordsView {
 
-public class RecordView implements CsvRepresentationView {
-    private final Entry entry;
-    private final Collection<ItemView> itemViews;
-    private final Iterable<Field> fields;
-
-    public RecordView(Entry entry, Collection<ItemView> itemViews, Iterable<Field> fields) {
-        this.entry = entry;
-        this.itemViews = itemViews;
-        this.fields = fields;
+    public RecordView(Record record, Iterable<Field> fields, ItemConverter itemConverter) {
+        super(ImmutableList.of(record), fields, itemConverter, true, false);
     }
 
+    @SuppressWarnings("unused, used by template")
     public String getEntryKey() {
-        return entry.getKey();
+        return getEntry().getKey();
     }
 
-    @SuppressWarnings("unused, used to create the json representation of this class")
-    @JsonValue
-    public Map<String, JsonNode> getRecordJson() {
-        ObjectMapper objectMapper = Jackson.newObjectMapper();
-        ObjectNode jsonNodes = objectMapper.convertValue(entry, ObjectNode.class);
-        jsonNodes.remove("item-hash");
-        ArrayNode items = jsonNodes.putArray("item");
-        itemViews.forEach( iv -> items.add(objectMapper.convertValue(iv, ObjectNode.class)));
-        return ImmutableMap.of(entry.getKey(), jsonNodes);
+    private Entry getEntry() {
+        return getRecords().keySet().stream().findFirst().get();
     }
-
-    ArrayNode getFlatRecordJson() {
-        ObjectMapper objectMapper = Jackson.newObjectMapper();
-        ArrayNode arrayNode = objectMapper.createArrayNode();
-        itemViews.forEach( iv -> {
-            ObjectNode jsonNodes = objectMapper.convertValue(entry, ObjectNode.class);
-            jsonNodes.remove("item-hash");
-            jsonNodes.setAll(objectMapper.convertValue(iv, ObjectNode.class));
-            arrayNode.add(jsonNodes);
-        });
-
-        return arrayNode;
-    }
-
-    public Set<Map<String, FieldValue>> getContent() {
-        return itemViews.stream().map(iv -> iv.getContent()).collect(Collectors.toSet());
-    }
-
-    public List<RecordView> asList(){
-        return Arrays.asList(this);
-    }
-
-    @Override
-    public CsvRepresentation<ArrayNode> csvRepresentation() {
-        Iterable<String> fieldNames = Iterables.transform(fields, f -> f.fieldName);
-        return new CsvRepresentation<>(Record.csvSchema(fieldNames), getFlatRecordJson());
-    }
-
-    public Collection<ItemView> getItemViews() {
-        return itemViews;
-    }
-
-    public Entry getEntry() {
-        return entry;
-    }
-
-    public Iterable<Field> getFields() {
-        return fields;
-    }
-
-    @SuppressWarnings("unused, used by template")
-    public boolean displayEntryKey() {
-        return false;
-    }
-
-    @SuppressWarnings("unused, used by template")
-    public boolean resolveLinks() { return true; }
 }

--- a/src/main/java/uk/gov/register/views/RecordsView.java
+++ b/src/main/java/uk/gov/register/views/RecordsView.java
@@ -18,7 +18,6 @@ public class RecordsView implements CsvRepresentationView {
     private List<RecordView> records;
     private final boolean isRegister;
 
-
     private Iterable<Field> fields;
 
     public RecordsView(List<RecordView> records, Iterable<Field> fields, boolean isRegister) {
@@ -59,7 +58,11 @@ public class RecordsView implements CsvRepresentationView {
         return fields;
     }
 
-    public boolean isRegister() {
-        return isRegister;
+    @SuppressWarnings("unused, used by template")
+    public boolean displayEntryKey() {
+        return !isRegister;
     }
+
+    @SuppressWarnings("unused, used by template")
+    public boolean resolveLinks() { return false; }
 }

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -9,7 +9,6 @@ import uk.gov.register.resources.Pagination;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.service.ItemConverter;
 import uk.gov.register.service.RegisterLinkService;
-import uk.gov.register.util.HashValue;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -125,7 +124,7 @@ public class ViewFactory {
         return getAttributionView("record.html", record);
     }
 
-    public PaginatedView<RecordsView> getRecordListView(Pagination pagination, RecordsView recordsView) {
+    public PaginatedView<RecordsView> getRecordsView(Pagination pagination, RecordsView recordsView) {
         return new PaginatedView<>("records.html", requestContext, getRegistry(), getBranding(), register.get(), registerTrackingConfiguration.get(), registerResolver, pagination,
                 recordsView);
     }
@@ -135,23 +134,15 @@ public class ViewFactory {
     }
 
     public RecordView getRecordMediaView(Record record) {
-        Map<HashValue, Item> itemMap = record.getItems();
-        Set<ItemView> itemViews = itemMap.values().stream().map(this::getItemMediaView).collect(Collectors.toSet());
-        return new RecordView(record.getEntry(), itemViews , getFields());
+        return new RecordView(record, getFields(), itemConverter);
     }
 
-    public RecordView getDerivationRecordMediaView(Record record) {
-        Map<HashValue, Item> itemMap = record.getItems();
-        Set<ItemView> itemViews = itemMap.values().stream().map(this::getItemMediaView).collect(Collectors.toSet());
-        return new RecordView(record.getEntry(), itemViews , getFields());
+    public RecordsView getRecordsMediaView(List<Record> records) {
+        return new RecordsView(records, getFields(), itemConverter, false, false);
     }
 
-    public RecordsView getRecordsMediaView(List<RecordView> recordViews) {
-        return new RecordsView(recordViews, getFields());
-    }
-
-    public RecordsView getDerivationRecordsMediaView(List<RecordView> recordViews) {
-        return new RecordsView(recordViews, getFields(), false);
+    public RecordsView getIndexRecordsMediaView(List<Record> records) {
+        return new RecordsView(records, getFields(), itemConverter, false, true);
     }
 
     private PublicBody getRegistry() {

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -140,10 +140,10 @@ public class ViewFactory {
         return new RecordView(record.getEntry(), itemViews , getFields());
     }
 
-    public RecordView getDerivationRecordMediaView(Record record, String indexName) {
+    public RecordView getDerivationRecordMediaView(Record record) {
         Map<HashValue, Item> itemMap = record.getItems();
         Set<ItemView> itemViews = itemMap.values().stream().map(this::getItemMediaView).collect(Collectors.toSet());
-        return new RecordView(record.getEntry(), itemViews , getFields(), indexName);
+        return new RecordView(record.getEntry(), itemViews , getFields());
     }
 
     public RecordsView getRecordsMediaView(List<RecordView> recordViews) {

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
@@ -9,7 +9,6 @@ import uk.gov.register.core.Entry;
 import uk.gov.register.core.RegisterName;
 import uk.gov.register.core.RegisterResolver;
 import uk.gov.register.views.ItemView;
-import uk.gov.register.views.RecordView;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.inject.Inject;
@@ -17,11 +16,12 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.ext.Provider;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 @Provider
 @Produces(ExtraMediaType.TEXT_TTL)
-public class RecordTurtleWriter extends TurtleRepresentationWriter<RecordView> {
+public class RecordTurtleWriter extends TurtleRepresentationWriter<Map.Entry<Entry, List<ItemView>>> {
 
     @Inject
     public RecordTurtleWriter(javax.inject.Provider<RegisterName> registerNameProvider, RegisterResolver registerResolver) {
@@ -29,15 +29,15 @@ public class RecordTurtleWriter extends TurtleRepresentationWriter<RecordView> {
     }
 
     @Override
-    protected Model rdfModelFor(RecordView view) {
-        Entry entry = view.getEntry();
-        ItemView itemView = view.getItemViews().stream().findFirst().get();
+    protected Model rdfModelFor(Map.Entry<Entry, List<ItemView>> record) {
+        Entry entry = record.getKey();
+        ItemView itemView = record.getValue().get(0);
 
         Model recordModel = ModelFactory.createDefaultModel();
         Model entryModel = new EntryTurtleWriter(registerNameProvider, registerResolver).rdfModelFor(entry, false);
         Model itemModel = new ItemTurtleWriter(registerNameProvider, registerResolver).rdfModelFor(itemView);
 
-        Resource recordResource = recordModel.createResource(recordUri(view.getEntryKey()).toString());
+        Resource recordResource = recordModel.createResource(recordUri(entry.getKey()).toString());
         addPropertiesToResource(recordResource, entryModel.getResource(entryUri(Integer.toString(entry.getEntryNumber())).toString()));
         addPropertiesToResource(recordResource, itemModel.getResource(itemUri(itemView.getItemHash().encode()).toString()));
 

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
@@ -37,7 +37,7 @@ public class RecordTurtleWriter extends TurtleRepresentationWriter<RecordView> {
         Model entryModel = new EntryTurtleWriter(registerNameProvider, registerResolver).rdfModelFor(entry, false);
         Model itemModel = new ItemTurtleWriter(registerNameProvider, registerResolver).rdfModelFor(itemView);
 
-        Resource recordResource = recordModel.createResource(recordUri(view.getPrimaryKey()).toString());
+        Resource recordResource = recordModel.createResource(recordUri(view.getEntryKey()).toString());
         addPropertiesToResource(recordResource, entryModel.getResource(entryUri(Integer.toString(entry.getEntryNumber())).toString()));
         addPropertiesToResource(recordResource, itemModel.getResource(itemUri(itemView.getItemHash().encode()).toString()));
 

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordsTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordsTurtleWriter.java
@@ -24,7 +24,7 @@ public class RecordsTurtleWriter extends TurtleRepresentationWriter<RecordsView>
     protected Model rdfModelFor(RecordsView view) {
         Model model = ModelFactory.createDefaultModel();
         RecordTurtleWriter recordTurtleWriter = new RecordTurtleWriter(registerNameProvider, registerResolver);
-        view.getRecords().forEach(r -> model.add(recordTurtleWriter.rdfModelFor(r)));
+        view.getRecords().entrySet().forEach(r -> model.add(recordTurtleWriter.rdfModelFor(r)));
         return model;
     }
 }

--- a/src/main/resources/templates/fragments/record-table-item-cells.html
+++ b/src/main/resources/templates/fragments/record-table-item-cells.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<body>
+<div th:fragment="record-table-item-cells(item, fieldNames, resolveAll, firstColumnLink)">
+  <th:block th:each="fieldName, iterStatus : ${fieldNames}">
+    <td th:if="${item.content.containsKey(fieldName)}" class="field-list field-list-in-table">
+      <ul th:if="${item.content.get(fieldName).isList()}">
+        <th:block th:each="fieldValue: ${item.content.get(fieldName)}"
+                  th:with="useFirstColumnLink = ${iterStatus.index == 0 and firstColumnLink != null}, resolveRegisterLink = ${resolveAll and fieldValue.isLink()}">
+          <li th:if="${resolveRegisterLink or useFirstColumnLink}">
+            <a th:href="${resolveRegisterLink} ? ${linkResolver.resolve(fieldValue)} : ${firstColumnLink}" th:text="${fieldValue.value}"></a>
+          </li>
+          <li th:unless="${resolveRegisterLink or useFirstColumnLink}" th:text="${fieldValue.value}"></li>
+        </th:block>
+      </ul>
+      <th:block th:unless="${item.content.get(fieldName).isList()}" th:with="fieldValue=${item.content.get(fieldName)}, useFirstColumnLink = ${iterStatus.index == 0 and firstColumnLink != null}, resolveRegisterLink = ${resolveAll and item.content.get(fieldName).isLink()}">
+        <a th:if="${resolveRegisterLink or useFirstColumnLink}" th:href="${resolveRegisterLink} ? ${linkResolver.resolve(fieldValue)} : ${firstColumnLink}"
+           th:text="${fieldValue.value}"></a>
+        <p th:unless="${resolveRegisterLink or useFirstColumnLink}" th:text="${fieldValue.value}"></p>
+      </th:block>
+    </td>
+    <td th:unless="${item.content.get(fieldName)}"></td>
+  </th:block>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/record-table-item-cells.html
+++ b/src/main/resources/templates/fragments/record-table-item-cells.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <body>
-<div th:fragment="record-table-item-cells(item, fieldNames, resolveAll, firstColumnLink)">
+<div th:fragment="record-table-item-cells(item, fieldNames, resolveAllLinks, firstColumnLink)">
   <th:block th:each="fieldName, iterStatus : ${fieldNames}">
     <td th:if="${item.content.containsKey(fieldName)}" class="field-list field-list-in-table">
       <ul th:if="${item.content.get(fieldName).isList()}">
         <th:block th:each="fieldValue: ${item.content.get(fieldName)}"
-                  th:with="useFirstColumnLink = ${iterStatus.index == 0 and firstColumnLink != null}, resolveRegisterLink = ${resolveAll and fieldValue.isLink()}">
+                  th:with="useFirstColumnLink = ${iterStatus.index == 0 and firstColumnLink != null}, resolveRegisterLink = ${resolveAllLinks and fieldValue.isLink()}">
           <li th:if="${resolveRegisterLink or useFirstColumnLink}">
             <a th:href="${resolveRegisterLink} ? ${linkResolver.resolve(fieldValue)} : ${firstColumnLink}" th:text="${fieldValue.value}"></a>
           </li>
           <li th:unless="${resolveRegisterLink or useFirstColumnLink}" th:text="${fieldValue.value}"></li>
         </th:block>
       </ul>
-      <th:block th:unless="${item.content.get(fieldName).isList()}" th:with="fieldValue=${item.content.get(fieldName)}, useFirstColumnLink = ${iterStatus.index == 0 and firstColumnLink != null}, resolveRegisterLink = ${resolveAll and item.content.get(fieldName).isLink()}">
+      <th:block th:unless="${item.content.get(fieldName).isList()}" th:with="fieldValue=${item.content.get(fieldName)}, useFirstColumnLink = ${iterStatus.index == 0 and firstColumnLink != null}, resolveRegisterLink = ${resolveAllLinks and item.content.get(fieldName).isLink()}">
         <a th:if="${resolveRegisterLink or useFirstColumnLink}" th:href="${resolveRegisterLink} ? ${linkResolver.resolve(fieldValue)} : ${firstColumnLink}"
            th:text="${fieldValue.value}"></a>
         <p th:unless="${resolveRegisterLink or useFirstColumnLink}" th:text="${fieldValue.value}"></p>

--- a/src/main/resources/templates/fragments/record-table.html
+++ b/src/main/resources/templates/fragments/record-table.html
@@ -3,15 +3,11 @@
 <body>
 <div th:fragment="record-table(view, records)">
   <table th:if="${!records.isEmpty()}"
-         th:with="fields = ${ view.isRegister()}? ${register.nonPrimaryFields} : ${register.fields}">
+         th:with="itemFieldNames = ${orderedFieldNames}">
     <thead>
     <tr>
-      <th scope="col" th:unless="${ view.isRegister()}">key</th>
-      <th scope="col" th:if="${ view.isRegister()}">
-        <a th:href="${linkResolver.resolve(new uk.gov.register.core.RegisterName('field'), registerId)}"
-           th:text="${registerId}"></a>
-      </th>
-      <th scope="col" th:each="fieldName : ${fields}">
+      <th scope="col" th:if="${view.displayEntryKey()}">key</th>
+      <th scope="col" th:each="fieldName : ${itemFieldNames}">
         <a th:href="${linkResolver.resolve(new uk.gov.register.core.RegisterName('field'), fieldName)}"
            th:text="${fieldName}"></a>
       </th>
@@ -19,28 +15,11 @@
     </thead>
     <tbody>
     <th:block th:each="record : ${records}">
-      <tr th:each="item : ${record.itemViews}">
-        <td>
-          <a th:href="${record.path + record.primaryKey}" th:text="${record.primaryKey}"></a>
+      <tr th:each="item : ${record.itemViews}" th:with="firstItemColumnLink = ${view.displayEntryKey()} ? ${null} : ${'../record/' + record.entryKey}">
+        <td th:if="${view.displayEntryKey()}">
+          <a th:href="${'./record/' + record.entryKey}" th:text="${record.entryKey}"></a>
         </td>
-        <th:block th:each="fieldName : ${fields}">
-          <td th:if="${item.content.containsKey(fieldName)}" class="field-list field-list-in-table">
-            <ul th:if="${item.content.get(fieldName).isList()}">
-              <th:block th:each="fieldValue: ${item.content.get(fieldName)}">
-                <li th:if="${fieldValue.isLink()}">
-                  <a th:href="${linkResolver.resolve(fieldValue)}" th:text="${fieldValue.value}"></a>
-                </li>
-                <li th:unless="${fieldValue.isLink()}" th:text="${fieldValue.value}"></li>
-              </th:block>
-            </ul>
-            <th:block th:unless="${item.content.get(fieldName).isList()}" th:with="fieldValue=${item.content.get(fieldName)}">
-              <a th:if="${fieldValue.isLink()}" th:href="${linkResolver.resolve(fieldValue)}"
-                 th:text="${fieldValue.value}"></a>
-              <p th:unless="${fieldValue.isLink()}" th:text="${fieldValue.value}"></p>
-            </th:block>
-          </td>
-          <td th:unless="${item.content.get(fieldName)}"></td>
-        </th:block>
+        <div th:include="fragments/record-table-item-cells.html :: record-table-item-cells (item = ${item}, fieldNames = ${itemFieldNames}, resolveAll = ${view.resolveLinks()}, firstColumnLink = ${firstItemColumnLink})"></div>
       </tr>
     </th:block>
     </tbody>

--- a/src/main/resources/templates/fragments/record-table.html
+++ b/src/main/resources/templates/fragments/record-table.html
@@ -6,7 +6,7 @@
          th:with="itemFieldNames = ${orderedFieldNames}">
     <thead>
     <tr>
-      <th scope="col" th:if="${view.displayEntryKey()}">key</th>
+      <th scope="col" th:if="${view.displayEntryKeyColumn()}">key</th>
       <th scope="col" th:each="fieldName : ${itemFieldNames}">
         <a th:href="${linkResolver.resolve(new uk.gov.register.core.RegisterName('field'), fieldName)}"
            th:text="${fieldName}"></a>
@@ -15,11 +15,11 @@
     </thead>
     <tbody>
     <th:block th:each="record : ${records}">
-      <tr th:each="item : ${record.itemViews}" th:with="firstItemColumnLink = ${view.displayEntryKey()} ? ${null} : ${'../record/' + record.entryKey}">
-        <td th:if="${view.displayEntryKey()}">
-          <a th:href="${'./record/' + record.entryKey}" th:text="${record.entryKey}"></a>
+      <tr th:each="item : ${record.value}" th:with="firstItemColumnLink = ${view.displayEntryKeyColumn()} ? ${null} : ${'../record/' + record.key.key}">
+        <td th:if="${view.displayEntryKeyColumn()}">
+          <a th:href="${'./record/' + record.key.key}" th:text="${record.key.key}"></a>
         </td>
-        <div th:include="fragments/record-table-item-cells.html :: record-table-item-cells (item = ${item}, fieldNames = ${itemFieldNames}, resolveAll = ${view.resolveLinks()}, firstColumnLink = ${firstItemColumnLink})"></div>
+        <div th:include="fragments/record-table-item-cells.html :: record-table-item-cells (item = ${item}, fieldNames = ${itemFieldNames}, resolveAllLinks = ${view.resolveAllItemLinks()}, firstColumnLink = ${firstItemColumnLink})"></div>
       </tr>
     </th:block>
     </tbody>

--- a/src/main/resources/templates/record.html
+++ b/src/main/resources/templates/record.html
@@ -17,7 +17,7 @@
         <li>
           <a href="/records">Records</a>
         </li>
-        <li th:utext="${'Record ' + content.primaryKey}"></li>
+        <li th:utext="${'Record ' + content.entryKey}"></li>
       </ol>
     </div>
 
@@ -25,11 +25,11 @@
       <div class="column-two-thirds">
         <h1 class="heading-large">
           Record
-          <th:block th:utext="${content.primaryKey}"></th:block>
+          <th:block th:utext="${content.entryKey}"></th:block>
         </h1>
         <p th:if="${#bools.isTrue(registerId.value() == 'register')}">
-          <a th:href="${registerResolver.baseUriFor(new uk.gov.register.core.RegisterName(content.primaryKey))}"
-             th:utext="${'View ' + content.primaryKey + ' register'}">View this register.</a>
+          <a th:href="${registerResolver.baseUriFor(new uk.gov.register.core.RegisterName(content.entryKey))}"
+             th:utext="${'View ' + content.entryKey + ' register'}">View this register.</a>
         </p>
         <div th:include="fragments/data-formats.html::data-formats"></div>
         <details role="group">
@@ -45,7 +45,7 @@
     </div>
     <div th:include="fragments/record-table.html :: record-table (view = ${content}, records = ${content.asList()})" class="table-wrapper"></div>
     <p>
-      <a th:href="${'/record/' + content.primaryKey +'/entries'}">View all versions of this record</a>
+      <a th:href="${'/record/' + content.entryKey +'/entries'}">View all versions of this record</a>
     </p>
 
   </main>

--- a/src/main/resources/templates/record.html
+++ b/src/main/resources/templates/record.html
@@ -43,7 +43,7 @@
       </div>
       <div class="column-third" th:include="fragments/attribution.html::attribution"></div>
     </div>
-    <div th:include="fragments/record-table.html :: record-table (view = ${content}, records = ${content.asList()})" class="table-wrapper"></div>
+    <div th:include="fragments/record-table.html :: record-table (view = ${content}, records = ${content.records})" class="table-wrapper"></div>
     <p>
       <a th:href="${'/record/' + content.entryKey +'/entries'}">View all versions of this record</a>
     </p>

--- a/src/test/java/uk/gov/register/core/RecordTest.java
+++ b/src/test/java/uk/gov/register/core/RecordTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.core.Is.is;
 public class RecordTest {
     private final HashValue hash1 = new HashValue(HashingAlgorithm.SHA256, "hash1");
     private final HashValue hash2 = new HashValue(HashingAlgorithm.SHA256, "hash2");
+    private final HashValue hash3 = new HashValue(HashingAlgorithm.SHA256, "hash3");
 
     private final Item item1 = getItem("{\"key1\":\"value1\"}");
     private final Item item2 = getItem("{\"key2\":\"value2\"}");
@@ -74,7 +75,7 @@ public class RecordTest {
                 new Entry(1, Arrays.asList(hash1, hash2), Instant.parse("2017-03-10T00:00:00Z"), "key"),
                 Arrays.asList(item1, item2));
         Record record2 = new Record(
-                new Entry(1, Arrays.asList(hash2, hash1), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                new Entry(1, Arrays.asList(hash2, hash1, hash3), Instant.parse("2017-03-10T00:00:00Z"), "key"),
                 Arrays.asList(item2, item1, item3));
 
         assertThat(record1.equals(record2), is(false));
@@ -86,7 +87,7 @@ public class RecordTest {
                 new Entry(1, Arrays.asList(hash1, hash2), Instant.parse("2017-03-10T00:00:00Z"), "key"),
                 Arrays.asList(item1, item2));
         Record record2 = new Record(
-                new Entry(1, Arrays.asList(hash2, hash1), Instant.parse("2017-03-10T00:00:00Z"), "key"),
+                new Entry(1, Arrays.asList(hash2, hash1, hash3), Instant.parse("2017-03-10T00:00:00Z"), "key"),
                 Arrays.asList(item2, item1, item3));
 
         assertThat(record1.hashCode(), not(record2.hashCode()));

--- a/src/test/java/uk/gov/register/core/RegisterMetadataTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterMetadataTest.java
@@ -9,6 +9,8 @@ import io.dropwizard.jackson.Jackson;
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.nullValue;
@@ -29,12 +31,40 @@ public class RegisterMetadataTest {
     }
 
     @Test
+    public void getPrimaryKeyField_returnsFieldWithSameNameAsRegister() {
+        RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("company"), ImmutableList.of("address", "company", "secretary", "company-status", "company-accounts-category"), "", "", "", "alpha");
+
+        Optional<String> primaryField = registerMetadata.getPrimaryKeyField();
+
+        assertThat(primaryField.isPresent(), is(true));
+        assertThat(primaryField.get(), is("company"));
+    }
+
+    @Test
+    public void getPrimaryKeyField_returnsEmptyIfNoFieldExistsWithSameNameAsRegister() {
+        RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("company-index"), ImmutableList.of("address", "company", "secretary", "company-status", "company-accounts-category"), "", "", "", "alpha");
+
+        Optional<String> primaryField = registerMetadata.getPrimaryKeyField();
+
+        assertThat(primaryField.isPresent(), is(false));
+    }
+
+    @Test
     public void getNonPrimaryFields_returnsFieldsOtherThanPrimaryInConfiguredOrder() throws Exception {
         RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("company"), ImmutableList.of("address", "company", "secretary", "company-status", "company-accounts-category"), "", "", "", "alpha");
 
         Iterable<String> fields = registerMetadata.getNonPrimaryFields();
 
         assertThat(fields, IsIterableContainingInOrder.contains("address", "secretary", "company-status", "company-accounts-category"));
+    }
+
+    @Test
+    public void getNonPrimaryFields_returnsAllFieldsIfNoPrimaryKeyField() throws Exception {
+        RegisterMetadata registerMetadata = new RegisterMetadata(new RegisterName("company-index"), ImmutableList.of("address", "company", "secretary", "company-status", "company-accounts-category"), "", "", "", "alpha");
+
+        Iterable<String> fields = registerMetadata.getNonPrimaryFields();
+
+        assertThat(fields, IsIterableContainingInOrder.contains("address", "company", "secretary", "company-status", "company-accounts-category"));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/integration/IndexQueryDaoIntegrationTest.java
+++ b/src/test/java/uk/gov/register/integration/IndexQueryDaoIntegrationTest.java
@@ -108,13 +108,13 @@ public class IndexQueryDaoIntegrationTest {
         assertThat(record.getEntry().getIndexEntryNumber(), is(96));
 
         HashValue hash01c = decode(SHA256, "sha-256:xxx01c");
-        assertTrue(record.getItems().containsKey(hash01c));
-        Item item = record.getItems().get(hash01c);
+        assertTrue(record.getItems().stream().anyMatch(i -> i.getSha256hex().equals(hash01c)));
+        Item item = record.getItems().stream().filter(i -> i.getSha256hex().equals(hash01c)).findFirst().get();
         assertThat(item.getValue("name").get(), is("Bedford"));
 
         HashValue hash126 = decode(SHA256, "sha-256:xxx126");
-        assertTrue(record.getItems().containsKey(hash126));
-        Item item2 = record.getItems().get(hash126);
+        assertTrue(record.getItems().stream().anyMatch(i -> i.getSha256hex().equals(hash126)));
+        Item item2 = record.getItems().stream().filter(i -> i.getSha256hex().equals(hash126)).findFirst().get();
         assertThat(item2.getValue("name").get(), is("New Bath"));
     }
 
@@ -131,13 +131,13 @@ public class IndexQueryDaoIntegrationTest {
         assertThat(record.getEntry().getIndexEntryNumber(), is(97));
 
         HashValue hash1 = decode(SHA256, "sha-256:xxxbdc");
-        assertTrue("record should contain key sha-256:xxxbdc", record.getItems().containsKey(hash1));
-        Item item = record.getItems().get(hash1);
+        assertTrue("record should contain key sha-256:xxxbdc", record.getItems().stream().anyMatch(i -> i.getSha256hex().equals(hash1)));
+        Item item = record.getItems().stream().filter(i -> i.getSha256hex().equals(hash1)).findFirst().get();
         assertThat(item.getValue("name").get(), is("Birmingham"));
 
         HashValue hash2 = decode(SHA256, "sha-256:xxx509");
-        assertTrue("record should contain key sha-256:xxx509", record.getItems().containsKey(hash2));
-        Item item2 = record.getItems().get(hash2);
+        assertTrue("record should contain key sha-256:xxx509", record.getItems().stream().anyMatch(i -> i.getSha256hex().equals(hash2)));
+        Item item2 = record.getItems().stream().filter(i -> i.getSha256hex().equals(hash2)).findFirst().get();
         assertThat(item2.getValue("name").get(), is("Blackburn with Darwen"));
     }
 
@@ -171,13 +171,13 @@ public class IndexQueryDaoIntegrationTest {
         assertThat(record0.getEntry().getIndexEntryNumber(), is(97));
 
         HashValue hash1 = decode(SHA256, "sha-256:xxxbdc");
-        assertTrue(record0.getItems().containsKey(hash1));
-        Item item1 = record0.getItems().get(hash1);
+        assertTrue(record0.getItems().stream().anyMatch(i -> i.getSha256hex().equals(hash1)));
+        Item item1 = record0.getItems().stream().filter(i -> i.getSha256hex().equals(hash1)).findFirst().get();
         assertThat(item1.getValue("name").get(), is("Birmingham"));
 
         HashValue hash2 = decode(SHA256, "sha-256:xxx509");
-        assertTrue(record0.getItems().containsKey(hash2));
-        Item item2 = record0.getItems().get(hash2);
+        assertTrue(record0.getItems().stream().anyMatch(i -> i.getSha256hex().equals(hash2)));
+        Item item2 = record0.getItems().stream().filter(i -> i.getSha256hex().equals(hash2)).findFirst().get();
         assertThat(item2.getValue("name").get(), is("Blackburn with Darwen"));
 
         Record record1 = records.get(1);
@@ -185,13 +185,13 @@ public class IndexQueryDaoIntegrationTest {
         assertThat(record1.getEntry().getIndexEntryNumber(), is(96));
 
         HashValue hash01c = decode(SHA256, "sha-256:xxx01c");
-        assertTrue(record1.getItems().containsKey(hash01c));
-        Item item3 = record1.getItems().get(hash01c);
+        assertTrue(record1.getItems().stream().anyMatch(i -> i.getSha256hex().equals(hash01c)));
+        Item item3 = record1.getItems().stream().filter(i -> i.getSha256hex().equals(hash01c)).findFirst().get();
         assertThat(item3.getValue("name").get(), is("Bedford"));
 
         HashValue hash126 = decode(SHA256, "sha-256:xxx126");
-        assertTrue(record1.getItems().containsKey(hash126));
-        Item item4 = record1.getItems().get(hash126);
+        assertTrue(record1.getItems().stream().anyMatch(i -> i.getSha256hex().equals(hash126)));
+        Item item4 = record1.getItems().stream().filter(i -> i.getSha256hex().equals(hash126)).findFirst().get();
         assertThat(item4.getValue("name").get(), is("New Bath"));
 
     }

--- a/src/test/java/uk/gov/register/views/RecordsViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordsViewTest.java
@@ -1,56 +1,52 @@
 package uk.gov.register.views;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableList;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import io.dropwizard.jackson.Jackson;
 import org.json.JSONException;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import uk.gov.register.core.*;
+import uk.gov.register.service.ItemConverter;
 import uk.gov.register.util.HashValue;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RecordsViewTest {
     @Test
     public void recordsJson_returnsTheMapOfRecords() throws IOException, JSONException {
+        ObjectMapper objectMapper = Jackson.newObjectMapper();
+
         Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
         Instant t2 = Instant.parse("2016-03-28T09:49:26Z");
-        ImmutableList<Field> fields = ImmutableList.of(
-                new Field("address", "datatype", new RegisterName("address"), Cardinality.ONE, "text"),
-                new Field("street", "datatype", new RegisterName("address"), Cardinality.ONE, "text"));
 
-        List<RecordView> records = Lists.newArrayList(
-                new RecordView(
-                        new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123"),
-                        Lists.newArrayList(new ItemView(new HashValue(HashingAlgorithm.SHA256, "ab"),
-                                ImmutableMap.of("address", new StringValue("123"),
-                                        "street", new StringValue("foo")),
-                                fields)),
-                        fields
-                ),
-                new RecordView(
-                        new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cd"), t2, "456"),
-                        Lists.newArrayList(new ItemView(new HashValue(HashingAlgorithm.SHA256, "cd"),
-                                ImmutableMap.of("address", new StringValue("456"),
-                                        "street", new StringValue("bar")),
-                                fields)),
-                        fields
-                )
-        );
-        RecordsView recordsView = new RecordsView(records, fields);
+        Entry entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123");
+        Entry entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cd"), t2, "456");
+        Item item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "ab"), objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}"));
+        Item item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "cd"), objectMapper.readTree("{\"address\":\"456\",\"street\":\"bar\"}"));
+        Record record1 = new Record(entry1, Arrays.asList(item1));
+        Record record2 = new Record(entry2, Arrays.asList(item2));
 
-        Map<String, JsonNode> result = recordsView.recordsJson();
+        ItemConverter itemConverter = mock(ItemConverter.class);
+        when(itemConverter.convertItem(item1)).thenReturn(ImmutableMap.of("address", new StringValue("123"),
+                "street", new StringValue("foo")));
+        when(itemConverter.convertItem(item2)).thenReturn(ImmutableMap.of("address", new StringValue("456"),
+                "street", new StringValue("bar")));
+
+        RecordsView recordsView = new RecordsView(Arrays.asList(record1, record2), emptyList(), itemConverter, false, false);
+
+        Map<String, JsonNode> result = recordsView.getNestedRecordJson();
         assertThat(result.size(), equalTo(2));
-
 
         JSONAssert.assertEquals(
                 "{" +
@@ -80,6 +76,4 @@ public class RecordsViewTest {
                 false
         );
     }
-
-
 }


### PR DESCRIPTION
See individual commit messages for more detail.

This change implements more consistent rules for rendering `/records` and `/record/x` pages that work for both indexes and registers (no matter which is "configured"). The rules in detail are here: https://trello.com/c/N2Q7KGKi/784-make-rendering-of-record-x-and-records-more-consistent-for-registers-and-indexes.

I have attempted to tidy up the RecordView and RecordsViews as I feel that much of the logic belonged in RecordsView - in most formats, the two are now the same.