### PR TITLE
Exclude system entries from particular index functions

### DIFF
--- a/src/main/java/uk/gov/register/indexer/function/CurrentCountriesIndexFunction.java
+++ b/src/main/java/uk/gov/register/indexer/function/CurrentCountriesIndexFunction.java
@@ -15,6 +15,10 @@ public class CurrentCountriesIndexFunction extends BaseIndexFunction {
 
     @Override
     protected void execute(Register register, EntryType type, String key, HashValue itemHash, Set<IndexKeyItemPair> result) {
+        if (type == EntryType.system) {
+            return;
+        }
+        
         register.getItemBySha256(itemHash).ifPresent(i -> {
             if (!i.getValue("end-date").isPresent()) {
                 result.add(new IndexKeyItemPair(key, i.getSha256hex()));

--- a/src/main/java/uk/gov/register/indexer/function/LocalAuthorityByTypeIndexFunction.java
+++ b/src/main/java/uk/gov/register/indexer/function/LocalAuthorityByTypeIndexFunction.java
@@ -15,6 +15,10 @@ public class LocalAuthorityByTypeIndexFunction extends BaseIndexFunction {
 
     @Override
     protected void execute(Register register, EntryType type, String key, HashValue itemHash, Set<IndexKeyItemPair> result) {
+        if (type == EntryType.system) {
+            return;
+        }
+        
         register.getItemBySha256(itemHash).ifPresent(i -> {
             if (i.getValue("local-authority-type").isPresent()) {
                 result.add(new IndexKeyItemPair(i.getValue("local-authority-type").get(), i.getSha256hex()));


### PR DESCRIPTION
With the addition of the new entry type property, we now need to ensure that we only run index functions on the appropriate type of data. For example, we should only run the `current-countries` index function when loading country data into a register, and similarly only run the `metadata` index function when loading system entries into a register.

If we do not check the entry type of incoming entries, we may incorrectly index system entries using any index functions available to the current register.