### PR TITLE
Move current keys to index [DO NOT MERGE yet...]

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,6 +31,9 @@ server:
     - type: http
       port: 9092
 
+indexes:
+  - records
+
 registerDomain: openregister.dev:8080
 
 register: school

--- a/src/main/java/uk/gov/register/configuration/IndexFunctionConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/IndexFunctionConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov.register.configuration;
 import uk.gov.register.indexer.function.CurrentCountriesIndexFunction;
 import uk.gov.register.indexer.function.IndexFunction;
 import uk.gov.register.indexer.function.LocalAuthorityByTypeIndexFunction;
+import uk.gov.register.indexer.function.RecordIndexFunction;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -12,7 +13,8 @@ import static java.util.stream.Collectors.toSet;
 public enum IndexFunctionConfiguration {
 
     CURRENT_COUNTRIES(Constants.CURRENT_COUNTRIES, new CurrentCountriesIndexFunction(Constants.CURRENT_COUNTRIES)),
-    LOCAL_AUTHORITY_BY_TYPE(Constants.LOCAL_AUTHORITY_BY_TYPE, new LocalAuthorityByTypeIndexFunction(Constants.LOCAL_AUTHORITY_BY_TYPE));
+    LOCAL_AUTHORITY_BY_TYPE(Constants.LOCAL_AUTHORITY_BY_TYPE, new LocalAuthorityByTypeIndexFunction(Constants.LOCAL_AUTHORITY_BY_TYPE)),
+    RECORDS(Constants.RECORDS, new RecordIndexFunction(Constants.RECORDS));
 
     public static IndexFunctionConfiguration getValueLowerCase(String name) {
         try {
@@ -41,6 +43,6 @@ public enum IndexFunctionConfiguration {
     private static class Constants {
         private static final String CURRENT_COUNTRIES = "current-countries";
         private static final String LOCAL_AUTHORITY_BY_TYPE = "local-authority-by-type";
+        private static final String RECORDS = "records";
     }
-
 }

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -108,7 +108,7 @@ public class PostgresRegister implements Register {
 
     @Override
     public int getTotalRecords() {
-        return recordIndex.getTotalRecords();
+        return getTotalDerivationRecords("records");
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -83,7 +83,7 @@ public class PostgresRegister implements Register {
 
     @Override
     public Optional<Record> getRecord(String key) {
-        return recordIndex.getRecord(key);
+        return derivationRecordIndex.getRecord(key, "records");
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -191,7 +191,6 @@ public class RegisterContext implements
                 dbi.onDemand(ItemQueryDAO.class),
                 dbi.onDemand(ItemDAO.class),
                 dbi.onDemand(RecordQueryDAO.class),
-                dbi.onDemand(CurrentKeysUpdateDAO.class),
                 dbi.onDemand(IndexDAO.class),
                 schema);
     }
@@ -205,7 +204,6 @@ public class RegisterContext implements
                 handle.attach(ItemQueryDAO.class),
                 handle.attach(ItemDAO.class),
                 handle.attach(RecordQueryDAO.class),
-                handle.attach(CurrentKeysUpdateDAO.class),
                 handle.attach(IndexDAO.class),
                 schema);
     }

--- a/src/main/java/uk/gov/register/db/IndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/IndexQueryDAO.java
@@ -1,5 +1,10 @@
 package uk.gov.register.db;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import org.postgresql.util.PGobject;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.customizers.OverrideStatementRewriterWith;
@@ -9,40 +14,79 @@ import uk.gov.register.core.Entry;
 import uk.gov.register.core.Record;
 import uk.gov.register.db.mappers.DerivationEntryMapper;
 import uk.gov.register.db.mappers.DerivationRecordMapper;
+import uk.gov.register.db.mappers.RecordMapper;
 
+import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
 @OverrideStatementRewriterWith(SubstituteSchemaRewriter.class)
-public interface IndexQueryDAO {
+public abstract class IndexQueryDAO {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
     @SqlQuery(recordForKeyQuery)
     @SingleValueResult(Record.class)
     @RegisterMapper(DerivationRecordMapper.class)
-    Optional<Record> findRecord(@Bind("key") String derivationKey, @Bind("name") String derivationName, @Bind("schema") String schema );
+    public abstract Optional<Record> findRecord(@Bind("key") String derivationKey, @Bind("name") String derivationName, @Bind("schema") String schema );
 
     @SqlQuery(recordQuery)
     @RegisterMapper(DerivationRecordMapper.class)
-    List<Record> findRecords(@Bind("limit") int limit, @Bind("offset") int offset, @Bind("name") String derivationName, @Bind("schema") String schema );
+    public abstract List<Record> findRecords(@Bind("limit") int limit, @Bind("offset") int offset, @Bind("name") String derivationName, @Bind("schema") String schema );
 
     @SqlQuery("select max(r.index_entry_number) from (select greatest(start_index_entry_number, end_index_entry_number) as index_entry_number from :schema.index where name = :name) r")
-    int getCurrentIndexEntryNumber(@Bind("name") String indexName, @Bind("schema") String schema );
+    public abstract int getCurrentIndexEntryNumber(@Bind("name") String indexName, @Bind("schema") String schema );
 
     @SqlQuery(entriesQuery)
     @RegisterMapper(DerivationEntryMapper.class)
-    Iterator<Entry> getIterator(@Bind("name") String indexName, @Bind("schema") String schema );
+    public abstract Iterator<Entry> getIterator(@Bind("name") String indexName, @Bind("schema") String schema );
 
     @SqlQuery(entriesQueryBetweenEntries)
     @RegisterMapper(DerivationEntryMapper.class)
-    Iterator<Entry> getIterator(@Bind("name") String indexName, @Bind("total_entries_1") int totalEntries1, @Bind("total_entries_2") int totalEntries2, @Bind("schema") String schema );
+    public abstract Iterator<Entry> getIterator(@Bind("name") String indexName, @Bind("total_entries_1") int totalEntries1, @Bind("total_entries_2") int totalEntries2, @Bind("schema") String schema );
 
     @SqlQuery("select count(1) from :schema.index where name = :name and key = :key and sha256hex = :sha256hex and end_entry_number is null")
-    int getExistingIndexCountForItem(@Bind("name") String indexName, @Bind("key") String key, @Bind("sha256hex") String sha256hex, @Bind("schema") String schema );
+    public abstract int getExistingIndexCountForItem(@Bind("name") String indexName, @Bind("key") String key, @Bind("sha256hex") String sha256hex, @Bind("schema") String schema );
 
     @SqlQuery(recordCountQuery)
-    int getTotalRecords(@Bind("name") String indexName, @Bind("schema") String schema );
+    public abstract int getTotalRecords(@Bind("name") String indexName, @Bind("schema") String schema );
 
-    String recordForKeyQuery = "select " +
+    @SqlQuery(recordsByKeyValue)
+    @RegisterMapper(RecordMapper.class)
+    public abstract List<Record> __findMax100RecordsByKeyValue(@Bind("contentPGobject") PGobject content, @Bind("key") String key);
+
+    public List<Record> findMax100RecordsByKeyValue(String key, String value) {
+        return __findMax100RecordsByKeyValue(writePGObject(key, value), key);
+    }
+
+    private PGobject writePGObject(String key, String value) {
+        try {
+            PGobject json = new PGobject();
+            json.setType("jsonb");
+            json.setValue(objectMapper.writeValueAsString(ImmutableMap.of(key, value)));
+            return json;
+        } catch (SQLException | JsonProcessingException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    static final String recordsByKeyValue = "select " +
+            "e.entry_number, " +
+            "array_agg(ei.sha256hex) as sha256hex, " +
+            "e.timestamp, " +
+            "e.key, " +
+            "array_agg(i.content) as content " +
+            "from :schema.entry e " +
+            "join :schema.entry_item ei on ei.entry_number = e.entry_number " +
+            "join :schema.item i on i.sha256hex = ei.sha256hex " +
+            "join :schema.index idx on idx.sha256hex = i.sha256hex " +
+            "where i.content @> :contentPGobject " +
+            "and idx.name = 'records' " +
+            "and idx.end_index_entry_number is null " +
+            "group by e.entry_number " +
+            "limit 100";
+
+    static final String recordForKeyQuery = "select " +
             " entry_numbers.mien as index_entry_number, " +
             " entry_numbers.men as entry_number, " +
             " entry.\"timestamp\" as \"timestamp\", " +
@@ -85,7 +129,7 @@ public interface IndexQueryDAO {
             " ) as unended join :schema.entry on " +
             " entry.entry_number = entry_numbers.men";
 
-    String recordQuery = "select " +
+    static final String recordQuery = "select " +
             " entry_numbers.key, " +
             " greatest( " +
             "  entry_numbers.meien, " +
@@ -138,10 +182,10 @@ public interface IndexQueryDAO {
             "  entry_numbers.msen " +
             " ) " +
             "order by " +
-            " key " +
+            " entry_number desc " +
             " limit :limit offset :offset ";
 
-    String entriesQuery = "select  " +
+    static final String entriesQuery = "select  " +
             "  index_entry.ien as index_entry_number,  " +
             "  index_entry.en as entry_number,  " +
             "  e.timestamp as timestamp,  " +
@@ -191,7 +235,7 @@ public interface IndexQueryDAO {
             "order by  " +
             "  ien  " ;
 
-    String entriesQueryBetweenEntries = "select  " +
+    static final String entriesQueryBetweenEntries = "select  " +
             "  index_entry.ien as index_entry_number,  " +
             "  index_entry.en as entry_number,  " +
             "  e.timestamp as timestamp,  " +
@@ -241,7 +285,7 @@ public interface IndexQueryDAO {
             "order by  " +
             "  ien  ";
     
-    String recordCountQuery = "select " +
+    static final String recordCountQuery = "select " +
             "count( distinct key) " +
             "from " +
             " :schema.index " +

--- a/src/main/java/uk/gov/register/db/IndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/db/IndexQueryDAO.java
@@ -28,35 +28,35 @@ public abstract class IndexQueryDAO {
     @SqlQuery(recordForKeyQuery)
     @SingleValueResult(Record.class)
     @RegisterMapper(DerivationRecordMapper.class)
-    public abstract Optional<Record> findRecord(@Bind("key") String derivationKey, @Bind("name") String derivationName, @Bind("schema") String schema );
+    public abstract Optional<Record> findRecord(@Bind("key") String derivationKey, @Bind("name") String derivationName, @Bind("schema") String schema);
 
     @SqlQuery(recordQuery)
     @RegisterMapper(DerivationRecordMapper.class)
-    public abstract List<Record> findRecords(@Bind("limit") int limit, @Bind("offset") int offset, @Bind("name") String derivationName, @Bind("schema") String schema );
+    public abstract List<Record> findRecords(@Bind("limit") int limit, @Bind("offset") int offset, @Bind("name") String derivationName, @Bind("schema") String schema);
 
     @SqlQuery("select max(r.index_entry_number) from (select greatest(start_index_entry_number, end_index_entry_number) as index_entry_number from :schema.index where name = :name) r")
-    public abstract int getCurrentIndexEntryNumber(@Bind("name") String indexName, @Bind("schema") String schema );
+    public abstract int getCurrentIndexEntryNumber(@Bind("name") String indexName, @Bind("schema") String schema);
 
     @SqlQuery(entriesQuery)
     @RegisterMapper(DerivationEntryMapper.class)
-    public abstract Iterator<Entry> getIterator(@Bind("name") String indexName, @Bind("schema") String schema );
+    public abstract Iterator<Entry> getIterator(@Bind("name") String indexName, @Bind("schema") String schema);
 
     @SqlQuery(entriesQueryBetweenEntries)
     @RegisterMapper(DerivationEntryMapper.class)
-    public abstract Iterator<Entry> getIterator(@Bind("name") String indexName, @Bind("total_entries_1") int totalEntries1, @Bind("total_entries_2") int totalEntries2, @Bind("schema") String schema );
+    public abstract Iterator<Entry> getIterator(@Bind("name") String indexName, @Bind("total_entries_1") int totalEntries1, @Bind("total_entries_2") int totalEntries2, @Bind("schema") String schema);
 
     @SqlQuery("select count(1) from :schema.index where name = :name and key = :key and sha256hex = :sha256hex and end_entry_number is null")
-    public abstract int getExistingIndexCountForItem(@Bind("name") String indexName, @Bind("key") String key, @Bind("sha256hex") String sha256hex, @Bind("schema") String schema );
+    public abstract int getExistingIndexCountForItem(@Bind("name") String indexName, @Bind("key") String key, @Bind("sha256hex") String sha256hex, @Bind("schema") String schema);
 
     @SqlQuery(recordCountQuery)
-    public abstract int getTotalRecords(@Bind("name") String indexName, @Bind("schema") String schema );
+    public abstract int getTotalRecords(@Bind("name") String indexName, @Bind("schema") String schema);
 
     @SqlQuery(recordsByKeyValue)
     @RegisterMapper(RecordMapper.class)
-    public abstract List<Record> __findMax100RecordsByKeyValue(@Bind("contentPGobject") PGobject content, @Bind("key") String key);
+    public abstract List<Record> __findMax100RecordsByKeyValue(@Bind("contentPGobject") PGobject content, @Bind("key") String key, @Bind("schema") String schema);
 
-    public List<Record> findMax100RecordsByKeyValue(String key, String value) {
-        return __findMax100RecordsByKeyValue(writePGObject(key, value), key);
+    public List<Record> findMax100RecordsByKeyValue(String key, String value, String schema) {
+        return __findMax100RecordsByKeyValue(writePGObject(key, value), key, schema);
     }
 
     private PGobject writePGObject(String key, String value) {
@@ -182,7 +182,7 @@ public abstract class IndexQueryDAO {
             "  entry_numbers.msen " +
             " ) " +
             "order by " +
-            " entry_number desc " +
+            " key " +
             " limit :limit offset :offset ";
 
     static final String entriesQuery = "select  " +

--- a/src/main/java/uk/gov/register/indexer/IndexDriver.java
+++ b/src/main/java/uk/gov/register/indexer/IndexDriver.java
@@ -17,7 +17,7 @@ public class IndexDriver {
     }
 
     public void indexEntry(Register register, Entry entry, IndexFunction indexFunction) {
-        Optional<Record> currentRecord = register.getRecord(entry.getKey());
+        Optional<Record> currentRecord = register.getDerivationRecord(entry.getKey(), indexFunction.getName());
         Set<IndexKeyItemPair> currentIndexKeyItemPairs = new HashSet<>();
         if (currentRecord.isPresent()) {
             currentIndexKeyItemPairs.addAll(indexFunction.execute(register, currentRecord.get().getEntry()));
@@ -25,8 +25,8 @@ public class IndexDriver {
 
         Set<IndexKeyItemPair> newIndexKeyItemPairs = indexFunction.execute(register, entry);
 
-        List<IndexKeyItemPairEvent> pairEvents = getEndIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs);
-        pairEvents.addAll(getStartIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs));
+        List<IndexKeyItemPairEvent> pairEvents = getEndIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs, indexFunction.getName());
+        pairEvents.addAll(getStartIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs, indexFunction.getName()));
 
         TreeMap<String, List<IndexKeyItemPairEvent>> sortedEvents = groupEventsByKey(pairEvents);
 
@@ -47,11 +47,11 @@ public class IndexDriver {
         }
     }
 
-    protected List<IndexKeyItemPairEvent> getEndIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs) {
+    protected List<IndexKeyItemPairEvent> getEndIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs, String name) {
         List<IndexKeyItemPairEvent> pairs = new ArrayList<>();
 
         existingPairs.forEach(existingPair -> {
-            if (!newPairs.contains(existingPair)) {
+            if (!newPairs.contains(existingPair) || name.equals("records")) {
                 pairs.add(new IndexKeyItemPairEvent(existingPair, false));
             }
         });
@@ -59,11 +59,11 @@ public class IndexDriver {
         return pairs;
     }
 
-    protected List<IndexKeyItemPairEvent> getStartIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs) {
+    protected List<IndexKeyItemPairEvent> getStartIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs, String name) {
         List<IndexKeyItemPairEvent> pairs = new ArrayList<>();
 
         newPairs.forEach(newPair -> {
-            if (!existingPairs.contains(newPair)) {
+            if (!existingPairs.contains(newPair) || name.equals("records")) {
                 pairs.add(new IndexKeyItemPairEvent(newPair, true));
             }
         });

--- a/src/main/java/uk/gov/register/indexer/IndexDriver.java
+++ b/src/main/java/uk/gov/register/indexer/IndexDriver.java
@@ -25,8 +25,9 @@ public class IndexDriver {
 
         Set<IndexKeyItemPair> newIndexKeyItemPairs = indexFunction.execute(register, entry);
 
-        List<IndexKeyItemPairEvent> pairEvents = getEndIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs, indexFunction.getName());
-        pairEvents.addAll(getStartIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs, indexFunction.getName()));
+        boolean isRecordIndexFunction = indexFunction.getName().equals("records");
+        List<IndexKeyItemPairEvent> pairEvents = getEndIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs, isRecordIndexFunction);
+        pairEvents.addAll(getStartIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs, isRecordIndexFunction));
 
         TreeMap<String, List<IndexKeyItemPairEvent>> sortedEvents = groupEventsByKey(pairEvents);
 
@@ -47,11 +48,11 @@ public class IndexDriver {
         }
     }
 
-    protected List<IndexKeyItemPairEvent> getEndIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs, String name) {
+    protected List<IndexKeyItemPairEvent> getEndIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs, boolean isRecordIndexFunction) {
         List<IndexKeyItemPairEvent> pairs = new ArrayList<>();
 
         existingPairs.forEach(existingPair -> {
-            if (!newPairs.contains(existingPair) || name.equals("records")) {
+            if (!newPairs.contains(existingPair) || isRecordIndexFunction) {
                 pairs.add(new IndexKeyItemPairEvent(existingPair, false));
             }
         });
@@ -59,11 +60,11 @@ public class IndexDriver {
         return pairs;
     }
 
-    protected List<IndexKeyItemPairEvent> getStartIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs, String name) {
+    protected List<IndexKeyItemPairEvent> getStartIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs, boolean isRecordIndexFunction) {
         List<IndexKeyItemPairEvent> pairs = new ArrayList<>();
 
         newPairs.forEach(newPair -> {
-            if (!existingPairs.contains(newPair) || name.equals("records")) {
+            if (!existingPairs.contains(newPair) || isRecordIndexFunction) {
                 pairs.add(new IndexKeyItemPairEvent(newPair, true));
             }
         });

--- a/src/main/java/uk/gov/register/indexer/IndexDriver.java
+++ b/src/main/java/uk/gov/register/indexer/IndexDriver.java
@@ -17,7 +17,7 @@ public class IndexDriver {
     }
 
     public void indexEntry(Register register, Entry entry, IndexFunction indexFunction) {
-        Optional<Record> currentRecord = register.getDerivationRecord(entry.getKey(), indexFunction.getName());
+        Optional<Record> currentRecord = register.getRecord(entry.getKey());
         Set<IndexKeyItemPair> currentIndexKeyItemPairs = new HashSet<>();
         if (currentRecord.isPresent()) {
             currentIndexKeyItemPairs.addAll(indexFunction.execute(register, currentRecord.get().getEntry()));
@@ -25,9 +25,8 @@ public class IndexDriver {
 
         Set<IndexKeyItemPair> newIndexKeyItemPairs = indexFunction.execute(register, entry);
 
-        boolean isRecordIndexFunction = indexFunction.getName().equals("records");
-        List<IndexKeyItemPairEvent> pairEvents = getEndIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs, isRecordIndexFunction);
-        pairEvents.addAll(getStartIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs, isRecordIndexFunction));
+        List<IndexKeyItemPairEvent> pairEvents = getEndIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs);
+        pairEvents.addAll(getStartIndices(currentIndexKeyItemPairs, newIndexKeyItemPairs));
 
         TreeMap<String, List<IndexKeyItemPairEvent>> sortedEvents = groupEventsByKey(pairEvents);
 
@@ -48,11 +47,11 @@ public class IndexDriver {
         }
     }
 
-    protected List<IndexKeyItemPairEvent> getEndIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs, boolean isRecordIndexFunction) {
+    protected List<IndexKeyItemPairEvent> getEndIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs) {
         List<IndexKeyItemPairEvent> pairs = new ArrayList<>();
 
         existingPairs.forEach(existingPair -> {
-            if (!newPairs.contains(existingPair) || isRecordIndexFunction) {
+            if (!newPairs.contains(existingPair)) {
                 pairs.add(new IndexKeyItemPairEvent(existingPair, false));
             }
         });
@@ -60,11 +59,11 @@ public class IndexDriver {
         return pairs;
     }
 
-    protected List<IndexKeyItemPairEvent> getStartIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs, boolean isRecordIndexFunction) {
+    protected List<IndexKeyItemPairEvent> getStartIndices(Set<IndexKeyItemPair> existingPairs, Set<IndexKeyItemPair> newPairs) {
         List<IndexKeyItemPairEvent> pairs = new ArrayList<>();
 
         newPairs.forEach(newPair -> {
-            if (!existingPairs.contains(newPair) || isRecordIndexFunction) {
+            if (!existingPairs.contains(newPair)) {
                 pairs.add(new IndexKeyItemPairEvent(newPair, true));
             }
         });

--- a/src/main/java/uk/gov/register/indexer/function/RecordIndexFunction.java
+++ b/src/main/java/uk/gov/register/indexer/function/RecordIndexFunction.java
@@ -1,0 +1,19 @@
+package uk.gov.register.indexer.function;
+
+import uk.gov.register.core.Register;
+import uk.gov.register.indexer.IndexKeyItemPair;
+import uk.gov.register.util.HashValue;
+
+import java.util.Set;
+
+public class RecordIndexFunction extends BaseIndexFunction {
+
+    public RecordIndexFunction(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void execute(Register register, String key, HashValue itemHash, Set<IndexKeyItemPair> result) {
+        result.add(new IndexKeyItemPair(key, itemHash));
+    }
+}

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -45,7 +45,7 @@ public class RecordResource {
     public RecordView getRecordByKey(@PathParam("record-key") String key) {
         httpServletResponseAdapter.addLinkHeader("version-history", String.format("/record/%s/entries", key));
 
-        return register.getRecord(key).map(viewFactory::getRecordMediaView)
+        return register.getDerivationRecord(key, "records").map(viewFactory::getRecordMediaView)
                 .orElseThrow(NotFoundException::new);
     }
 
@@ -118,7 +118,7 @@ public class RecordResource {
     }
 
     private IndexSizePagination setUpPagination(@QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntegerParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntegerParam> pageSize) {
-        IndexSizePagination pagination = new IndexSizePagination(pageIndex.map(IntParam::get), pageSize.map(IntParam::get), register.getTotalRecords());
+        IndexSizePagination pagination = new IndexSizePagination(pageIndex.map(IntParam::get), pageSize.map(IntParam::get), register.getTotalDerivationRecords("records"));
 
         if (pagination.hasNextPage()) {
             httpServletResponseAdapter.addLinkHeader("next", pagination.getNextPageLink());

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDataAccessLayer.java
@@ -82,7 +82,6 @@ public class PostgresDataAccessLayer extends PostgresReadDataAccessLayer impleme
     public void checkpoint() {
         writeStagedEntriesToDatabase();
         writeStagedItemsToDatabase();
-        writeStagedCurrentKeysToDatabase();
     }
 
     private void writeStagedEntriesToDatabase() {

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDataAccessLayer.java
@@ -1,6 +1,5 @@
 package uk.gov.register.store.postgres;
 
-import com.google.common.collect.Iterables;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.db.*;
@@ -9,7 +8,6 @@ import uk.gov.register.util.EntryItemPair;
 import uk.gov.register.util.HashValue;
 
 import java.util.*;
-import java.util.stream.IntStream;
 
 public class PostgresDataAccessLayer extends PostgresReadDataAccessLayer implements DataAccessLayer {
     private final List<Entry> stagedEntries;
@@ -20,18 +18,16 @@ public class PostgresDataAccessLayer extends PostgresReadDataAccessLayer impleme
     private final EntryDAO entryDAO;
     private final EntryItemDAO entryItemDAO;
     private final ItemDAO itemDAO;
-    private final CurrentKeysUpdateDAO currentKeysDAO;
     private final IndexDAO indexDAO;
 
     public PostgresDataAccessLayer(
             EntryQueryDAO entryQueryDAO, IndexQueryDAO indexQueryDAO, EntryDAO entryDAO,
             EntryItemDAO entryItemDAO, ItemQueryDAO itemQueryDAO,
-            ItemDAO itemDAO, RecordQueryDAO recordQueryDAO, CurrentKeysUpdateDAO currentKeysUpdateDAO, IndexDAO indexDAO, String schema) {
+            ItemDAO itemDAO, RecordQueryDAO recordQueryDAO, IndexDAO indexDAO, String schema) {
         super(entryQueryDAO, indexQueryDAO, itemQueryDAO, recordQueryDAO, schema);
         this.entryDAO = entryDAO;
         this.entryItemDAO = entryItemDAO;
         this.itemDAO = itemDAO;
-        this.currentKeysDAO = currentKeysUpdateDAO;
         this.indexDAO = indexDAO;
 
         stagedEntries = new ArrayList<>();
@@ -106,27 +102,10 @@ public class PostgresDataAccessLayer extends PostgresReadDataAccessLayer impleme
         stagedItems.clear();
     }
 
-    private void writeStagedCurrentKeysToDatabase() {
-        int noOfRecordsDeleted = removeRecordsWithKeys(stagedCurrentKeys.keySet());
-
-        currentKeysDAO.writeCurrentKeys(Iterables.transform(stagedCurrentKeys.entrySet(),
-                keyValue -> new CurrentKey(keyValue.getKey(), keyValue.getValue()))
-                , schema);
-
-        currentKeysDAO.updateTotalRecords(stagedCurrentKeys.size() - noOfRecordsDeleted - entriesWithoutItems.size(), schema);
-        stagedCurrentKeys.clear();
-        entriesWithoutItems.clear();
-    }
-
     private OptionalInt getMaxStagedEntryNumber() {
         if (stagedEntries.isEmpty()) {
             return OptionalInt.empty();
         }
         return OptionalInt.of(stagedEntries.get(stagedEntries.size() - 1).getEntryNumber());
-    }
-
-    private int removeRecordsWithKeys(Iterable<String> keySet) {
-        int[] noOfRecordsDeletedPerBatch = currentKeysDAO.removeRecordWithKeys(keySet, schema);
-        return IntStream.of(noOfRecordsDeletedPerBatch).sum();
     }
 }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
@@ -1,6 +1,5 @@
 package uk.gov.register.store.postgres;
 
-import org.skife.jdbi.v2.sqlobject.Bind;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
@@ -9,7 +8,10 @@ import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.util.HashValue;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 public abstract class PostgresReadDataAccessLayer implements DataAccessLayer {
@@ -126,13 +128,13 @@ public abstract class PostgresReadDataAccessLayer implements DataAccessLayer {
     @Override
     public List<Record> getRecords(int limit, int offset) {
         checkpoint();
-        return recordQueryDAO.getRecords(limit, offset, schema);
+        return indexQueryDAO.findRecords(limit, offset, "records", schema);
     }
 
     @Override
     public List<Record> findMax100RecordsByKeyValue(String key, String value) {
         checkpoint();
-        return recordQueryDAO.findMax100RecordsByKeyValue(key, value, schema);
+        return indexQueryDAO.findMax100RecordsByKeyValue(key, value);
     }
 
     @Override
@@ -151,6 +153,7 @@ public abstract class PostgresReadDataAccessLayer implements DataAccessLayer {
 
     @Override
     public Optional<Record> getIndexRecord(String key, String indexName) {
+        checkpoint(); // do we need this?
         Optional<Record> record = indexQueryDAO.findRecord(key, indexName, schema);
         return record.filter(r -> r.getItems().size() != 0);
     }

--- a/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
@@ -134,7 +134,7 @@ public abstract class PostgresReadDataAccessLayer implements DataAccessLayer {
     @Override
     public List<Record> findMax100RecordsByKeyValue(String key, String value) {
         checkpoint();
-        return indexQueryDAO.findMax100RecordsByKeyValue(key, value);
+        return indexQueryDAO.findMax100RecordsByKeyValue(key, value, schema);
     }
 
     @Override
@@ -177,8 +177,6 @@ public abstract class PostgresReadDataAccessLayer implements DataAccessLayer {
     public int getExistingIndexCountForItem(String indexName, String key, String sha256hex){
         return indexQueryDAO.getExistingIndexCountForItem(indexName, key,sha256hex, schema );
     }
-
-
 
     protected abstract void checkpoint();
 }

--- a/src/test/java/uk/gov/register/core/InMemoryEntryLog.java
+++ b/src/test/java/uk/gov/register/core/InMemoryEntryLog.java
@@ -1,11 +1,11 @@
 package uk.gov.register.core;
 
-import static java.util.Collections.singletonList;
-import static org.mockito.Mockito.mock;
-
 import uk.gov.register.db.*;
 import uk.gov.register.store.postgres.PostgresDataAccessLayer;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.mock;
 
 public class InMemoryEntryLog extends EntryLogImpl {
     private final EntryDAO entryDAO;
@@ -13,7 +13,7 @@ public class InMemoryEntryLog extends EntryLogImpl {
     public InMemoryEntryLog(MemoizationStore memoizationStore, EntryQueryDAO entryQueryDAO, EntryDAO entryDAO) {
         super(new PostgresDataAccessLayer(entryQueryDAO, mock(IndexQueryDAO.class), mock(EntryDAO.class),
                 mock(EntryItemDAO.class), mock(ItemQueryDAO.class), mock(ItemDAO.class),
-                mock(RecordQueryDAO.class), mock(CurrentKeysUpdateDAO.class),  mock(IndexDAO.class), "schema"), memoizationStore);
+                mock(RecordQueryDAO.class), mock(IndexDAO.class), "schema"), memoizationStore);
         this.entryDAO = entryDAO;
     }
 

--- a/src/test/java/uk/gov/register/core/InMemoryItemStore.java
+++ b/src/test/java/uk/gov/register/core/InMemoryItemStore.java
@@ -14,7 +14,7 @@ public class InMemoryItemStore extends ItemStoreImpl {
     public InMemoryItemStore(ItemQueryDAO itemQueryDAO, ItemDAO itemDAO, ItemValidator itemValidator) {
         super(new PostgresDataAccessLayer(mock(EntryQueryDAO.class), mock(IndexQueryDAO.class), mock(EntryDAO.class),
                 mock(EntryItemDAO.class), itemQueryDAO, itemDAO,
-                mock(RecordQueryDAO.class), mock(CurrentKeysUpdateDAO.class), mock(IndexDAO.class), "schema"), itemValidator);
+                mock(RecordQueryDAO.class), mock(IndexDAO.class), "schema"), itemValidator);
         this.itemDAO = itemDAO;
         this.itemValidator = itemValidator;
     }

--- a/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
@@ -10,9 +10,13 @@ import org.skife.jdbi.v2.Handle;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.EntryType;
 import uk.gov.register.core.Item;
+import uk.gov.register.core.Record;
+import uk.gov.register.db.IndexQueryDAO;
 import uk.gov.register.functional.app.RegisterRule;
 import uk.gov.register.functional.app.TestRegister;
-import uk.gov.register.functional.db.*;
+import uk.gov.register.functional.db.TestDBItem;
+import uk.gov.register.functional.db.TestEntryDAO;
+import uk.gov.register.functional.db.TestItemCommandDAO;
 import uk.gov.register.util.CanonicalJsonMapper;
 
 import javax.ws.rs.core.Response;
@@ -33,14 +37,14 @@ public class DataUploadFunctionalTest {
     private static String schema;
 
     private final CanonicalJsonMapper canonicalJsonMapper = new CanonicalJsonMapper();
-    private static TestRecordDAO testRecordDAO;
+    private static IndexQueryDAO testRecordDAO;
     private static TestEntryDAO testEntryDAO;
     private static TestItemCommandDAO testItemDAO;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
         Handle handle = register.handleFor(TestRegister.register);
-        testRecordDAO = handle.attach(TestRecordDAO.class);
+        testRecordDAO = handle.attach(IndexQueryDAO.class);
         testEntryDAO = handle.attach(TestEntryDAO.class);
         testItemDAO = handle.attach(TestItemCommandDAO.class);
         schema = TestRegister.register.getSchema();
@@ -64,9 +68,9 @@ public class DataUploadFunctionalTest {
         Entry entry = testEntryDAO.getAllEntries(schema).get(0);
         assertThat(entry, equalTo(new Entry(1, storedItem.hashValue, entry.getTimestamp(), "ft_openregister_test", EntryType.user)));
 
-        TestRecord record = testRecordDAO.getRecord("ft_openregister_test", schema);
-        assertThat(record.getEntryNumber(), equalTo(1));
-        assertThat(record.getPrimaryKey(), equalTo("ft_openregister_test"));
+        Record record = testRecordDAO.findRecord("ft_openregister_test", "records", schema).get();
+        assertThat(record.getEntry().getEntryNumber(), equalTo(1));
+        assertThat(record.getEntry().getKey(), equalTo("ft_openregister_test"));
 
         Response response = register.getRequest(TestRegister.register, "/record/ft_openregister_test.json");
 
@@ -110,13 +114,12 @@ public class DataUploadFunctionalTest {
                 )
         );
 
-        TestRecord record1 = testRecordDAO.getRecord("register1", schema);
-        assertThat(record1.getEntryNumber(), equalTo(1));
-        assertThat(record1.getPrimaryKey(), equalTo("register1"));
-        TestRecord record2 = testRecordDAO.getRecord("register2", schema);
-        assertThat(record2.getEntryNumber(), equalTo(2));
-        assertThat(record2.getPrimaryKey(), equalTo("register2"));
-
+        Record record1 = testRecordDAO.findRecord("register1", "records", schema).get();
+        assertThat(record1.getEntry().getEntryNumber(), equalTo(1));
+        assertThat(record1.getEntry().getKey(), equalTo("register1"));
+        Record record2 = testRecordDAO.findRecord("register2", "records", schema).get();
+        assertThat(record2.getEntry().getEntryNumber(), equalTo(2));
+        assertThat(record2.getEntry().getKey(), equalTo("register2"));
     }
 
     @Test
@@ -147,9 +150,9 @@ public class DataUploadFunctionalTest {
         );
 
 
-        TestRecord record = testRecordDAO.getRecord("register1", schema);
-        assertThat(record.getEntryNumber(), equalTo(2));
-        assertThat(record.getPrimaryKey(), equalTo("register1"));
+        Record record = testRecordDAO.findRecord("register1", "records", schema).get();
+        assertThat(record.getEntry().getEntryNumber(), equalTo(2));
+        assertThat(record.getEntry().getKey(), equalTo("register1"));
     }
 
     @Test
@@ -186,13 +189,12 @@ public class DataUploadFunctionalTest {
         );
 
 
-        TestRecord record1 = testRecordDAO.getRecord("register1", schema);
-        assertThat(record1.getEntryNumber(), equalTo(2));
-        assertThat(record1.getPrimaryKey(), equalTo("register1"));
-        TestRecord record2 = testRecordDAO.getRecord("register2", schema);
-        assertThat(record2.getEntryNumber(), equalTo(3));
-        assertThat(record2.getPrimaryKey(), equalTo("register2"));
-
+        Record record1 = testRecordDAO.findRecord("register1", "records", schema).get();
+        assertThat(record1.getEntry().getEntryNumber(), equalTo(2));
+        assertThat(record1.getEntry().getKey(), equalTo("register1"));
+        Record record2 = testRecordDAO.findRecord("register2", "records", schema).get();
+        assertThat(record2.getEntry().getEntryNumber(), equalTo(3));
+        assertThat(record2.getEntry().getKey(), equalTo("register2"));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
@@ -7,14 +7,14 @@ import org.junit.rules.TestRule;
 import org.skife.jdbi.v2.Handle;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.core.Record;
+import uk.gov.register.db.IndexQueryDAO;
 import uk.gov.register.functional.app.RegisterRule;
 import uk.gov.register.functional.app.TestRegister;
 import uk.gov.register.functional.app.WipeDatabaseRule;
 import uk.gov.register.functional.db.TestDBItem;
 import uk.gov.register.functional.db.TestEntryDAO;
 import uk.gov.register.functional.db.TestItemCommandDAO;
-import uk.gov.register.functional.db.TestRecord;
-import uk.gov.register.functional.db.TestRecordDAO;
 import uk.gov.register.util.HashValue;
 
 import javax.ws.rs.core.Response;
@@ -39,7 +39,7 @@ public class LoadSerializedFunctionalTest {
     public static final RegisterRule register = new RegisterRule();
     private static TestItemCommandDAO testItemDAO;
     private static TestEntryDAO testEntryDAO;
-    private static TestRecordDAO testRecordDAO;
+    private static IndexQueryDAO testRecordDAO;
     private static String schema = testRegister.getSchema();
 
     @BeforeClass
@@ -47,7 +47,7 @@ public class LoadSerializedFunctionalTest {
         Handle handle = register.handleFor(testRegister);
         testItemDAO = handle.attach(TestItemCommandDAO.class);
         testEntryDAO = handle.attach(TestEntryDAO.class);
-        testRecordDAO = handle.attach(TestRecordDAO.class);
+        testRecordDAO = handle.attach(IndexQueryDAO.class);
     }
 
     @Test
@@ -74,12 +74,12 @@ public class LoadSerializedFunctionalTest {
         assertThat(entries.get(1).getEntryNumber(), is(2));
         assertThat(entries.get(1).getItemHashes().get(0).getValue(), is("b8b56d0329b4a82ce55217cfbb3803c322bf43711f82649757e9c2df5f5b8371"));
 
-        TestRecord record1 = testRecordDAO.getRecord("ft_openregister_test", schema);
-        assertThat(record1.getEntryNumber(), equalTo(1));
-        assertThat(record1.getPrimaryKey(), equalTo("ft_openregister_test"));
-        TestRecord record2 = testRecordDAO.getRecord("ft_openregister_test2", schema);
-        assertThat(record2.getEntryNumber(), equalTo(2));
-        assertThat(record2.getPrimaryKey(), equalTo("ft_openregister_test2"));
+        Record record1 = testRecordDAO.findRecord("ft_openregister_test", "records", schema).get();
+        assertThat(record1.getEntry().getEntryNumber(), equalTo(1));
+        assertThat(record1.getEntry().getKey(), equalTo("ft_openregister_test"));
+        Record record2 = testRecordDAO.findRecord("ft_openregister_test2", "records", schema).get();
+        assertThat(record2.getEntry().getEntryNumber(), equalTo(2));
+        assertThat(record2.getEntry().getKey(), equalTo("ft_openregister_test2"));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -13,8 +13,6 @@ import uk.gov.register.functional.app.RegisterRule;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -87,6 +85,22 @@ public class RecordResourceFunctionalTest {
     }
 
     @Test
+    public void recordResource_returnsMostRecentRecord_whenMultipleEntriesExist() throws IOException {
+        Response response = register.getRequest(address, "/record/6789.json");
+        JsonNode res = Jackson.newObjectMapper().readValue(response.readEntity(String.class), JsonNode.class);
+
+        assertThat(res.get("6789").get("item").get(0).get("street").textValue(), equalTo("presley"));
+    }
+
+    @Test
+    public void recordResource_returnsIdenticalResponseAsIndexEndpoint() throws IOException {
+        String indexResponse = register.getRequest(address, "/index/records/record/6789.json").readEntity(String.class);
+        String recordsResponse = register.getRequest(address, "/record/6789.json").readEntity(String.class);
+
+        assertThat(indexResponse, equalTo(recordsResponse));
+    }
+
+    @Test
     public void historyResource_returnsHistoryOfARecord() throws IOException {
         Response response = register.getRequest(address, "/record/6789/entries.json");
 
@@ -107,7 +121,6 @@ public class RecordResourceFunctionalTest {
         assertThat(secondEntry.get("entry-number").textValue(), equalTo("2"));
         assertThat(secondEntry.get("item-hash").get(0).textValue(), equalTo("sha-256:" + DigestUtils.sha256Hex(item1)));
         assertTrue(secondEntry.get("entry-timestamp").textValue().matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"));
-
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -1,6 +1,7 @@
 package uk.gov.register.functional.app;
 
 import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.jdbi.OptionalContainerFactory;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.apache.http.impl.conn.InMemoryDnsResolver;
@@ -113,7 +114,9 @@ public class RegisterRule implements TestRule {
      * the handle will automatically be closed by the RegisterRule
      */
     public Handle handleFor(TestRegister register) {
-        Handle handle = new DBI(register.getDatabaseConnectionString("RegisterRule")).open();
+        DBI dbi = new DBI(register.getDatabaseConnectionString("RegisterRule"));
+        dbi.registerContainerFactory(new OptionalContainerFactory());
+        Handle handle = dbi.open();
         handles.add(handle);
         return handle;
     }

--- a/src/test/java/uk/gov/register/functional/db/TestRecordDAO.java
+++ b/src/test/java/uk/gov/register/functional/db/TestRecordDAO.java
@@ -14,8 +14,7 @@ import java.sql.SQLException;
 
 @OverrideStatementRewriterWith(SubstituteSchemaRewriter.class)
 public interface TestRecordDAO {
-    @SqlUpdate("delete from :schema.current_keys;" +
-            "delete from :schema.total_records;" +
+    @SqlUpdate("delete from :schema.total_records;" +
             "insert into :schema.total_records values(0)")
     void wipeData(@Bind("schema") String schema);
 

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -176,7 +176,6 @@ public class PostgresRegisterTransactionalFunctionalTest {
                 handle.attach(ItemQueryDAO.class),
                 handle.attach(ItemDAO.class),
                 handle.attach(RecordQueryDAO.class),
-                handle.attach(CurrentKeysUpdateDAO.class),
                 handle.attach(IndexDAO.class),
                 "address");
     }

--- a/src/test/java/uk/gov/register/indexer/IndexDriverTest.java
+++ b/src/test/java/uk/gov/register/indexer/IndexDriverTest.java
@@ -43,7 +43,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs, "");
+        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs, false);
 
         assertThat(pairsToStart, empty());
     }
@@ -62,7 +62,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("C", new HashValue(HashingAlgorithm.SHA256, "ccc"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs, "");
+        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs, false);
 
         assertThat(pairsToStart, contains(new IndexKeyItemPairEvent(new IndexKeyItemPair("C", new HashValue(HashingAlgorithm.SHA256, "ccc")), true)));
     }
@@ -81,7 +81,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs, "");
+        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs, false);
 
         assertThat(pairsToEnd, empty());
     }
@@ -98,7 +98,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs, "");
+        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs, false);
 
         assertThat(pairsToEnd, contains(new IndexKeyItemPairEvent(new IndexKeyItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa")), false)));
     }

--- a/src/test/java/uk/gov/register/indexer/IndexDriverTest.java
+++ b/src/test/java/uk/gov/register/indexer/IndexDriverTest.java
@@ -43,7 +43,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs);
+        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs, "");
 
         assertThat(pairsToStart, empty());
     }
@@ -62,7 +62,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("C", new HashValue(HashingAlgorithm.SHA256, "ccc"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs);
+        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs, "");
 
         assertThat(pairsToStart, contains(new IndexKeyItemPairEvent(new IndexKeyItemPair("C", new HashValue(HashingAlgorithm.SHA256, "ccc")), true)));
     }
@@ -81,7 +81,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs);
+        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs, "");
 
         assertThat(pairsToEnd, empty());
     }
@@ -98,7 +98,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs);
+        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs, "");
 
         assertThat(pairsToEnd, contains(new IndexKeyItemPairEvent(new IndexKeyItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa")), false)));
     }
@@ -111,7 +111,7 @@ public class IndexDriverTest {
         Entry newEntry = new Entry(2, Arrays.asList(new HashValue(HashingAlgorithm.SHA256, "aaa"), new HashValue(HashingAlgorithm.SHA256, "bbb")), Instant.now(), "A", EntryType.user);
 
 
-        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, item)));
+        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.of(new Record(previousEntry, item)));
 
         IndexDAO indexDAO = mock(IndexDAO.class);
         IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
@@ -138,7 +138,7 @@ public class IndexDriverTest {
         Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A", EntryType.user);
 
 
-        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, item)));
+        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.of(new Record(previousEntry, item)));
 
         IndexDAO indexDAO = mock(IndexDAO.class);
         IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
@@ -166,7 +166,7 @@ public class IndexDriverTest {
         Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A", EntryType.user);
 
 
-        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, itemP)));
+        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.of(new Record(previousEntry, itemP)));
 
         IndexDAO indexDAO = mock(IndexDAO.class);
         IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
@@ -195,8 +195,7 @@ public class IndexDriverTest {
         Entry previousEntry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A", EntryType.user);
         Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "A", EntryType.user);
 
-
-        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, itemQ)));
+        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.of(new Record(previousEntry, itemQ)));
 
         IndexDAO indexDAO = mock(IndexDAO.class);
         IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
@@ -226,7 +225,7 @@ public class IndexDriverTest {
         Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A", EntryType.user);
 
 
-        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, itemP)));
+        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.of(new Record(previousEntry, itemP)));
 
         IndexDAO indexDAO = mock(IndexDAO.class);
         IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
