### PR TITLE
RSF for append-entry should have the key in 2nd position

### DIFF
--- a/src/main/java/uk/gov/register/serialization/RSFExecutor.java
+++ b/src/main/java/uk/gov/register/serialization/RSFExecutor.java
@@ -74,7 +74,7 @@ public class RSFExecutor {
     }
 
     private Boolean validateAppendEntry(RegisterCommand command, Register register, Map<HashValue, Integer> hashRefLine) {
-        String delimitedHashes = command.getCommandArguments().get(1);
+        String delimitedHashes = command.getCommandArguments().get(2);
         if (StringUtils.isEmpty(delimitedHashes)) {
             return false;
         }

--- a/src/main/java/uk/gov/register/serialization/RSFFormatter.java
+++ b/src/main/java/uk/gov/register/serialization/RSFFormatter.java
@@ -46,7 +46,8 @@ public class RSFFormatter {
     }
 
     public RegisterCommand parse(String str) throws SerializedRegisterParseException {
-        List<String> parts = Arrays.asList(str.split(TAB));
+        // -1 -> if str ends with \t then final string in list will be ""
+        List<String> parts = Arrays.asList(str.split(TAB, -1));
 
         if (parts.isEmpty() || parts.size() < 2) {
             throw new SerializedRegisterParseException("String is empty or is in incorrect format");
@@ -87,11 +88,11 @@ public class RSFFormatter {
                 throw new SerializedRegisterParseException("Append entry line must have 3 arguments, was: " + argsToString(arguments));
             }
             try {
-                Instant.parse(arguments.get(0));
+                Instant.parse(arguments.get(1));
             } catch (DateTimeParseException e) {
                 throw new SerializedRegisterParseException("Date is not in the correct format", e);
             }
-            validateHash(arguments.get(1), "Append entry hash value was not hashed using " + SHA_256);
+            validateHash(arguments.get(2), "Append entry hash value was not hashed using " + SHA_256);
         };
     }
 

--- a/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
@@ -23,7 +23,7 @@ public class AppendEntryCommandHandler extends RegisterCommandHandler {
         try {
             List<String> parts = command.getCommandArguments();
             int newEntryNo = register.getTotalEntries() + 1;
-            String delimitedHashes = parts.get(1);
+            String delimitedHashes = parts.get(2);
             List<HashValue> hashValues;
             if (StringUtils.isNotEmpty(delimitedHashes)) {
                 hashValues = Splitter.on(";").splitToList(delimitedHashes).stream()
@@ -31,7 +31,7 @@ public class AppendEntryCommandHandler extends RegisterCommandHandler {
             } else {
                 hashValues = new ArrayList<>();
             }
-            Entry entry = new Entry(newEntryNo, hashValues, Instant.parse(parts.get(0)), parts.get(2));
+            Entry entry = new Entry(newEntryNo, hashValues, Instant.parse(parts.get(1)), parts.get(0));
             register.appendEntry(entry);
             return RegisterResult.createSuccessResult();
         } catch (Exception e) {

--- a/src/main/java/uk/gov/register/serialization/mappers/EntryToCommandMapper.java
+++ b/src/main/java/uk/gov/register/serialization/mappers/EntryToCommandMapper.java
@@ -9,10 +9,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-public class EntryToCommandMapper extends RegisterCommandMapper<Entry,RegisterCommand> {
+public class EntryToCommandMapper extends RegisterCommandMapper<Entry, RegisterCommand> {
     @Override
     public RegisterCommand apply(Entry entry) {
-        return new RegisterCommand("append-entry", Arrays.asList(entry.getTimestampAsISOFormat(), toDelimited(entry.getItemHashes()), entry.getKey()));
+        return new RegisterCommand("append-entry", Arrays.asList(entry.getKey(), entry.getTimestampAsISOFormat(), toDelimited(entry.getItemHashes())));
     }
 
     private String toDelimited(Collection<HashValue> hashValues) {

--- a/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
@@ -114,11 +114,11 @@ public class DataDownloadFunctionalTest {
                 "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}",
                 "add-item\t{\"address\":\"12345\",\"street\":\"foo\"}"));
 
-        assertFormattedEntry(rsfLines.get(5), "sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\t12345");
-        assertFormattedEntry(rsfLines.get(6), "sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\t6789");
-        assertFormattedEntry(rsfLines.get(7), "sha-256:cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592\t12345");
-        assertFormattedEntry(rsfLines.get(8), "sha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983\t145678");
-        assertFormattedEntry(rsfLines.get(9), "sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\t12345");
+        assertFormattedEntry(rsfLines.get(5), "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
+        assertFormattedEntry(rsfLines.get(6), "6789","sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934");
+        assertFormattedEntry(rsfLines.get(7), "12345","sha-256:cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
+        assertFormattedEntry(rsfLines.get(8), "145678","sha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983");
+        assertFormattedEntry(rsfLines.get(9), "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
 
         assertThat(rsfLines.get(10), containsString("assert-root-hash\t"));
     }
@@ -139,8 +139,8 @@ public class DataDownloadFunctionalTest {
                 "add-item\t{\"address\":\"12345\",\"street\":\"ellis\"}",
                 "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}"));
 
-        assertFormattedEntry(rsfLines.get(3), "sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\t12345");
-        assertFormattedEntry(rsfLines.get(4), "sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\t6789");
+        assertFormattedEntry(rsfLines.get(3), "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
+        assertFormattedEntry(rsfLines.get(4), "6789","sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934");
 
         assertThat(rsfLines.get(5), containsString("assert-root-hash\t"));
     }
@@ -193,9 +193,12 @@ public class DataDownloadFunctionalTest {
         return new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.toList());
     }
 
-    private void assertFormattedEntry(String actualEntry, String expectedLine) {
-        assertThat(actualEntry, startsWith("append-entry"));
-        assertThat(actualEntry, endsWith(expectedLine));
+    private void assertFormattedEntry(String actualEntry, String expectedKey, String expectedHash) {
+        String[] parts = actualEntry.split("\t");
+        assertThat(parts.length, is(4));
+        assertThat(parts[0], is("append-entry"));
+        assertThat(parts[1], is(expectedKey));
+        assertThat(parts[3], is(expectedHash));
     }
 
     private Map<String, JsonNode> getEntries(InputStream inputStream) throws IOException {

--- a/src/test/java/uk/gov/register/functional/RepresentationsFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RepresentationsFunctionalTest.java
@@ -40,8 +40,8 @@ public class RepresentationsFunctionalTest {
         register.wipe();
         register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
-                "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
-                "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
+                "append-entry\tvalue1\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\n" +
+                "append-entry\tvalue2\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\n");
     }
 
     @Parameters(name = "{0}")

--- a/src/test/java/uk/gov/register/functional/db/EntryIteratorFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/db/EntryIteratorFunctionalTest.java
@@ -35,8 +35,8 @@ public class EntryIteratorFunctionalTest {
     public void testCanIterateInOrder() {
         register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
-                "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
-                "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
+                "append-entry\tvalue1\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\n" +
+                "append-entry\tvalue2\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\n");
 
         EntryIterator.withEntryIterator(entryQueryDAO, entryIteratorDAO -> {
             assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
@@ -49,8 +49,8 @@ public class EntryIteratorFunctionalTest {
     public void testCanIterateNotInOrder() {
         register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
-                "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
-                "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
+                "append-entry\tvalue1\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\n" +
+                "append-entry\tvalue2\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\n");
 
         EntryIterator.withEntryIterator(entryQueryDAO, entryIteratorDAO -> {
             assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));
@@ -63,12 +63,12 @@ public class EntryIteratorFunctionalTest {
     public void testCanStillIterateAfterIteratorEndsThenNewEntriesAdded() {
         EntryIterator.withEntryIterator(entryQueryDAO, entryIteratorDAO -> {
             register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
-                    "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n");
+                    "append-entry\tvalue1\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\n");
 
             assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
 
             register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
-                    "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
+                    "append-entry\tvalue2\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\n");
 
             assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));
             return null;
@@ -80,13 +80,13 @@ public class EntryIteratorFunctionalTest {
         EntryIterator.withEntryIterator(entryQueryDAO, entryIteratorDAO -> {
             register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                     "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
-                    "append-entry\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\tvalue1\n" +
-                    "append-entry\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\tvalue2\n");
+                    "append-entry\tvalue1\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\n" +
+                    "append-entry\tvalue2\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\n");
 
             assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
 
             register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\",\"field2\",\"field3\"],\"register\":\"value3\",\"text\":\"The Entry 3\"}\n" +
-                    "append-entry\t2016-03-01T01:02:03Z\tsha-256:8d5c2ed1e59f8871dff6e2132171008f12f43aa37e70ab158d598bc6b6db848f\tvalue1\n");
+                    "append-entry\tvalue1\t2016-03-01T01:02:03Z\tsha-256:8d5c2ed1e59f8871dff6e2132171008f12f43aa37e70ab158d598bc6b6db848f\n");
 
             assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));
             assertThat(entryIteratorDAO.findByEntryNumber(3).getEntryNumber(), equalTo(3));

--- a/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
@@ -73,8 +73,8 @@ public class RSFCreatorTest {
 
         addItem1Command = new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}"));
         addItem2Command = new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}"));
-        appendEntry1Command = new RegisterCommand("append-entry", Arrays.asList("2016-07-24T16:55:00Z", "sha-256:item1sha", "entry1-field-1-value"));
-        appendEntry2Command = new RegisterCommand("append-entry", Arrays.asList("2016-07-24T16:56:00Z", "sha-256:item2sha", "entry2-field-1-value"));
+        appendEntry1Command = new RegisterCommand("append-entry", Arrays.asList("entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item1sha"));
+        appendEntry2Command = new RegisterCommand("append-entry", Arrays.asList("entry2-field-1-value","2016-07-24T16:56:00Z", "sha-256:item2sha" ));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
@@ -77,8 +77,8 @@ public class RSFExecutorTest {
 
         addItem1Command = new RegisterCommand("add-item", singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}"));
         addItem2Command = new RegisterCommand("add-item", singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}"));
-        appendEntry1Command = new RegisterCommand("append-entry", asList("2016-07-24T16:55:00Z", "sha-256:3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c", "entry1-field-1-value"));
-        appendEntry2Command = new RegisterCommand("append-entry", asList("2016-07-24T16:56:00Z", "sha-256:1c7a3bbe9df447813863aead4a5ab7e3c20ffa59459df2540461c7d3de9d227a", "entry2-field-1-value"));
+        appendEntry1Command = new RegisterCommand("append-entry", asList("entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c"));
+        appendEntry2Command = new RegisterCommand("append-entry", asList("entry2-field-1-value", "2016-07-24T16:56:00Z", "sha-256:1c7a3bbe9df447813863aead4a5ab7e3c20ffa59459df2540461c7d3de9d227a"));
     }
 
 
@@ -211,13 +211,13 @@ public class RSFExecutorTest {
     }
 
     @Test
-    public void shouldHandleMultiItemAddEntryCommands(){
+    public void shouldHandleMultiItemAddEntryCommands() {
         RegisterCommand addItem1 = new RegisterCommand("add-item", singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}"));
         String itemHash1 = "sha-256:3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c";
         RegisterCommand addItem2 = new RegisterCommand("add-item", singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}"));
         String itemHash2 = "sha-256:1c7a3bbe9df447813863aead4a5ab7e3c20ffa59459df2540461c7d3de9d227a";
         RegisterCommand appendEntry = new RegisterCommand("append-entry",
-                asList("2016-07-24T16:55:00Z", itemHash1 + ";" + itemHash2, "entry1-field-1-value"));
+                asList("entry1-field-1-value", "2016-07-24T16:55:00Z", itemHash1 + ";" + itemHash2));
 
         when(addItemHandler.execute(any(), eq(register))).thenReturn(RegisterResult.createSuccessResult());
         when(appendEntryHandler.execute(any(), eq(register))).thenReturn(RegisterResult.createSuccessResult());

--- a/src/test/java/uk/gov/register/serialization/RSFFormatterTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFFormatterTest.java
@@ -33,28 +33,28 @@ public class RSFFormatterTest {
 
     @Test
     public void parse_parsesAppendEntryCommand() {
-        RegisterCommand parsedCommand = rsfFormatter.parse("append-entry\t2016-11-02T14:45:54Z\tsha-256:3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254\tft_openregister_test");
+        RegisterCommand parsedCommand = rsfFormatter.parse("append-entry\tft_openregister_test\t2016-11-02T14:45:54Z\tsha-256:3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254");
         assertThat(parsedCommand.getCommandName(), equalTo("append-entry"));
-        assertThat(parsedCommand.getCommandArguments(), equalTo(Arrays.asList("2016-11-02T14:45:54Z", "sha-256:3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254", "ft_openregister_test")));
+        assertThat(parsedCommand.getCommandArguments(), equalTo(Arrays.asList("ft_openregister_test", "2016-11-02T14:45:54Z", "sha-256:3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254")));
     }
 
     @Test
     public void parse_parsesAppendEntryMultiItemCommand() {
         System.setProperty("multi-item-entries-enabled", "true");
-        String line = "append-entry\t2016-11-02T14:45:54Z\tsha-256:a;sha-256:b\tft_openregister_test";
+        String line = "append-entry\tft_openregister_test\t2016-11-02T14:45:54Z\tsha-256:a;sha-256:b";
         RegisterCommand parsedCommand = rsfFormatter.parse(line);
         assertThat(parsedCommand.getCommandName(), equalTo("append-entry"));
-        assertThat(parsedCommand.getCommandArguments(), equalTo(Arrays.asList("2016-11-02T14:45:54Z", "sha-256:a;sha-256:b", "ft_openregister_test")));
+        assertThat(parsedCommand.getCommandArguments(), equalTo(Arrays.asList("ft_openregister_test", "2016-11-02T14:45:54Z", "sha-256:a;sha-256:b")));
         System.clearProperty("multi-item-entries-enabled");
     }
 
     @Test
     public void parse_parsesAppendEntryNoItems() {
         System.setProperty("multi-item-entries-enabled", "true");
-        String line = "append-entry\t2016-11-02T14:45:54Z\t\tft_openregister_test";
+        String line = "append-entry\tft_openregister_test\t2016-11-02T14:45:54Z\t";
         RegisterCommand parsedCommand = rsfFormatter.parse(line);
         assertThat(parsedCommand.getCommandName(), equalTo("append-entry"));
-        assertThat(parsedCommand.getCommandArguments(), equalTo(Arrays.asList("2016-11-02T14:45:54Z", "", "ft_openregister_test")));
+        assertThat(parsedCommand.getCommandArguments(), equalTo(Arrays.asList("ft_openregister_test", "2016-11-02T14:45:54Z", "")));
         System.clearProperty("multi-item-entries-enabled");
     }
 

--- a/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Register;
@@ -39,7 +39,7 @@ public class AppendEntryCommandHandlerTest {
     @Before
     public void setUp() throws Exception {
         sutHandler = new AppendEntryCommandHandler();
-        appendEntryCommand = new RegisterCommand("append-entry", Arrays.asList("2016-07-24T16:55:00Z", "sha-256:item-sha", "entry1-field-1-value"));
+        appendEntryCommand = new RegisterCommand("append-entry", Arrays.asList("entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item-sha"));
     }
 
     @Test
@@ -64,7 +64,7 @@ public class AppendEntryCommandHandlerTest {
         when(register.getTotalEntries()).thenReturn(2);
 
         RegisterCommand command = new RegisterCommand("append-entry",
-                Arrays.asList("2016-07-24T16:55:00Z", "sha-256:aaa;sha-256:bbb", "entry1-field-1-value"));
+                Arrays.asList("entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:aaa;sha-256:bbb"));
         RegisterResult registerResult = sutHandler.execute(command, register);
 
         Entry expectedEntry = new Entry(3, Arrays.asList(new HashValue(SHA256, "aaa"),
@@ -78,7 +78,7 @@ public class AppendEntryCommandHandlerTest {
         when(register.getTotalEntries()).thenReturn(2);
 
         RegisterCommand command = new RegisterCommand("append-entry",
-                Arrays.asList("2016-07-24T16:55:00Z", "", "entry1-field-1-value"));
+                Arrays.asList("entry1-field-1-value", "2016-07-24T16:55:00Z", ""));
         RegisterResult registerResult = sutHandler.execute(command, register);
 
         Entry expectedEntry = new Entry(3, new ArrayList<>(), july24, "entry1-field-1-value");
@@ -105,7 +105,7 @@ public class AppendEntryCommandHandlerTest {
     @Test
     public void execute_failsForCommandWithInvalidArguments() {
         when(register.getTotalEntries()).thenReturn(2);
-        RegisterCommand commandWithInvalidArguments = new RegisterCommand("append-entry", Arrays.asList("2016-07-T16:55:00Z", "sha-2tem-sha"));
+        RegisterCommand commandWithInvalidArguments = new RegisterCommand("append-entry", Arrays.asList("sha-2tem-sha", "2016-07-T16:55:00Z"));
 
         RegisterResult registerResult = sutHandler.execute(commandWithInvalidArguments, register);
 

--- a/src/test/java/uk/gov/register/serialization/mappers/EntryToCommandMapperTest.java
+++ b/src/test/java/uk/gov/register/serialization/mappers/EntryToCommandMapperTest.java
@@ -29,7 +29,7 @@ public class EntryToCommandMapperTest {
         RegisterCommand mapResult = sutMapper.apply(entryToMap);
 
         assertThat(mapResult.getCommandName(), equalTo("append-entry"));
-        assertThat(mapResult.getCommandArguments(), equalTo(Arrays.asList("2016-07-24T16:55:00Z", "sha-256:item-sha", "entry1-field-1-value")));
+        assertThat(mapResult.getCommandArguments(), equalTo(Arrays.asList("entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item-sha")));
     }
 
     @Test
@@ -42,6 +42,6 @@ public class EntryToCommandMapperTest {
         RegisterCommand mapResult = sutMapper.apply(entryToMap);
 
         assertThat(mapResult.getCommandName(), equalTo("append-entry"));
-        assertThat(mapResult.getCommandArguments(), equalTo(Arrays.asList("2016-07-24T16:55:00Z", "sha-256:item-sha;sha-256:item-sha2", "entry1-field-1-value")));
+        assertThat(mapResult.getCommandArguments(), equalTo(Arrays.asList("entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item-sha;sha-256:item-sha2")));
     }
 }

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import uk.gov.register.core.Register;
 import uk.gov.register.core.RegisterContext;
@@ -70,7 +70,7 @@ public class RegisterSerialisationFormatServiceTest {
     public void process_passesCommandsToExecutorAndReturnsItsResult() {
         RegisterCommand command1 = new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
         RegisterCommand command2 = new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}"));
-        RegisterCommand command3 = new RegisterCommand("append-entry", Arrays.asList("2016-07-24T16:55:00Z", "sha-256:item1sha", "entry1-field-1-value"));
+        RegisterCommand command3 = new RegisterCommand("append-entry", Arrays.asList("entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item1sha"));
         RegisterCommand command4 = new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e"));
         RegisterSerialisationFormat rsfInput = new RegisterSerialisationFormat(Iterators.forArray(command1, command2, command3, command4));
 
@@ -89,8 +89,8 @@ public class RegisterSerialisationFormatServiceTest {
                         new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")),
                         new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}")),
                         new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}")),
-                        new RegisterCommand("append-entry", Arrays.asList("2016-07-24T16:55:00Z", "sha-256:item1sha", "entry1-field-1-value")),
-                        new RegisterCommand("append-entry", Arrays.asList("2016-07-24T16:56:00Z", "sha-256:item2sha", "entry2-field-1-value")),
+                        new RegisterCommand("append-entry", Arrays.asList("entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item1sha")),
+                        new RegisterCommand("append-entry", Arrays.asList("entry2-field-1-value", "2016-07-24T16:56:00Z", "sha-256:item2sha")),
                         new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e")))));
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -102,8 +102,8 @@ public class RegisterSerialisationFormatServiceTest {
                 "assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n" +
                 "add-item\t{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}\n" +
                 "add-item\t{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}\n" +
-                "append-entry\t2016-07-24T16:55:00Z\tsha-256:item1sha\tentry1-field-1-value\n" +
-                "append-entry\t2016-07-24T16:56:00Z\tsha-256:item2sha\tentry2-field-1-value\n" +
+                "append-entry\tentry1-field-1-value\t2016-07-24T16:55:00Z\tsha-256:item1sha\n" +
+                "append-entry\tentry2-field-1-value\t2016-07-24T16:56:00Z\tsha-256:item2sha\n" +
                 "assert-root-hash\tsha-256:K3rfuFF1e\n";
 
         String actualRSF = outputStream.toString();
@@ -116,7 +116,7 @@ public class RegisterSerialisationFormatServiceTest {
                 new RegisterSerialisationFormat(Iterators.forArray(
                         new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e_uno")),
                         new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}")),
-                        new RegisterCommand("append-entry", Arrays.asList("2016-07-24T16:56:00Z", "sha-256:item2sha", "entry2-field-1-value")),
+                        new RegisterCommand("append-entry", Arrays.asList("entry2-field-1-value", "2016-07-24T16:56:00Z", "sha-256:item2sha")),
                         new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e_dos")))));
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -127,7 +127,7 @@ public class RegisterSerialisationFormatServiceTest {
         String expectedRSF =
                 "assert-root-hash\tsha-256:K3rfuFF1e_uno\n" +
                 "add-item\t{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}\n" +
-                "append-entry\t2016-07-24T16:56:00Z\tsha-256:item2sha\tentry2-field-1-value\n" +
+                "append-entry\tentry2-field-1-value\t2016-07-24T16:56:00Z\tsha-256:item2sha\n" +
                 "assert-root-hash\tsha-256:K3rfuFF1e_dos\n";
 
         String actualRSF = outputStream.toString();
@@ -140,8 +140,8 @@ public class RegisterSerialisationFormatServiceTest {
                 "assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n" +
                 "add-item\t{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}\n" +
                 "add-item\t{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}\n" +
-                "append-entry\t2016-07-24T16:55:00Z\tsha-256:item1sha\tentry1-field-1-value\n" +
-                "append-entry\t2016-07-24T16:56:00Z\tsha-256:item2sha\tentry2-field-1-value\n" +
+                "append-entry\tentry1-field-1-value\t2016-07-24T16:55:00Z\tsha-256:item1sha\n" +
+                "append-entry\tentry2-field-1-value\t2016-07-24T16:56:00Z\tsha-256:item2sha\n" +
                 "assert-root-hash\tsha-256:K3rfuFF1e\n";
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream(streamValue.getBytes());
@@ -152,8 +152,8 @@ public class RegisterSerialisationFormatServiceTest {
                 new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")),
                 new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}")),
                 new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}")),
-                new RegisterCommand("append-entry", Arrays.asList("2016-07-24T16:55:00Z", "sha-256:item1sha", "entry1-field-1-value")),
-                new RegisterCommand("append-entry", Arrays.asList("2016-07-24T16:56:00Z", "sha-256:item2sha", "entry2-field-1-value")),
+                new RegisterCommand("append-entry", Arrays.asList("entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item1sha")),
+                new RegisterCommand("append-entry", Arrays.asList("entry2-field-1-value", "2016-07-24T16:56:00Z", "sha-256:item2sha")),
                 new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e"))));
 
         assertThat(Lists.newArrayList(rsfReadResult.getCommands()), equalTo(Lists.newArrayList(expectedRsf.getCommands())));
@@ -166,7 +166,7 @@ public class RegisterSerialisationFormatServiceTest {
 
             RegisterSerialisationFormat expectedRsf = new RegisterSerialisationFormat(Iterators.forArray(
                     new RegisterCommand("add-item", Collections.singletonList("{\"name\":\"New College\\\\New College School\",\"school\":\"402019\",\"school-authority\":\"681\",\"school-type\":\"30\"}")),
-                    new RegisterCommand("append-entry", Arrays.asList("2016-11-07T16:26:22Z", "sha-256:d6cca062b6a4ff7f60e401aa1ebf4bf5af51c2217916c0115d0a38a42182aec5", "402019"))));
+                    new RegisterCommand("append-entry", Arrays.asList("402019", "2016-11-07T16:26:22Z", "sha-256:d6cca062b6a4ff7f60e401aa1ebf4bf5af51c2217916c0115d0a38a42182aec5"))));
 
             assertThat(Lists.newArrayList(rsfReadResult.getCommands()), equalTo(Lists.newArrayList(expectedRsf.getCommands())));
         }

--- a/src/test/resources/fixtures/serialized/register-by-registry.rsf
+++ b/src/test/resources/fixtures/serialized/register-by-registry.rsf
@@ -1,4 +1,4 @@
 add-item	{"register":"address","registry":"government-digital-service","text":"Addresses"}
 add-item	{"register":"food-authority","registry":"government-digital-service","text":"Food Authority"}
-append-entry	2016-11-02T14:45:54Z	sha-256:4bdfee6268fd1365ad9ef378799c1ce567d237c1c0d38d0cf64e64c51aaec559;sha-256:6344e3925465464b317795010fc400ffa8c10380429a3d0260b71ccd9ffc08c7	government-digital-service
-append-entry	2016-11-02T14:45:54Z		cabinet-office
+append-entry	government-digital-service	2016-11-02T14:45:54Z	sha-256:4bdfee6268fd1365ad9ef378799c1ce567d237c1c0d38d0cf64e64c51aaec559;sha-256:6344e3925465464b317795010fc400ffa8c10380429a3d0260b71ccd9ffc08c7
+append-entry	cabinet-office	2016-11-02T14:45:54Z	

--- a/src/test/resources/fixtures/serialized/register-register-orphan-rsf.tsv
+++ b/src/test/resources/fixtures/serialized/register-register-orphan-rsf.tsv
@@ -1,5 +1,5 @@
 assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 add-item	{"register":"ft_openregister_test","text":"SomeText"}
 add-item	{"register":"ft_openregister_test","text":"orphan item"}
-append-entry	2016-11-02T14:45:54Z	sha-256:3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254	ft_openregister_test
+append-entry	ft_openregister_test	2016-11-02T14:45:54Z	sha-256:3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254
 assert-root-hash	sha-256:707166227cb8271fc9b6a4f8add42d3567edf7007159ea92ba3f4fb84b10249c

--- a/src/test/resources/fixtures/serialized/register-register-rsf.tsv
+++ b/src/test/resources/fixtures/serialized/register-register-rsf.tsv
@@ -1,7 +1,7 @@
 assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 add-item	{"register":"ft_openregister_test","text":"SomeText"}
-append-entry	2016-11-02T14:45:54Z	sha-256:3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254	ft_openregister_test
+append-entry	ft_openregister_test	2016-11-02T14:45:54Z	sha-256:3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254
 assert-root-hash	sha-256:707166227cb8271fc9b6a4f8add42d3567edf7007159ea92ba3f4fb84b10249c
 add-item	{"register":"ft_openregister_test2","text":"SomeText"}
-append-entry	2016-11-02T14:45:54Z	sha-256:b8b56d0329b4a82ce55217cfbb3803c322bf43711f82649757e9c2df5f5b8371	ft_openregister_test2
+append-entry	ft_openregister_test2	2016-11-02T14:45:54Z	sha-256:b8b56d0329b4a82ce55217cfbb3803c322bf43711f82649757e9c2df5f5b8371
 assert-root-hash	sha-256:09eeabcd8e0d7f3d83e0b9faf268ac03ac791ae6e84428946bfee9b5a3e46429

--- a/src/test/resources/fixtures/serialized/valid-register-escaped.tsv
+++ b/src/test/resources/fixtures/serialized/valid-register-escaped.tsv
@@ -1,2 +1,2 @@
 add-item	{"name":"New College\\New College School","school":"402019","school-authority":"681","school-type":"30"}
-append-entry	2016-11-07T16:26:22Z	sha-256:d6cca062b6a4ff7f60e401aa1ebf4bf5af51c2217916c0115d0a38a42182aec5	402019
+append-entry	402019	2016-11-07T16:26:22Z	sha-256:d6cca062b6a4ff7f60e401aa1ebf4bf5af51c2217916c0115d0a38a42182aec5


### PR DESCRIPTION
An 'append-entry' line in RSF will now have the form: 

append-entry[tab]key[tab]timestamp][tab]hash

Code to read and write RSF and associated tests are changed accordingly.

Note deploying this code needs to be coordinated with corresponding change in Serializer.