### PR TITLE
Output Docker logs in JSON format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ repositories {
     maven {
         url 'https://dl.bintray.com/openregister/openregister'
     }
+    maven {
+        url 'https://dl.bintray.com/alphagov/maven'
+    }
 }
 
 //noinspection GroovyAssignabilityCheck
@@ -68,6 +71,7 @@ dependencies {
     compile dropwizard, stringTemplate, apacheCommonsCodec, apacheCommonsCollections, awsS3
     compile jacksonCsv, jena, jerseyMedia, markdown, thymeleaf, verifiableLog
     compile jdbi, jersey_client
+    compile dropwizardLogstash
     compile(postgresClient) {
         exclude group: 'org.slf4j'
     }

--- a/config.docker.basic.yaml
+++ b/config.docker.basic.yaml
@@ -20,6 +20,10 @@ server:
   adminConnectors:
     - type: http
       port: 9092
+  requestLog:
+    type: classic
+    appenders:
+      - type: logstash-console
 
 registerDomain: openregister.dev:8080
 
@@ -62,14 +66,10 @@ registers:
 
 # Logging settings.
 logging:
-
   level: INFO
-
   # Logger-specific levels.
   loggers:
     "uk.gov": DEBUG
     "org.skife.jdbi.v2": TRACE
   appenders:
-    - type: console
-      target: stdout
-      logFormat: "%-5p [%d{ISO8601}] %X{register} %c: %m%n%rEx"
+    - type: logstash-console

--- a/config.docker.register.yaml
+++ b/config.docker.register.yaml
@@ -17,6 +17,10 @@ server:
   adminConnectors:
     - type: http
       port: 9092
+  requestLog:
+    type: classic
+    appenders:
+      - type: logstash-console
 
 registerDomain: openregister.dev:8080
 
@@ -44,14 +48,10 @@ credentials:
 
 # Logging settings.
 logging:
-
   level: INFO
-
   # Logger-specific levels.
   loggers:
     "uk.gov": DEBUG
     "org.skife.jdbi.v2": TRACE
   appenders:
-    - type: console
-      target: stdout
-      logFormat: "%-5p [%d{ISO8601}] %X{register} %c: %m%n%rEx"
+    - type: logstash-console

--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,11 @@ registers:
     schema: register
 
 server:
+  requestLog:
+    type: classic
+    appenders:
+      - type: logstash-console
+
   registerDefaultExceptionMappers: false
   adminConnectors:
     - type: http
@@ -54,14 +59,10 @@ credentials:
 
 # Logging settings.
 logging:
-
   level: INFO
-
   # Logger-specific levels.
   loggers:
     "uk.gov": DEBUG
     "org.skife.jdbi.v2": TRACE
   appenders:
-    - type: console
-      target: stdout
-      logFormat: "%-5p [%d{ISO8601}] %X{register} %c: %m%n%rEx"
+    - type: logstash-console

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -44,6 +44,8 @@ ext {
 
     thymeleaf = 'org.thymeleaf:thymeleaf:2.1.5.RELEASE'
 
+    dropwizardLogstash = "uk.gov.ida:dropwizard-logstash:1.1.0-2"
+
     // test dependencies
     dropwizardTest = "io.dropwizard:dropwizard-testing:${dropwizard_version}"
     junit = ['junit:junit:4.12','org.hamcrest:hamcrest-library:1.3']

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -15,6 +15,7 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.CommonProperties;
+import uk.gov.ida.dropwizard.logstash.LogstashBundle;
 import uk.gov.organisation.client.GovukOrganisationClient;
 import uk.gov.register.auth.BasicAuthFilter;
 import uk.gov.register.auth.RegisterAuthDynamicFeature;
@@ -68,6 +69,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 ));
         bootstrap.addBundle(new AssetsBundle("/assets"));
         bootstrap.addBundle(new CorsBundle());
+        bootstrap.addBundle(new LogstashBundle());
 
         System.setProperty("java.protocol.handler.pkgs", "uk.gov.register.protocols");
     }


### PR DESCRIPTION
This makes it easier to parse/filter/do useful things with the logs
particularly at the point they're being ingested by Sumologic.