@@ -256,7 +255,7 @@ public class IndexDriverTest {
         Entry newEntry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "B", EntryType.user);
 
 
-        when(register.getRecord(anyString())).thenReturn(Optional.empty());
+        when(register.getDerivationRecord(anyString(), eq("by-x"))).thenReturn(Optional.empty());
 
         when(dataAccessLayer.getCurrentIndexEntryNumber("by-x")).thenReturn(0, 1);
         IndexFunction indexFunction = mock(IndexFunction.class);
@@ -290,10 +289,10 @@ public class IndexDriverTest {
         Entry newEntry5 = new Entry(5, new HashValue(HashingAlgorithm.SHA256, "ccc"), Instant.now(), "D", EntryType.user);
 
 
-        when(register.getRecord("A")).thenReturn(Optional.empty());
-        when(register.getRecord("B")).thenReturn(Optional.empty());
-        when(register.getRecord("C")).thenReturn(Optional.empty(), Optional.of(new Record(newEntry3, itemS)));
-        when(register.getRecord("D")).thenReturn(Optional.empty());
+        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.empty());
+        when(register.getDerivationRecord("B", "by-x")).thenReturn(Optional.empty());
+        when(register.getDerivationRecord("C", "by-x")).thenReturn(Optional.empty(), Optional.of(new Record(newEntry3, itemS)));
+        when(register.getDerivationRecord("D", "by-x")).thenReturn(Optional.empty());
 
         when(dataAccessLayer.getCurrentIndexEntryNumber("by-x")).thenReturn(0, 1, 2, 3, 4);
         when(dataAccessLayer.getExistingIndexCountForItem("by-x", "Q", "bbb")).thenReturn(0, 1);
