### PR TITLE
Add new endpoint to get RSF from specified entry to end of register

### DIFF
--- a/src/main/java/uk/gov/register/serialization/RSFCreator.java
+++ b/src/main/java/uk/gov/register/serialization/RSFCreator.java
@@ -36,7 +36,7 @@ public class RSFCreator {
         Iterator<?> iterators;
 
         if (totalEntries1 == totalEntries2) {
-            iterators = Iterators.singletonIterator(register.getRegisterProof(totalEntries1));
+            iterators = Iterators.singletonIterator(register.getRegisterProof(totalEntries1).getRootHash());
         } else {
 
             HashValue previousRootHash = totalEntries1 == 0 ? EMPTY_ROOT_HASH : register.getRegisterProof(totalEntries1).getRootHash();

--- a/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
@@ -201,6 +201,21 @@ public class DataDownloadFunctionalTest {
     }
 
     @Test
+    public void downloadPartialRSF_shouldReturnCurrentRootHash_whenStartEntryNumbersIsCurrentMaximum() {
+        Response response = register.getRequest(address, "/download-rsf/5");
+        List<String> partialRsfLines = getRsfLinesFrom(response);
+        assertThat(partialRsfLines.get(0), equalTo("assert-root-hash\tsha-256:a0aa6dace50e47c68fd4a79e3d94ba525f827e0a44bb64ed2e5f75cfe051b71c"));
+    }
+
+    @Test
+    public void downloadPartialRSF_shouldReturnRootHash_whenStartAndEndEntryNumbersEqual() {
+        Response response = register.getRequest(address, "/download-rsf/0/0");
+        List<String> partialRsfLines = getRsfLinesFrom(response);
+
+        assertThat(partialRsfLines.get(0), equalTo("assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+    }
+
+    @Test
     public void downloadPartialRSF_shouldReturn400_whenRequestedTotalEntriesExceedsEntriesInRegister() {
         Response response = register.getRequest(address, "/download-rsf/0/6");
 


### PR DESCRIPTION
This PR adds a new endpoint to the DataDownload resource which enables a user to download items and entries from a particular point in time, to the most recent. This saves the user needing to make a separate call to the `/register` endpoint to query the total number of entries held by the register before calling the existing endpoint `/download-rsf/x/y`.