### PR TITLE
Wrap schema name in quotes when substituting

### DIFF
--- a/src/main/java/uk/gov/register/db/SubstituteSchemaRewriter.java
+++ b/src/main/java/uk/gov/register/db/SubstituteSchemaRewriter.java
@@ -1,6 +1,5 @@
 package uk.gov.register.db;
 
-import org.apache.commons.lang3.StringUtils;
 import org.skife.jdbi.v2.Binding;
 import org.skife.jdbi.v2.ColonPrefixNamedParamStatementRewriter;
 import org.skife.jdbi.v2.StatementContext;
@@ -16,7 +15,7 @@ public class SubstituteSchemaRewriter implements StatementRewriter {
 
     @Override
     public RewrittenStatement rewrite(String sql, Binding params, StatementContext ctx) {
-        String sqlWithSchema = sql.replaceAll(":schema", StringUtils.strip(params.forName("schema").toString(), "'" ));
+        String sqlWithSchema = sql.replaceAll(":schema", params.forName("schema").toString().replace("'","\""));
         return colonRewriter.rewrite(sqlWithSchema, params, ctx);
     }
 }

--- a/src/test/java/uk/gov/register/functional/app/MigrateDatabaseRule.java
+++ b/src/test/java/uk/gov/register/functional/app/MigrateDatabaseRule.java
@@ -24,7 +24,7 @@ public class MigrateDatabaseRule extends ExternalResource {
         for (TestRegister register : registers) {
             FlywayFactory flywayFactory = getFlywayFactory(register.name());
             Flyway flyway = flywayFactory.build(getDataSource(register.getDatabaseConnectionString("MigrateDatabaseRule")));
-            flyway.setSchemas(register.name());
+            flyway.setSchemas(register.getSchema());
             flyway.migrate();
         }
     }

--- a/src/test/java/uk/gov/register/functional/app/TestRegister.java
+++ b/src/test/java/uk/gov/register/functional/app/TestRegister.java
@@ -3,10 +3,10 @@ package uk.gov.register.functional.app;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 
 public enum TestRegister {
-    address("foo", "bar"), postcode("pat", "goggins"), register("sasine", "inhibition");
+    address("foo", "bar"), postcode("pat", "goggins"), register("sasine", "inhibition"), local_authority_eng("bar","baz");
 
     private static final String REGISTER_DOMAIN = "test.register.gov.uk";
-    private final String hostname = name() + "." + REGISTER_DOMAIN;
+    private final String hostname = getSchema() + "." + REGISTER_DOMAIN;
     private final String username;
     private final String password;
     private final String databaseConnectionString = "jdbc:postgresql://localhost:5432/ft_openregister_java_multi?user=postgres&ApplicationName=%s";
@@ -31,6 +31,7 @@ public enum TestRegister {
     }
 
     public String getSchema() {
-        return name();
+        return name().replaceAll("_","-");
     }
+
 }

--- a/src/test/java/uk/gov/register/functional/app/WipeDatabaseRule.java
+++ b/src/test/java/uk/gov/register/functional/app/WipeDatabaseRule.java
@@ -23,10 +23,10 @@ public class WipeDatabaseRule extends ExternalResource {
         for (TestRegister register : registers) {
             DBI dbi = new DBI(register.getDatabaseConnectionString("WipeDatabaseRule"));
             dbi.useHandle(handle -> {
-                handle.attach(TestEntryDAO.class).wipeData(register.name());
-                handle.attach(TestItemCommandDAO.class).wipeData(register.name());
-                handle.attach(TestRecordDAO.class).wipeData(register.name());
-                handle.attach(TestIndexDAO.class).wipeData(register.name());
+                handle.attach(TestEntryDAO.class).wipeData(register.getSchema());
+                handle.attach(TestItemCommandDAO.class).wipeData(register.getSchema());
+                handle.attach(TestRecordDAO.class).wipeData(register.getSchema());
+                handle.attach(TestIndexDAO.class).wipeData(register.getSchema());
             });
         }
     }

--- a/src/test/java/uk/gov/register/integration/ItemQueryDAOIntegrationTest.java
+++ b/src/test/java/uk/gov/register/integration/ItemQueryDAOIntegrationTest.java
@@ -1,0 +1,33 @@
+package uk.gov.register.integration;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.register.core.Item;
+import uk.gov.register.db.ItemQueryDAO;
+import uk.gov.register.functional.app.MigrateDatabaseRule;
+
+import java.util.Collection;
+
+import static org.hamcrest.Matchers.is;
+import static uk.gov.register.functional.app.TestRegister.local_authority_eng;
+
+public class ItemQueryDAOIntegrationTest {
+    private DBI dbi;
+
+    @ClassRule
+    public static MigrateDatabaseRule migrateDatabaseRule = new MigrateDatabaseRule(local_authority_eng);
+    @Before
+    public void setup() {
+        dbi = new DBI(local_authority_eng.getDatabaseConnectionString("PGRegisterTxnFT"));
+    }
+
+    @Test
+    public void shouldFindNoItems(){
+        Collection<Item> items = dbi.withHandle(handle -> handle.attach(ItemQueryDAO.class).getAllItemsNoPagination("local-authority-eng"));
+        Assert.assertThat(items.size(), is(0));
+    }
+
+}

--- a/src/test/java/uk/gov/register/integration/SchemaSubstitutionIntegrationTest.java
+++ b/src/test/java/uk/gov/register/integration/SchemaSubstitutionIntegrationTest.java
@@ -14,7 +14,7 @@ import java.util.Collection;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.register.functional.app.TestRegister.local_authority_eng;
 
-public class ItemQueryDAOIntegrationTest {
+public class SchemaSubstitutionIntegrationTest {
     private DBI dbi;
 
     @ClassRule
@@ -25,7 +25,7 @@ public class ItemQueryDAOIntegrationTest {
     }
 
     @Test
-    public void shouldFindNoItems(){
+    public void shouldSuccessfullyQueryWhenSchemaContainsHyphens(){
         Collection<Item> items = dbi.withHandle(handle -> handle.attach(ItemQueryDAO.class).getAllItemsNoPagination("local-authority-eng"));
         Assert.assertThat(items.size(), is(0));
     }

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -8,7 +8,7 @@ database:
   #db connection properties
   initialSize: 1
   minSize: 1
-  maxSize: 3
+  maxSize: 4
 
   properties:
     charSet: UTF-8
@@ -48,6 +48,11 @@ registers:
     credentials:
       user: sasine
       password: inhibition
+  local-authority-eng:
+    schema: local-authority-eng
+    credentials:
+      user: bar
+      password: baz
 
 enableDownloadResource: true
 


### PR DESCRIPTION
This fixes a bug where the database queries are not properly constructed if the schema name has hyphens. 