@@ -358,7 +357,7 @@ public class IndexDriverTest {
         Entry newEntry = new Entry(3, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "B", EntryType.user);
 
 
-        when(register.getRecord(anyString())).thenReturn(Optional.of(new Record(previousEntry, item)));
+        when(register.getDerivationRecord(anyString(), eq("by-x"))).thenReturn(Optional.of(new Record(previousEntry, item)));
 
         when(dataAccessLayer.getCurrentIndexEntryNumber("by-x")).thenReturn(1);
         when(dataAccessLayer.getExistingIndexCountForItem("by-x", "P", "aaa")).thenReturn(2);

--- a/src/test/java/uk/gov/register/indexer/IndexDriverTest.java
+++ b/src/test/java/uk/gov/register/indexer/IndexDriverTest.java
@@ -43,7 +43,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs, false);
+        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs);
 
         assertThat(pairsToStart, empty());
     }
@@ -62,7 +62,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("C", new HashValue(HashingAlgorithm.SHA256, "ccc"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs, false);
+        List<IndexKeyItemPairEvent> pairsToStart = indexDriver.getStartIndices(existingPairs, newPairs);
 
         assertThat(pairsToStart, contains(new IndexKeyItemPairEvent(new IndexKeyItemPair("C", new HashValue(HashingAlgorithm.SHA256, "ccc")), true)));
     }
