### PR TITLE
Remove org logo border when no logo is present

### DIFF
--- a/src/main/resources/assets/sass/_organisations.scss
+++ b/src/main/resources/assets/sass/_organisations.scss
@@ -200,9 +200,9 @@
 }
 
 .organisation-logo-no-identity {
-  padding-top: 2px;
-  padding-bottom: 2px;
   background: none;
+  border: none;
+  padding: 2px 0;
 }
 
 .organisation-logo-org {


### PR DESCRIPTION
When a gov org logo has no identity i.e. crown, crest or other logo then we should just display plain text with no styling as it break branding guidelines for some orgs i.e. Scottish Government