### PR TITLE
Tag metrics with region and availability zone

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -5,6 +5,7 @@ set -eu
 INSTANCE_ID=$(curl 169.254.169.254/2014-11-05/meta-data/instance-id)
 REGISTER_NAME=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Register --region eu-west-1 --query 'Tags[0].Value' --output text)
 ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Environment --region eu-west-1 --query 'Tags[0].Value' --output text)
+DATACENTER=$(curl http://169.254.169.254/2016-09-02/meta-data/placement/availability-zone)
 CONFIG_BUCKET=openregister.${ENV}.config
 TOTAL_MEMORY=$(awk '($1 == "MemTotal:") { print $2 }' /proc/meminfo)
 MAX_JVM_HEAP_SIZE=$(($TOTAL_MEMORY-512*1024))
@@ -25,6 +26,7 @@ docker run \
     --volume /srv/openregister-java/telegraf.conf:/etc/telegraf/telegraf.conf:ro \
     --network openregisters \
     --env REGISTER_NAME=${REGISTER_NAME} \
+    --env DATACENTER=${DATACENTER} \
     telegraf
 
 docker run \


### PR DESCRIPTION
This might be useful when diagnosing any future issues. It shouldn't
cost us anything extra series cardinality-wise because we're already
tagging with the host.

```
$ curl http://169.254.169.254/2016-09-02/meta-data/placement/availability-zone
eu-west-1a
```