@@ -81,7 +81,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs, false);
+        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs);
 
         assertThat(pairsToEnd, empty());
     }
@@ -98,7 +98,7 @@ public class IndexDriverTest {
                 new IndexKeyItemPair("B", new HashValue(HashingAlgorithm.SHA256, "bbb"))
         ));
 
-        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs, false);
+        List<IndexKeyItemPairEvent> pairsToEnd = indexDriver.getEndIndices(existingPairs, newPairs);
 
         assertThat(pairsToEnd, contains(new IndexKeyItemPairEvent(new IndexKeyItemPair("A", new HashValue(HashingAlgorithm.SHA256, "aaa")), false)));
     }
@@ -137,8 +137,7 @@ public class IndexDriverTest {
         Entry previousEntry = new Entry(1, Arrays.asList(new HashValue(HashingAlgorithm.SHA256, "aaa"), new HashValue(HashingAlgorithm.SHA256, "bbb")), Instant.now(), "A", EntryType.user);
         Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A", EntryType.user);
 
-
-        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.of(new Record(previousEntry, item)));
+        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, item)));
 
         IndexDAO indexDAO = mock(IndexDAO.class);
         IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
@@ -165,8 +164,7 @@ public class IndexDriverTest {
         Entry previousEntry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "A", EntryType.user);
         Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A", EntryType.user);
 
-
-        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.of(new Record(previousEntry, itemP)));
+        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, itemP)));
 
         IndexDAO indexDAO = mock(IndexDAO.class);
         IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
@@ -195,7 +193,7 @@ public class IndexDriverTest {
         Entry previousEntry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A", EntryType.user);
         Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "A", EntryType.user);
 
-        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.of(new Record(previousEntry, itemQ)));
+        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, itemQ)));
 
         IndexDAO indexDAO = mock(IndexDAO.class);
         IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
@@ -224,8 +222,7 @@ public class IndexDriverTest {
         Entry previousEntry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "A", EntryType.user);
         Entry newEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "A", EntryType.user);
 
-
-        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.of(new Record(previousEntry, itemP)));
+        when(register.getRecord("A")).thenReturn(Optional.of(new Record(previousEntry, itemP)));
 
         IndexDAO indexDAO = mock(IndexDAO.class);
         IndexQueryDAO indexQueryDAO = mock(IndexQueryDAO.class);
@@ -254,8 +251,7 @@ public class IndexDriverTest {
         Entry newEntry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "A", EntryType.user);
         Entry newEntry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "bbb"), Instant.now(), "B", EntryType.user);
 
-
-        when(register.getDerivationRecord(anyString(), eq("by-x"))).thenReturn(Optional.empty());
+        when(register.getRecord(anyString())).thenReturn(Optional.empty());
 
         when(dataAccessLayer.getCurrentIndexEntryNumber("by-x")).thenReturn(0, 1);
         IndexFunction indexFunction = mock(IndexFunction.class);
@@ -289,10 +285,10 @@ public class IndexDriverTest {
         Entry newEntry5 = new Entry(5, new HashValue(HashingAlgorithm.SHA256, "ccc"), Instant.now(), "D", EntryType.user);
 
 
-        when(register.getDerivationRecord("A", "by-x")).thenReturn(Optional.empty());
-        when(register.getDerivationRecord("B", "by-x")).thenReturn(Optional.empty());
-        when(register.getDerivationRecord("C", "by-x")).thenReturn(Optional.empty(), Optional.of(new Record(newEntry3, itemS)));
-        when(register.getDerivationRecord("D", "by-x")).thenReturn(Optional.empty());
+        when(register.getRecord("A")).thenReturn(Optional.empty());
+        when(register.getRecord("B")).thenReturn(Optional.empty());
+        when(register.getRecord("C")).thenReturn(Optional.empty(), Optional.of(new Record(newEntry3, itemS)));
+        when(register.getRecord("D")).thenReturn(Optional.empty());
 
         when(dataAccessLayer.getCurrentIndexEntryNumber("by-x")).thenReturn(0, 1, 2, 3, 4);
         when(dataAccessLayer.getExistingIndexCountForItem("by-x", "Q", "bbb")).thenReturn(0, 1);
@@ -356,7 +352,7 @@ public class IndexDriverTest {
         Entry previousEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "B", EntryType.user);
         Entry newEntry = new Entry(3, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "B", EntryType.user);
 
-        when(register.getDerivationRecord(anyString(), eq("by-x"))).thenReturn(Optional.of(new Record(previousEntry, item)));
+        when(register.getRecord(anyString())).thenReturn(Optional.of(new Record(previousEntry, item)));
  
         when(dataAccessLayer.getCurrentIndexEntryNumber("by-x")).thenReturn(1);
         when(dataAccessLayer.getExistingIndexCountForItem("by-x", "P", "aaa")).thenReturn(2);
@@ -373,27 +369,5 @@ public class IndexDriverTest {
         verify(dataAccessLayer, times(1)).end("by-x", "B", "P", "aaa", 3, Optional.empty());
         verify(dataAccessLayer, times(1)).end(anyString(), anyString(), anyString(), anyString(), anyInt(), any());
         verify(dataAccessLayer, times(0)).start(anyString(), anyString(), anyString(), anyInt(), any());
-    }
-    
-    @Test
-    public void indexEntry_shouldStartNewIndex_whenUpdatingExistingRecord() throws IOException {
-        Item item = new Item(new HashValue(HashingAlgorithm.SHA256, "aaa"), objectMapper.readTree("{\"x\":\"P\"}"));
-        
-        Entry entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "P", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "P", EntryType.user);
-        
-        when(register.getDerivationRecord("P", "records")).thenReturn(Optional.of(new Record(entry1, item)));
-        
-        IndexFunction indexFunction = mock(IndexFunction.class);
-        when(indexFunction.getName()).thenReturn("records");
-        when(indexFunction.execute(register, entry1)).thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")))));
-        when(indexFunction.execute(register, entry2)).thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")))));
-        when(dataAccessLayer.getCurrentIndexEntryNumber("by-x")).thenReturn(1);
-        when(dataAccessLayer.getExistingIndexCountForItem("records", "P", "aaa")).thenReturn(1);
-        IndexDriver indexDriver = new IndexDriver(dataAccessLayer);
-        indexDriver.indexEntry(register, entry2, indexFunction);
-
-        verify(dataAccessLayer, times(1)).end("records", "P", "P", "aaa", 2, Optional.of(1));
-        verify(dataAccessLayer, times(1)).start("records", "P", "aaa", 2, Optional.empty()); 
     }
 }

--- a/src/test/java/uk/gov/register/indexer/function/RecordIndexFunctionTest.java
+++ b/src/test/java/uk/gov/register/indexer/function/RecordIndexFunctionTest.java
@@ -1,0 +1,39 @@
+package uk.gov.register.indexer.function;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.core.Register;
+import uk.gov.register.indexer.IndexKeyItemPair;
+import uk.gov.register.util.HashValue;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+public class RecordIndexFunctionTest{
+    RecordIndexFunction func;
+    Register register;
+
+    @Before
+    public void setup() {
+        register = mock(Register.class);
+        func = new RecordIndexFunction("records");
+    }
+
+    @Test
+    public void executeWithKeyAndHash_shouldReturnIndexValueItemPairByKey() throws IOException {
+        HashValue itemHash = new HashValue(HashingAlgorithm.SHA256, "abc");
+
+        Set<IndexKeyItemPair> resultSet = new HashSet<>();
+        func.execute(register, "LND", new HashValue(HashingAlgorithm.SHA256, "abc"), resultSet);
+
+        assertThat(resultSet.size(), is(1));
+        assertThat(resultSet, contains(new IndexKeyItemPair("LND", itemHash)));
+    }
+}

--- a/src/test/java/uk/gov/register/integration/IndexQueryDaoIntegrationTest.java
+++ b/src/test/java/uk/gov/register/integration/IndexQueryDaoIntegrationTest.java
@@ -14,7 +14,6 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
 import uk.gov.register.db.IndexQueryDAO;
-import uk.gov.register.db.SubstituteSchemaRewriter;
 import uk.gov.register.functional.app.WipeDatabaseRule;
 import uk.gov.register.util.HashValue;
 
@@ -158,7 +157,6 @@ public class IndexQueryDaoIntegrationTest {
         assertThat(records.size(), is(0));
     }
 
-
     @Test
     public void shouldReadRecords() {
         nameChangeAndGroupChangeScenario();
@@ -262,7 +260,14 @@ public class IndexQueryDaoIntegrationTest {
     }
 
     @Test
-    public void shouldCountRecords() {
+    public void getTotalRecords_shouldReturnZero_whenNoRecordsExist() {
+        int totalRecords = dao.getTotalRecords("by-type", schema);
+
+        assertThat(totalRecords, is(0));
+    }
+
+    @Test
+    public void getTotalRecords_shouldReturnTotalRecords_whenRecordsExist() {
         nameChangeAndGroupChangeScenario();
         int totalRecords = dao.getTotalRecords("by-type", schema);
 

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDataAccessLayerTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDataAccessLayerTest.java
@@ -29,11 +29,9 @@ public class PostgresDataAccessLayerTest {
     IndexDAO indexDAO;
     InMemoryItemDAO itemDAO;
     RecordQueryDAO recordQueryDAO;
-    InMemoryCurrentKeysUpdateDAO currentKeysUpdateDAO;
 
     private List<Entry> entries;
     private Map<HashValue, Item> itemMap;
-    private Map<String, Integer> currentKeys;
 
     private PostgresDataAccessLayer dataAccessLayer;
 
@@ -46,7 +44,6 @@ public class PostgresDataAccessLayerTest {
     public void setUp() throws Exception {
         entries = new ArrayList<>();
         itemMap = new HashMap<>();
-        currentKeys = new HashMap<>();
 
         entryQueryDAO = new InMemoryEntryDAO(entries);
         entryItemDAO = new InMemoryEntryItemDAO();
@@ -54,10 +51,9 @@ public class PostgresDataAccessLayerTest {
         indexDAO = mock(IndexDAO.class);
         itemDAO = new InMemoryItemDAO(itemMap, new InMemoryEntryDAO(entries));
         recordQueryDAO = mock(RecordQueryDAO.class);
-        currentKeysUpdateDAO = new InMemoryCurrentKeysUpdateDAO(currentKeys);
 
         dataAccessLayer = new PostgresDataAccessLayer(entryQueryDAO, indexQueryDAO, entryQueryDAO, entryItemDAO,
-                itemDAO, itemDAO, recordQueryDAO, currentKeysUpdateDAO, indexDAO, "zzz");
+                itemDAO, itemDAO, recordQueryDAO, indexDAO, "zzz");
 
         item1 = new Item(new HashValue(SHA256, "abcd"), objectMapper.readTree("{}"));
         item2 = new Item(new HashValue(SHA256, "jkl1"), objectMapper.readTree("{}"));
@@ -167,152 +163,56 @@ public class PostgresDataAccessLayerTest {
     public void updateRecordIndex_shouldNotCommitChanges() throws Exception {
         dataAccessLayer.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
 
-        assertThat(currentKeys.entrySet(), is(empty()));
+//        assertThat(currentKeys.entrySet(), is(empty()));
     }
 
     @Test
     public void getRecord_shouldCauseCheckpoint() {
-        dataAccessLayer.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
+        dataAccessLayer.appendEntry(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
 
         Optional<Record> ignored = dataAccessLayer.getRecord("foo");
 
         // ignore the result, but check that we flushed out to currentKeys
-        assertThat(currentKeys.get("foo"), is(5));
+        assertThat(dataAccessLayer.getTotalEntries(), is(1));
     }
 
     @Test
     public void getRecords_shouldCauseCheckpoint() {
-        dataAccessLayer.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
+        dataAccessLayer.appendEntry(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
 
         List<Record> ignored = dataAccessLayer.getRecords(1,0);
 
-        // ignore the result, but check that we flushed out to currentKeys
-        assertThat(currentKeys.get("foo"), is(5));
+        // ignore the result, but check that committed to DB
+        assertThat(dataAccessLayer.getTotalEntries(), is(1));
     }
 
     @Test
     public void findMax100RecordsByKeyValue_shouldCauseCheckpoint() {
-        dataAccessLayer.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
+        dataAccessLayer.appendEntry(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
 
         List<Record> ignored = dataAccessLayer.findMax100RecordsByKeyValue("foo", "bar");
 
-        // ignore the result, but check that we flushed out to currentKeys
-        assertThat(currentKeys.get("foo"), is(5));
+        // ignore the result, but check that committed to DB
+        assertThat(dataAccessLayer.getTotalEntries(), is(1));
     }
 
     @Test
     public void findAllEntriesOfRecordBy_shouldCauseCheckpoint() {
-        dataAccessLayer.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
+        dataAccessLayer.appendEntry(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
 
         Collection<Entry> ignored = dataAccessLayer.findAllEntriesOfRecordBy("bar");
 
-        // ignore the result, but check that we flushed out to currentKeys
-        assertThat(currentKeys.get("foo"), is(5));
+        // ignore the result, but check that committed to DB
+        assertThat(dataAccessLayer.getTotalEntries(), is(1));
     }
 
     @Test
     public void getTotalRecords_shouldCauseCheckpoint() {
-        dataAccessLayer.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
+        dataAccessLayer.appendEntry(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "foo"), Instant.now(), "foo", EntryType.user));
 
         int ignored = dataAccessLayer.getTotalRecords();
 
-        // ignore the result, but check that we flushed out to currentKeys
-        assertThat(currentKeys.get("foo"), is(5));
-    }
-
-    @Test
-    public void insertRecordWithSameKeyValueDoesNotStageBothCurrentKeys() {
-        dataAccessLayer.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "va"), Instant.now(), "VA", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(3, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE", EntryType.user));
-
-        assertThat(currentKeys.entrySet(), is(empty()));
-
-        dataAccessLayer.checkpoint(); // force writing staged data
-
-        assertThat(currentKeys.size(), is(2));
-        assertThat(currentKeys.get("DE"), is(3));
-        assertThat(currentKeys.get("VA"), is(2));
-    }
-
-    @Test
-    public void whenInserting_shouldUpdateRecordCount() throws Exception {
-        dataAccessLayer.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "va"), Instant.now(), "VA", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.checkpoint(); // force writing staged data
-
-        assertThat(currentKeys.size(), is(2));
-        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
-        dataAccessLayer.updateRecordIndex(new Entry(4, new HashValue(HashingAlgorithm.SHA256, "cz"), Instant.now(), "CZ", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(5, new HashValue(HashingAlgorithm.SHA256, "tv"), Instant.now(), "TV", EntryType.user));
-        dataAccessLayer.checkpoint();
-
-        assertThat(currentKeys.size(), is(4));
-        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(4));
-    }
-
-    @Test
-    public void updateRecordIndex_shouldUpdateTotalRecords_whenKeyExistsInDatabaseAndEntryContainsNoItems() {
-        dataAccessLayer.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cz"), Instant.now(), "CZ", EntryType.user));
-        dataAccessLayer.checkpoint();
-
-        assertThat(currentKeys.size(), is(2));
-        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
-
-        dataAccessLayer.updateRecordIndex(new Entry(3, Collections.emptyList(), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.checkpoint();
-
-        assertThat(currentKeys.size(), is(2));
-        assertThat(currentKeys.containsKey("DE"), is(true));
-        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(1));
-    }
-
-    @Test
-    public void updateRecordIndex_shouldUpdateCurrentKeysAndTotalRecords_whenKeyExistsInDatabase() {
-        dataAccessLayer.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "va"), Instant.now(), "VA", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(3, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.checkpoint();
-
-        assertThat(currentKeys.size(), is(2));
-        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
-
-        dataAccessLayer.updateRecordIndex(new Entry(4, Collections.emptyList(), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.checkpoint();
-
-        assertThat(currentKeys.size(), is(2));
-        assertThat(currentKeys.containsKey("DE"), is(true));
-        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(1));
-    }
-
-    @Test
-    public void updateRecordIndex_shouldNotUpdateCurrentKeysAndTotalRecords_whenKeyExistsInStagedData() {
-        dataAccessLayer.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "va"), Instant.now(), "VA", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(3, Collections.emptyList(), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.checkpoint();
-
-        assertThat(currentKeys.size(), is(2));
-        assertThat(currentKeys.containsKey("DE"), is(true));
-        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(1));
-    }
-
-    @Test
-    public void updateRecordIndex_shouldNotUpdateCurrentKeysAndTotalRecords_whenKeyDoesNotExistInStagedDataOrDatabase() {
-        dataAccessLayer.updateRecordIndex(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "de"), Instant.now(), "DE", EntryType.user));
-        dataAccessLayer.updateRecordIndex(new Entry(2, new HashValue(HashingAlgorithm.SHA256, "va"), Instant.now(), "VA", EntryType.user));
-        dataAccessLayer.checkpoint();
-
-        assertThat(currentKeys.size(), is(2));
-        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
-
-        dataAccessLayer.updateRecordIndex(new Entry(3, Collections.emptyList(), Instant.now(), "CZ", EntryType.user));
-        dataAccessLayer.checkpoint();
-
-        assertThat(currentKeys.size(), is(3));
-        assertThat(currentKeys.containsKey("CZ"), is(true));
-        assertThat(currentKeysUpdateDAO.getTotalRecords(), is(2));
+        // ignore the result, but check that committed to DB
+        assertThat(dataAccessLayer.getTotalEntries(), is(1));
     }
 }

--- a/src/test/resources/conformance-app-config.yaml
+++ b/src/test/resources/conformance-app-config.yaml
@@ -42,3 +42,5 @@ externalConfigDirectory: /tmp
 
 downloadConfigs: true
 
+indexes:
+  - records

--- a/src/test/resources/fixtures/list.csv
+++ b/src/test/resources/fixtures/list.csv
@@ -1,3 +1,3 @@
 index-entry-number,entry-number,entry-timestamp,key,register,text,registry,phase,copyright,fields
-2,2,2016-03-02T02:03:04Z,value2,value2,"The Entry 2",,,,field1;field2
 1,1,2016-03-01T01:02:03Z,value1,value1,"The Entry 1",,,,field1
+2,2,2016-03-02T02:03:04Z,value2,value2,"The Entry 2",,,,field1;field2

--- a/src/test/resources/fixtures/list.tsv
+++ b/src/test/resources/fixtures/list.tsv
@@ -1,3 +1,3 @@
 index-entry-number	entry-number	entry-timestamp	key	register	text	registry	phase	copyright	fields
-2	2	2016-03-02T02:03:04Z	value2	value2	The Entry 2				field1;field2
 1	1	2016-03-01T01:02:03Z	value1	value1	The Entry 1				field1
+2	2	2016-03-02T02:03:04Z	value2	value2	The Entry 2				field1;field2

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -30,6 +30,9 @@ credentials:
   user: foo
   password: bar
 
+indexes:
+  - records
+
 jerseyClient:
   timeout: 3000ms
 
@@ -43,16 +46,22 @@ registers:
     credentials:
       user: pat
       password: goggins
+    indexes:
+      - records
   register:
     schema: register
     credentials:
       user: sasine
       password: inhibition
+    indexes:
+      - records
   local-authority-eng:
     schema: local-authority-eng
     credentials:
       user: bar
       password: baz
+    indexes:
+      - records
 
 enableDownloadResource: true
 


### PR DESCRIPTION
This PR removes the usage of the `current_keys` table from DAO objects and instead uses indexes to store and retrieve the records of a register.

Joint venture with @samcrang 