### PR TITLE
Validate metadata against environment

### DIFF
--- a/school-data.rsf
+++ b/school-data.rsf
@@ -1,6 +1,6 @@
 assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-add-item	{"register-name":"school"}
-append-entry	system	field:register-name	2017-06-21T15:49:20Z	sha-256:f16b0342a7d6946f5cfa367680a74b268fddf0174d3423ea7a648205fa73b1d5
+add-item	{"name":"school"}
+append-entry	system	name	2017-06-21T15:49:20Z	sha-256:19b8af613df4dd09fec78e1453b56185e8617c8ae431166043eb7a8d688ee5d0
 add-item	{"cardinality":"1","datatype":"string","field":"school","phase":"alpha","register":"school","text":"A school in the UK."}
 append-entry	system	field:school	2017-06-21T15:49:20Z	sha-256:cb945c34ab916fa447a0943e05590cd81e974fafc7ce6b0f570ab9bf87437f39
 add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","text":"Name of field"}

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -34,6 +34,7 @@ import uk.gov.register.serialization.handlers.AssertRootHashCommandHandler;
 import uk.gov.register.serialization.mappers.EntryToCommandMapper;
 import uk.gov.register.serialization.mappers.ItemToCommandMapper;
 import uk.gov.register.serialization.mappers.RootHashCommandMapper;
+import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.ItemConverter;
 import uk.gov.register.service.RegisterLinkService;
 import uk.gov.register.service.RegisterSerialisationFormatService;
@@ -90,11 +91,13 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         ConfigManager configManager = new ConfigManager(configuration);
         configManager.refreshConfig();
 
+        EnvironmentValidator environmentValidator = new EnvironmentValidator(configManager);
+
         DatabaseManager databaseManager = new DatabaseManager(configuration, environment, dbiFactory);
 
         RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
 
-        AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(configManager, databaseManager, registerLinkService, configuration);
+        AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(configManager, databaseManager, registerLinkService, environmentValidator, configuration);
         allTheRegisters.stream().parallel().forEach(RegisterContext::migrate);
 
         RSFExecutor rsfExecutor = new RSFExecutor();
@@ -123,6 +126,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bindAsContract(RegisterFieldsConfiguration.class);
 
                 bind(configManager).to(ConfigManager.class);
+                bind(environmentValidator).to(EnvironmentValidator.class);
                 bind(registerLinkService).to(RegisterLinkService.class);
                 bind(new PublicBodiesConfiguration(Optional.ofNullable(System.getProperty("publicBodiesYaml")))).to(PublicBodiesConfiguration.class);
 

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -98,7 +98,10 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
 
         AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(configManager, databaseManager, registerLinkService, environmentValidator, configuration);
-        allTheRegisters.stream().parallel().forEach(RegisterContext::migrate);
+        allTheRegisters.stream().parallel().forEach(registerContext -> {
+            registerContext.migrate();
+            environmentValidator.validateExistingMetadataAgainstEnvironment(registerContext);
+        });
 
         RSFExecutor rsfExecutor = new RSFExecutor();
         rsfExecutor.register(new AddItemCommandHandler());

--- a/src/main/java/uk/gov/register/configuration/FieldsConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/FieldsConfiguration.java
@@ -19,8 +19,8 @@ public class FieldsConfiguration {
         fields = fieldConfigRecords.stream().map(FieldConfigRecord::getSingleItem).collect(toList());
     }
 
-    public Field getField(String fieldName) {
-        return fields.stream().filter(f -> Objects.equals(f.fieldName, fieldName)).findFirst().get();
+    public Optional<Field> getField(String fieldName) {
+        return fields.stream().filter(f -> Objects.equals(f.fieldName, fieldName)).findFirst();
     }
 
     public Collection<Field> getAllFields() {

--- a/src/main/java/uk/gov/register/core/AllTheRegistersFactory.java
+++ b/src/main/java/uk/gov/register/core/AllTheRegistersFactory.java
@@ -3,6 +3,7 @@ package uk.gov.register.core;
 import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.configuration.DatabaseManager;
 import uk.gov.register.configuration.RegisterConfigConfiguration;
+import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.RegisterLinkService;
 
 import java.util.Map;
@@ -20,16 +21,22 @@ public class AllTheRegistersFactory {
         this.defaultRegisterName = defaultRegisterName;
     }
 
-    public AllTheRegisters build(ConfigManager configManager, DatabaseManager databaseManager, RegisterLinkService registerLinkService, RegisterConfigConfiguration registerConfigConfiguration) {
+    public AllTheRegisters build(ConfigManager configManager, DatabaseManager databaseManager, RegisterLinkService registerLinkService, EnvironmentValidator environmentValidator, RegisterConfigConfiguration registerConfigConfiguration) {
         Map<RegisterName, RegisterContext> builtRegisters = otherRegisters.entrySet().stream().collect(toMap(Map.Entry::getKey,
-                e -> buildRegister(e.getKey(), e.getValue(), configManager, databaseManager, registerLinkService, registerConfigConfiguration)));
+                e -> buildRegister(e.getKey(), e.getValue(), configManager, databaseManager, environmentValidator, registerLinkService, registerConfigConfiguration)));
         return new AllTheRegisters(
-                defaultRegisterFactory.build(defaultRegisterName, configManager, databaseManager, registerLinkService, registerConfigConfiguration),
+                defaultRegisterFactory.build(defaultRegisterName, configManager, databaseManager, environmentValidator, registerLinkService, registerConfigConfiguration),
                 builtRegisters
         );
     }
 
-    private RegisterContext buildRegister(RegisterName registerName, RegisterContextFactory registerFactory, ConfigManager configManager, DatabaseManager databaseManager, RegisterLinkService registerLinkService, RegisterConfigConfiguration registerConfigConfiguration) {
-        return registerFactory.build(registerName, configManager, databaseManager, registerLinkService, registerConfigConfiguration);
+    private RegisterContext buildRegister(RegisterName registerName, 
+          RegisterContextFactory registerFactory, 
+          ConfigManager configManager, 
+          DatabaseManager databaseManager, 
+          EnvironmentValidator environmentValidator, 
+          RegisterLinkService registerLinkService, 
+          RegisterConfigConfiguration registerConfigConfiguration) {
+        return registerFactory.build(registerName, configManager, databaseManager, environmentValidator, registerLinkService, registerConfigConfiguration);
     }
 }

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -101,7 +101,8 @@ public class RegisterContext implements
                 new DerivationRecordIndex(dataAccessLayer),
                 getIndexFunctions(),
                 new IndexDriver(dataAccessLayer),
-                itemValidator);
+                itemValidator,
+                configManager);
     }
 
     private Register buildTransactionalRegister(Handle handle, DataAccessLayer dataAccessLayer, TransactionalMemoizationStore memoizationStore) {
@@ -112,7 +113,8 @@ public class RegisterContext implements
                 new DerivationRecordIndex(dataAccessLayer),
                 getIndexFunctions(),
                 new IndexDriver(dataAccessLayer),
-                itemValidator);
+                itemValidator,
+                configManager);
     }
 
     public void transactionalRegisterOperation(Consumer<Register> consumer) {

--- a/src/main/java/uk/gov/register/core/RegisterContextFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterContextFactory.java
@@ -8,12 +8,12 @@ import uk.gov.register.auth.RegisterAuthenticatorFactory;
 import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.configuration.DatabaseManager;
 import uk.gov.register.configuration.RegisterConfigConfiguration;
+import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.RegisterLinkService;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -91,10 +91,12 @@ public class RegisterContextFactory {
     }
 
     public RegisterContext build(RegisterName registerName, ConfigManager configManager, DatabaseManager databaseManager,
-                                 RegisterLinkService registerLinkService, RegisterConfigConfiguration registerConfigConfiguration) {
+                                 EnvironmentValidator environmentValidator, RegisterLinkService registerLinkService, 
+                                 RegisterConfigConfiguration registerConfigConfiguration) {
         return new RegisterContext(
                 registerName,
                 configManager,
+                environmentValidator,
                 registerLinkService,
                 databaseManager.getDbi(),
                 getFlywayFactory(registerName, custodianName, registerConfigConfiguration).build(databaseManager.getDataSource()),

--- a/src/main/java/uk/gov/register/exceptions/FieldValidationException.java
+++ b/src/main/java/uk/gov/register/exceptions/FieldValidationException.java
@@ -1,0 +1,7 @@
+package uk.gov.register.exceptions;
+
+public class FieldValidationException extends RuntimeException {
+	public FieldValidationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/uk/gov/register/exceptions/RegisterValidationException.java
+++ b/src/main/java/uk/gov/register/exceptions/RegisterValidationException.java
@@ -1,0 +1,9 @@
+package uk.gov.register.exceptions;
+
+import uk.gov.register.core.RegisterName;
+
+public class RegisterValidationException extends RuntimeException {
+	public RegisterValidationException(RegisterName registerName) {
+		super("Definition of register " + registerName.value() + " does not match Register Register");
+	}
+}

--- a/src/main/java/uk/gov/register/service/EnvironmentValidator.java
+++ b/src/main/java/uk/gov/register/service/EnvironmentValidator.java
@@ -2,10 +2,13 @@ package uk.gov.register.service;
 
 import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.core.Field;
+import uk.gov.register.core.Register;
+import uk.gov.register.core.RegisterContext;
 import uk.gov.register.core.RegisterMetadata;
 import uk.gov.register.exceptions.FieldValidationException;
 import uk.gov.register.exceptions.RegisterValidationException;
 import uk.gov.register.util.FieldComparer;
+import uk.gov.register.configuration.IndexFunctionConfiguration.IndexNames;
 
 import java.util.List;
 
@@ -34,5 +37,17 @@ public class EnvironmentValidator {
         if (!FieldComparer.equals(localField, environmentField)) {
             throw new FieldValidationException("Definition of field " + localField.fieldName + " does not match Field Register");
         }
+    }
+    
+    public void validateExistingMetadataAgainstEnvironment(RegisterContext registerContext) {
+        Register register = registerContext.buildOnDemandRegister();
+
+        if (register.getTotalDerivationRecords(IndexNames.METADATA) == 0) {
+            return;
+        }
+        
+        RegisterMetadata localRegisterMetadata = register.getRegisterMetadata();
+        register.getFieldsByName().values().forEach(f -> validateFieldAgainstEnvironment(f));
+        validateRegisterAgainstEnvironment(localRegisterMetadata);
     }
 }

--- a/src/main/java/uk/gov/register/service/EnvironmentValidator.java
+++ b/src/main/java/uk/gov/register/service/EnvironmentValidator.java
@@ -1,0 +1,38 @@
+package uk.gov.register.service;
+
+import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.exceptions.FieldValidationException;
+import uk.gov.register.exceptions.RegisterValidationException;
+import uk.gov.register.util.FieldComparer;
+
+import java.util.List;
+
+public class EnvironmentValidator {
+
+    private final ConfigManager configManager;
+
+    public EnvironmentValidator(ConfigManager configManager) {
+        this.configManager = configManager;
+    }
+
+    public void validateRegisterAgainstEnvironment(RegisterMetadata registerMetadata) {
+        RegisterMetadata environmentRegisterMetadata = configManager.getRegistersConfiguration().getRegisterMetadata(registerMetadata.getRegisterName());
+        List<String> environmentRegisterFields = environmentRegisterMetadata.getFields();
+        List<String> localRegisterFields = registerMetadata.getFields();
+
+        if (environmentRegisterFields.size() != localRegisterFields.size() || !environmentRegisterFields.containsAll(localRegisterFields)) {
+            throw new RegisterValidationException(registerMetadata.getRegisterName());
+        }
+    }
+    
+    public void validateFieldAgainstEnvironment(Field localField) {
+        Field environmentField = configManager.getFieldsConfiguration().getField(localField.fieldName)
+                .orElseThrow(() -> new FieldValidationException("Field " + localField.fieldName + " does not exist in Field Register"));
+
+        if (!FieldComparer.equals(localField, environmentField)) {
+            throw new FieldValidationException("Definition of field " + localField.fieldName + " does not match Field Register");
+        }
+    }
+}

--- a/src/main/java/uk/gov/register/service/RegisterSerialisationFormatService.java
+++ b/src/main/java/uk/gov/register/service/RegisterSerialisationFormatService.java
@@ -2,21 +2,15 @@ package uk.gov.register.service;
 
 import uk.gov.register.core.Register;
 import uk.gov.register.core.RegisterContext;
-import uk.gov.register.serialization.RSFCreator;
-import uk.gov.register.serialization.RSFExecutor;
-import uk.gov.register.serialization.RSFFormatter;
-import uk.gov.register.serialization.RegisterCommand;
-import uk.gov.register.serialization.RegisterResult;
-import uk.gov.register.serialization.RegisterSerialisationFormat;
+import uk.gov.register.serialization.*;
 
+import javax.inject.Inject;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.Iterator;
 import java.util.function.Function;
-
-import javax.inject.Inject;
 
 public class RegisterSerialisationFormatService {
     private final RegisterContext registerContext;

--- a/src/main/java/uk/gov/register/util/FieldComparer.java
+++ b/src/main/java/uk/gov/register/util/FieldComparer.java
@@ -1,0 +1,13 @@
+package uk.gov.register.util;
+
+import uk.gov.register.core.Field;
+
+public class FieldComparer {
+
+    public static boolean equals(Field field1, Field field2) {
+        return field1.getCardinality().equals(field2.getCardinality())
+                && field1.getDatatype().equals(field2.getDatatype())
+                && field1.fieldName.equals(field2.fieldName)
+                && field1.getRegister().equals(field2.getRegister());
+    }
+}

--- a/src/main/resources/config/fields.yaml
+++ b/src/main/resources/config/fields.yaml
@@ -482,7 +482,7 @@ registry:
   - text: "Body responsible for maintaining one or more registers"
     field: "registry"
     phase: "alpha"
-    datatype: "curie"
+    datatype: "string"
     register: "public-body"
     cardinality: "1"
 website:

--- a/src/test/java/uk/gov/register/configuration/FieldsConfigurationTest.java
+++ b/src/test/java/uk/gov/register/configuration/FieldsConfigurationTest.java
@@ -4,7 +4,6 @@ import io.dropwizard.testing.ResourceHelpers;
 import org.junit.Test;
 
 import java.net.URISyntaxException;
-import java.util.Optional;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -14,7 +13,7 @@ public class FieldsConfigurationTest {
     public void loadConfigurationWithDefaultFieldsResourceFile() {
         FieldsConfiguration fieldsConfiguration = new FieldsConfiguration("src/main/resources/config/fields.yaml");
 
-        assertThat(fieldsConfiguration.getField("register").fieldName, equalTo("register"));
+        assertThat(fieldsConfiguration.getField("register").get().fieldName, equalTo("register"));
     }
 
     @Test
@@ -24,6 +23,6 @@ public class FieldsConfigurationTest {
 
         FieldsConfiguration fieldsConfiguration = new FieldsConfiguration(fileUrl);
 
-        assertThat(fieldsConfiguration.getField("register").fieldName, equalTo("register"));
+        assertThat(fieldsConfiguration.getField("register").get().fieldName, equalTo("register"));
     }
 }

--- a/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
+++ b/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.configuration.IndexFunctionConfiguration.IndexNames;
 import uk.gov.register.db.DerivationRecordIndex;
 import uk.gov.register.db.InMemoryEntryDAO;
@@ -52,6 +53,9 @@ public class PostgresRegisterTest {
     private Record fieldRecord;
     @Mock
     private Record registerRecord;
+    @Mock
+    private ConfigManager configManager;
+
 
     private PostgresRegister register;
 
@@ -61,7 +65,7 @@ public class PostgresRegisterTest {
     public void setup() throws IOException {
         register = new PostgresRegister(new RegisterName("postcode"),
                 inMemoryEntryLog(entryDAO, entryDAO), inMemoryItemStore(itemValidator, entryDAO), recordIndex,
-                derivationRecordIndex, Arrays.asList(indexFunction), indexDriver, itemValidator);
+                derivationRecordIndex, Arrays.asList(indexFunction), indexDriver, itemValidator, configManager);
 
         when(registerRecord.getItems()).thenReturn(Arrays.asList(getItem(postcodeRegisterItem)));
 

--- a/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
+++ b/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
@@ -72,7 +72,7 @@ public class PostgresRegisterTest {
         when(fieldRecord.getItems()).thenReturn(Arrays.asList(getItem("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"register\":\"postcode\",\"text\":\"field description\"}")));
 
         when(derivationRecordIndex.getRecord("register:postcode", IndexNames.METADATA)).thenReturn(Optional.of(registerRecord));
-        //when(derivationRecordIndex.getRecord("field:postcode", IndexNames.METADATA)).thenReturn(Optional.of(fieldRecord));
+        when(derivationRecordIndex.getRecord("field:postcode", IndexNames.METADATA)).thenReturn(Optional.of(fieldRecord));
     }
 
     @Test(expected = NoSuchFieldException.class)

--- a/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
+++ b/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.configuration.IndexFunctionConfiguration.IndexNames;
 import uk.gov.register.db.DerivationRecordIndex;
 import uk.gov.register.db.InMemoryEntryDAO;
@@ -17,6 +16,7 @@ import uk.gov.register.exceptions.NoSuchFieldException;
 import uk.gov.register.exceptions.SerializationFormatValidationException;
 import uk.gov.register.indexer.IndexDriver;
 import uk.gov.register.indexer.function.IndexFunction;
+import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.ItemValidator;
 import uk.gov.register.util.HashValue;
 
@@ -54,7 +54,7 @@ public class PostgresRegisterTest {
     @Mock
     private Record registerRecord;
     @Mock
-    private ConfigManager configManager;
+    private EnvironmentValidator environmentValidator;
 
 
     private PostgresRegister register;
@@ -65,7 +65,7 @@ public class PostgresRegisterTest {
     public void setup() throws IOException {
         register = new PostgresRegister(new RegisterName("postcode"),
                 inMemoryEntryLog(entryDAO, entryDAO), inMemoryItemStore(itemValidator, entryDAO), recordIndex,
-                derivationRecordIndex, Arrays.asList(indexFunction), indexDriver, itemValidator, configManager);
+                derivationRecordIndex, Arrays.asList(indexFunction), indexDriver, itemValidator, environmentValidator);
 
         when(registerRecord.getItems()).thenReturn(Arrays.asList(getItem(postcodeRegisterItem)));
 

--- a/src/test/java/uk/gov/register/core/RegisterContextTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterContextTest.java
@@ -8,6 +8,7 @@ import uk.gov.register.auth.RegisterAuthenticator;
 import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.exceptions.NoSuchConfigException;
+import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.RegisterLinkService;
 
 import java.io.IOException;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.*;
 public class RegisterContextTest {
     private RegisterName registerName;
     private ConfigManager configManager;
+    private EnvironmentValidator environmentValidator;
     private RegisterLinkService registerLinkService;
     private DBI dbi;
     private Flyway flyway;
@@ -32,6 +34,7 @@ public class RegisterContextTest {
         registerName = new RegisterName("register");
         schema = "register";
         configManager = mock(ConfigManager.class, RETURNS_DEEP_STUBS);
+        environmentValidator = mock(EnvironmentValidator.class);
         registerLinkService = mock(RegisterLinkService.class);
         dbi = mock(DBI.class);
         flyway = mock(Flyway.class);
@@ -39,7 +42,7 @@ public class RegisterContextTest {
 
     @Test
     public void resetRegister_shouldNotResetRegister_whenEnableRegisterDataDeleteIsDisabled() throws IOException, NoSuchConfigException {
-        RegisterContext context = new RegisterContext(registerName, configManager, registerLinkService, dbi, flyway, schema, Optional.empty(), false, false, Optional.empty(), emptyList(), emptyList(), new RegisterAuthenticator("", ""));
+        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, Optional.empty(), false, false, Optional.empty(), emptyList(), emptyList(), new RegisterAuthenticator("", ""));
         context.resetRegister();
 
         verify(flyway, never()).clean();
@@ -49,7 +52,7 @@ public class RegisterContextTest {
 
     @Test
     public void resetRegister_shouldResetRegister_whenEnableRegisterDataDeleteIsEnabled() throws IOException, NoSuchConfigException {
-        RegisterContext context = new RegisterContext(registerName, configManager, registerLinkService, dbi, flyway, schema, Optional.empty(), true, false, Optional.empty(), emptyList(), emptyList(), new RegisterAuthenticator("", ""));
+        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, Optional.empty(), true, false, Optional.empty(), emptyList(), emptyList(), new RegisterAuthenticator("", ""));
         context.resetRegister();
 
         verify(flyway, times(1)).clean();
@@ -82,7 +85,7 @@ public class RegisterContextTest {
                 .thenReturn(expectedInitialMetadata)
                 .thenReturn(expectedUpdatedMetadata);
 
-        RegisterContext context = new RegisterContext(registerName, configManager, registerLinkService, dbi, flyway, schema, Optional.empty(), true, false, Optional.empty(), emptyList(), emptyList(), new RegisterAuthenticator("", ""));
+        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, Optional.empty(), true, false, Optional.empty(), emptyList(), emptyList(), new RegisterAuthenticator("", ""));
 
         RegisterMetadata actualInitialMetadata = context.getRegisterMetadata();
         assertThat(actualInitialMetadata, equalTo(expectedInitialMetadata));

--- a/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
@@ -71,7 +71,7 @@ public class DataDownloadFunctionalTest {
         // TODO: Revisit this later to determine if item count should be 17 (metadata included) or 4 (without metadata)
         assertThat(zipEntryNames, hasItem("register.json"));
         assertThat(zipEntryNames.stream().filter(e -> e.matches("(entry/)(\\d+)(.json)")).count(), is(5L));
-        assertThat(zipEntryNames.stream().filter(e -> e.matches("(item/)(\\w+)(.json)")).count(), is(17L));
+        assertThat(zipEntryNames.stream().filter(e -> e.matches("(item/)(\\w+)(.json)")).count(), is(18L));
     }
 
     @Test
@@ -120,7 +120,7 @@ public class DataDownloadFunctionalTest {
 
         assertThat(rsfLines.get(0), equalTo("assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
         assertThat(rsfLines.contains("add-item\t{\"custodian\":\"John Smith\"}"), is(true));
-        assertThat(rsfLines.get(27), equalTo("append-entry\tsystem\tcustodian\t2017-06-01T10:00:00Z\tsha-256:7652aabbc817e434b1b6aedffe58582412c79be9d2ebcb12071d3f7fe7fe96d8"));
+        assertThat(rsfLines.get(29), equalTo("append-entry\tsystem\tcustodian\t2017-06-01T10:00:00Z\tsha-256:7652aabbc817e434b1b6aedffe58582412c79be9d2ebcb12071d3f7fe7fe96d8"));
     }
 
     @Test
@@ -131,7 +131,7 @@ public class DataDownloadFunctionalTest {
 
         assertThat(rsfLines.get(0), equalTo("assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
         assertThat(rsfLines.contains("add-item\t{\"register-name\":\"address\"}"), is(true));
-        assertThat(rsfLines.get(15), equalTo("append-entry\tsystem\tregister-name\t2017-06-01T10:00:00Z\tsha-256:50e3d51c16e203c0124e8bf3a8807abc7693f0d01cb0569499c608f98d2924e9"));
+        assertThat(rsfLines.get(16), equalTo("append-entry\tsystem\tregister-name\t2017-06-01T10:00:00Z\tsha-256:50e3d51c16e203c0124e8bf3a8807abc7693f0d01cb0569499c608f98d2924e9"));
     }
 
     @Test
@@ -152,13 +152,13 @@ public class DataDownloadFunctionalTest {
                 "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}",
                 "add-item\t{\"address\":\"12345\",\"street\":\"foo\"}"));
 
-        assertFormattedEntry(rsfLines.get(31), EntryType.user, "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
-        assertFormattedEntry(rsfLines.get(32), EntryType.user, "6789","sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934");
-        assertFormattedEntry(rsfLines.get(33), EntryType.user, "12345","sha-256:cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
-        assertFormattedEntry(rsfLines.get(34), EntryType.user, "145678","sha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983");
-        assertFormattedEntry(rsfLines.get(35), EntryType.user, "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
+        assertFormattedEntry(rsfLines.get(33), EntryType.user, "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
+        assertFormattedEntry(rsfLines.get(34), EntryType.user, "6789","sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934");
+        assertFormattedEntry(rsfLines.get(35), EntryType.user, "12345","sha-256:cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
+        assertFormattedEntry(rsfLines.get(36), EntryType.user, "145678","sha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983");
+        assertFormattedEntry(rsfLines.get(37), EntryType.user, "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
 
-        assertThat(rsfLines.get(36), containsString("assert-root-hash\t"));
+        assertThat(rsfLines.get(38), containsString("assert-root-hash\t"));
     }
 
     @Test
@@ -272,9 +272,9 @@ public class DataDownloadFunctionalTest {
         List<String> partialRsfLines = getRsfLinesFrom(partialRsfResponse);
 
         assertThat(partialRsfLines.get(0), is(fullRsfLines.get(0)));
-        assertThat(partialRsfLines.subList(1, 18).containsAll(fullRsfLines.subList(1, 18)), is(true));
-        assertThat(partialRsfLines.subList(18, 36), equalTo(fullRsfLines.subList(18, 36)));
-        assertThat(partialRsfLines.get(36), is(fullRsfLines.get(36)));
+        assertThat(partialRsfLines.subList(1, 20).containsAll(fullRsfLines.subList(1, 20)), is(true));
+        assertThat(partialRsfLines.subList(20, 38), equalTo(fullRsfLines.subList(20, 38)));
+        assertThat(partialRsfLines.get(38), is(fullRsfLines.get(38)));
     }
 
     @Test
@@ -286,9 +286,9 @@ public class DataDownloadFunctionalTest {
         List<String> partialRsfLines = getRsfLinesFrom(partialRsfResponse);
 
         assertThat(partialRsfLines.get(0), is(fullRsfLines.get(0)));
-        assertThat(partialRsfLines.subList(1, 18).containsAll(fullRsfLines.subList(1, 18)), is(true));
-        assertThat(partialRsfLines.subList(18, 36), equalTo(fullRsfLines.subList(18, 36)));
-        assertThat(partialRsfLines.get(36), is(fullRsfLines.get(36)));
+        assertThat(partialRsfLines.subList(1, 20).containsAll(fullRsfLines.subList(1, 20)), is(true));
+        assertThat(partialRsfLines.subList(20, 38), equalTo(fullRsfLines.subList(20, 38)));
+        assertThat(partialRsfLines.get(38), is(fullRsfLines.get(38)));
     }
 
     private List<String> getRsfLinesFrom(Response response) {

--- a/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
@@ -71,7 +71,7 @@ public class DataDownloadFunctionalTest {
         // TODO: Revisit this later to determine if item count should be 17 (metadata included) or 4 (without metadata)
         assertThat(zipEntryNames, hasItem("register.json"));
         assertThat(zipEntryNames.stream().filter(e -> e.matches("(entry/)(\\d+)(.json)")).count(), is(5L));
-        assertThat(zipEntryNames.stream().filter(e -> e.matches("(item/)(\\w+)(.json)")).count(), is(18L));
+        assertThat(zipEntryNames.stream().filter(e -> e.matches("(item/)(\\w+)(.json)")).count(), is(17L));
     }
 
     @Test
@@ -120,7 +120,7 @@ public class DataDownloadFunctionalTest {
 
         assertThat(rsfLines.get(0), equalTo("assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
         assertThat(rsfLines.contains("add-item\t{\"custodian\":\"John Smith\"}"), is(true));
-        assertThat(rsfLines.get(29), equalTo("append-entry\tsystem\tcustodian\t2017-06-01T10:00:00Z\tsha-256:7652aabbc817e434b1b6aedffe58582412c79be9d2ebcb12071d3f7fe7fe96d8"));
+        assertThat(rsfLines.get(27), equalTo("append-entry\tsystem\tcustodian\t2017-06-01T10:00:00Z\tsha-256:7652aabbc817e434b1b6aedffe58582412c79be9d2ebcb12071d3f7fe7fe96d8"));
     }
 
     @Test
@@ -131,7 +131,7 @@ public class DataDownloadFunctionalTest {
 
         assertThat(rsfLines.get(0), equalTo("assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
         assertThat(rsfLines.contains("add-item\t{\"register-name\":\"address\"}"), is(true));
-        assertThat(rsfLines.get(16), equalTo("append-entry\tsystem\tregister-name\t2017-06-01T10:00:00Z\tsha-256:50e3d51c16e203c0124e8bf3a8807abc7693f0d01cb0569499c608f98d2924e9"));
+        assertThat(rsfLines.get(15), equalTo("append-entry\tsystem\tregister-name\t2017-06-01T10:00:00Z\tsha-256:50e3d51c16e203c0124e8bf3a8807abc7693f0d01cb0569499c608f98d2924e9"));
     }
 
     @Test
@@ -152,13 +152,13 @@ public class DataDownloadFunctionalTest {
                 "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}",
                 "add-item\t{\"address\":\"12345\",\"street\":\"foo\"}"));
 
-        assertFormattedEntry(rsfLines.get(33), EntryType.user, "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
-        assertFormattedEntry(rsfLines.get(34), EntryType.user, "6789","sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934");
-        assertFormattedEntry(rsfLines.get(35), EntryType.user, "12345","sha-256:cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
-        assertFormattedEntry(rsfLines.get(36), EntryType.user, "145678","sha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983");
-        assertFormattedEntry(rsfLines.get(37), EntryType.user, "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
+        assertFormattedEntry(rsfLines.get(31), EntryType.user, "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
+        assertFormattedEntry(rsfLines.get(32), EntryType.user, "6789","sha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934");
+        assertFormattedEntry(rsfLines.get(33), EntryType.user, "12345","sha-256:cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
+        assertFormattedEntry(rsfLines.get(34), EntryType.user, "145678","sha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983");
+        assertFormattedEntry(rsfLines.get(35), EntryType.user, "12345","sha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9");
 
-        assertThat(rsfLines.get(38), containsString("assert-root-hash\t"));
+        assertThat(rsfLines.get(36), containsString("assert-root-hash\t"));
     }
 
     @Test
@@ -273,8 +273,8 @@ public class DataDownloadFunctionalTest {
 
         assertThat(partialRsfLines.get(0), is(fullRsfLines.get(0)));
         assertThat(partialRsfLines.subList(1, 20).containsAll(fullRsfLines.subList(1, 20)), is(true));
-        assertThat(partialRsfLines.subList(20, 38), equalTo(fullRsfLines.subList(20, 38)));
-        assertThat(partialRsfLines.get(38), is(fullRsfLines.get(38)));
+        assertThat(partialRsfLines.subList(20, 36), equalTo(fullRsfLines.subList(20, 36)));
+        assertThat(partialRsfLines.get(36), is(fullRsfLines.get(36)));
     }
 
     @Test
@@ -287,8 +287,8 @@ public class DataDownloadFunctionalTest {
 
         assertThat(partialRsfLines.get(0), is(fullRsfLines.get(0)));
         assertThat(partialRsfLines.subList(1, 20).containsAll(fullRsfLines.subList(1, 20)), is(true));
-        assertThat(partialRsfLines.subList(20, 38), equalTo(fullRsfLines.subList(20, 38)));
-        assertThat(partialRsfLines.get(38), is(fullRsfLines.get(38)));
+        assertThat(partialRsfLines.subList(20, 36), equalTo(fullRsfLines.subList(20, 36)));
+        assertThat(partialRsfLines.get(36), is(fullRsfLines.get(36)));
     }
 
     private List<String> getRsfLinesFrom(Response response) {

--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataAvailabilityFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataAvailabilityFunctionalTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.RsfRegisterDefinition;
 import uk.gov.register.functional.app.TestRegister;
 
 import javax.ws.rs.core.Response;
@@ -30,12 +31,7 @@ public class DeleteRegisterDataAvailabilityFunctionalTest {
     
     @Before
     public void setup() {
-        register.loadRsf(address, 
-            "assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n" +
-            "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"address\",\"phase\":\"beta\",\"text\":\"An address in the UK.\"}\n" +
-            "append-entry\tsystem\tfield:address\t2016-04-05T13:23:05Z\tsha-256:fc62aba14a2fac9d9653217e7c98cd099051833161b10d19de5cca4adf043379\n" +
-            "add-item\t{\"fields\":[\"address\"],\"phase\":\"beta\",\"register\":\"address\",\"registry\":\"gds\",\"text\":\"Register of addresses.\"}\n" +
-            "append-entry\tsystem\tregister:address\t2016-04-05T13:23:05Z\tsha-256:6cfccf53ba6d1f80cf8ccc615b01367b1e2714431230231d51e6342c4b916fda");
+        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
     }
 
     private final Boolean isAuthenticated;

--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
@@ -23,7 +23,7 @@ public class DeleteRegisterDataFunctionalTest {
 
     @Test
     public void deleteRegisterData_deletesAllDataFromDb() throws Exception {
-        register.loadRsf(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
+        Response r = register.loadRsf(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
 
         String item1 = "{\"postcode\":\"P1\"}";
         String item2 = "{\"postcode\":\"P2\"}";

--- a/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
@@ -61,8 +61,8 @@ public class LoadSerializedFunctionalTest {
                 new HashValue(HashingAlgorithm.SHA256, "ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f"),
                 nodeOf("{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"text\",\"phase\":\"alpha\",\"text\":\"Description of register entry.\"}"));
         TestDBItem expectedItem3 = new TestDBItem(
-                new HashValue(HashingAlgorithm.SHA256, "4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2"),
-                nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"registry\",\"phase\":\"alpha\",\"text\":\"Body responsible for maintaining one or more registers\"}"));
+                new HashValue(HashingAlgorithm.SHA256, "8d720e24af4cf63a43b0f9ccd759ed7f36b16617c776124e00faf6ccd30bcc45"),
+                nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"registry\",\"phase\":\"alpha\",\"register\":\"public-body\",\"text\":\"Body responsible for maintaining one or more registers\"}"));
         TestDBItem expectedItem4 = new TestDBItem(
                 new HashValue(HashingAlgorithm.SHA256, "1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4"),
                 nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"phase\",\"phase\":\"alpha\",\"text\":\"Phase of a register or service as defined by the [digital service manual](https://www.gov.uk/service-manual).\"}"));
@@ -73,8 +73,8 @@ public class LoadSerializedFunctionalTest {
                 new HashValue(HashingAlgorithm.SHA256, "61138002a7ae8a53f3ad16bb91ee41fe73cc7ab7c8b24a8afd2569eb0e6a1c26"),
                 nodeOf("{\"cardinality\":\"n\",\"datatype\":\"string\",\"field\":\"fields\",\"phase\":\"alpha\",\"register\":\"field\",\"text\":\"Set of field names.\"}"));
         TestDBItem expectedItem7 = new TestDBItem(
-                new HashValue(HashingAlgorithm.SHA256, "2238e546c1d9e81a3715d10949dedced0311f596304fbf9bb48c50833f8ab025"),
-                nodeOf("{\"fields\":[\"register\",\"text\",\"registry\",\"phase\",\"copyright\",\"fields\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of registers\"}"));
+                new HashValue(HashingAlgorithm.SHA256, "f404b4739b51afeb39bba26f3bbf1aa8c6f7d25f0d54444992fc00f24587ef77"),
+                nodeOf("{\"fields\":[\"register\",\"text\",\"registry\",\"phase\",\"copyright\",\"fields\"],\"phase\":\"alpha\",\"register\":\"register\",\"registry\":\"cabinet-office\",\"text\":\"Register of registers\"}"));
         TestDBItem expectedItem8 = new TestDBItem(
                 new HashValue(HashingAlgorithm.SHA256, "3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254"),
                 nodeOf("{\"text\":\"SomeText\",\"register\":\"ft_openregister_test\"}"));
@@ -92,7 +92,7 @@ public class LoadSerializedFunctionalTest {
         assertThat(systemEntries.get(1).getEntryNumber(), is(2));
         assertThat(systemEntries.get(1).getItemHashes().get(0).getValue(), is("ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f"));
         assertThat(systemEntries.get(2).getEntryNumber(), is(3));
-        assertThat(systemEntries.get(2).getItemHashes().get(0).getValue(), is("4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2"));
+        assertThat(systemEntries.get(2).getItemHashes().get(0).getValue(), is("8d720e24af4cf63a43b0f9ccd759ed7f36b16617c776124e00faf6ccd30bcc45"));
         assertThat(systemEntries.get(3).getEntryNumber(), is(4));
         assertThat(systemEntries.get(3).getItemHashes().get(0).getValue(), is("1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4"));
         assertThat(systemEntries.get(4).getEntryNumber(), is(5));
@@ -100,7 +100,7 @@ public class LoadSerializedFunctionalTest {
         assertThat(systemEntries.get(5).getEntryNumber(), is(6));
         assertThat(systemEntries.get(5).getItemHashes().get(0).getValue(), is("61138002a7ae8a53f3ad16bb91ee41fe73cc7ab7c8b24a8afd2569eb0e6a1c26"));
         assertThat(systemEntries.get(6).getEntryNumber(), is(7));
-        assertThat(systemEntries.get(6).getItemHashes().get(0).getValue(), is("2238e546c1d9e81a3715d10949dedced0311f596304fbf9bb48c50833f8ab025"));
+        assertThat(systemEntries.get(6).getItemHashes().get(0).getValue(), is("f404b4739b51afeb39bba26f3bbf1aa8c6f7d25f0d54444992fc00f24587ef77"));
 
         List<Entry> userEntries = testEntryDAO.getAllEntries(schema);
 
@@ -184,17 +184,18 @@ public class LoadSerializedFunctionalTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenRegisterDefinitionIsMissingFields() throws Exception {
+    public void shouldReturnBadRequestWhenRegisterIsMissingFieldsDefinedInEnvironment() throws Exception {
         Response response = register.loadRsf(TestRegister.postcode,
             "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
             "append-entry\tsystem\tfield:postcode\t2017-06-09T12:59:51Z\tsha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a\n" +
             "add-item\t{\"fields\":[\"postcode\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
             "append-entry\tsystem\tregister:postcode\t2017-06-06T09:54:11Z\tsha-256:323fb3d9167d55ea8173172d756ddbc653292f8debbb13f251f7057d5cb5e450\n");
         assertThat(response.getStatus(), equalTo(400));
+        assertThat(response.readEntity(String.class), equalTo("{\"success\":false,\"message\":\"Exception when executing command: RegisterCommand{commandName='append-entry', arguments=[system, field:postcode, 2017-06-09T12:59:51Z, sha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a]}\",\"details\":\"Definition of field postcode does not match Field Register\"}"));
     }
 
     @Test
-    public void shouldThrowExceptionWhenLocalFieldDoesNotMatchEnvironmentFieldDefinition() throws Exception {
+    public void shouldReturnBadRequestWhenLocalFieldDoesNotMatchEnvironmentField() throws Exception {
         String rsf =
             "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
             "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"point\",\"phase\":\"alpha\",\"text\":\"A geographical point\"}\n" +
@@ -205,6 +206,7 @@ public class LoadSerializedFunctionalTest {
 
         Response response = register.loadRsf(TestRegister.postcode, rsf);
         assertThat(response.getStatus(), equalTo(400));
+        assertThat(response.readEntity(String.class), equalTo("{\"success\":false,\"message\":\"Exception when executing command: RegisterCommand{commandName='append-entry', arguments=[system, field:postcode, 2017-06-09T12:59:51Z, sha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a]}\",\"details\":\"Definition of field postcode does not match Field Register\"}"));
     }
 
     @After

--- a/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
@@ -58,8 +58,8 @@ public class LoadSerializedFunctionalTest {
                 new HashValue(HashingAlgorithm.SHA256, "955a84bcec7dad1a4d9b05e28ebfa21b17ac9552cc0aabbc459c73d63ab530b0"),
                 nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"register\",\"phase\":\"alpha\",\"register\":\"register\",\"text\":\"A register name.\"}"));
         TestDBItem expectedItem2 = new TestDBItem(
-                new HashValue(HashingAlgorithm.SHA256, "243a2dafca693363f99c38487a03d1a241915c47a38ad5627ad941c9e52b4c7b"),
-                nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"text\",\"phase\":\"alpha\",\"text\":\"Description of register entry.\"}"));
+                new HashValue(HashingAlgorithm.SHA256, "ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f"),
+                nodeOf("{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"text\",\"phase\":\"alpha\",\"text\":\"Description of register entry.\"}"));
         TestDBItem expectedItem3 = new TestDBItem(
                 new HashValue(HashingAlgorithm.SHA256, "4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2"),
                 nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"registry\",\"phase\":\"alpha\",\"text\":\"Body responsible for maintaining one or more registers\"}"));
@@ -67,8 +67,8 @@ public class LoadSerializedFunctionalTest {
                 new HashValue(HashingAlgorithm.SHA256, "1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4"),
                 nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"phase\",\"phase\":\"alpha\",\"text\":\"Phase of a register or service as defined by the [digital service manual](https://www.gov.uk/service-manual).\"}"));
         TestDBItem expectedItem5 = new TestDBItem(
-                new HashValue(HashingAlgorithm.SHA256, "ecbbde36c6a9808b5f116c63f9ca14773ac3fac251b53e21a1d9fd4b2dd1b35c"),
-                nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"copyright\",\"phase\":\"alpha\",\"text\":\"Copyright for the data in the register.\"}"));
+                new HashValue(HashingAlgorithm.SHA256, "c7e5a90c020f7686d9a275cb0cc164636745b10ae168a72538772692cc90d633"),
+                nodeOf("{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"copyright\",\"phase\":\"alpha\",\"text\":\"Copyright for the data in the register.\"}"));
         TestDBItem expectedItem6 = new TestDBItem(
                 new HashValue(HashingAlgorithm.SHA256, "61138002a7ae8a53f3ad16bb91ee41fe73cc7ab7c8b24a8afd2569eb0e6a1c26"),
                 nodeOf("{\"cardinality\":\"n\",\"datatype\":\"string\",\"field\":\"fields\",\"phase\":\"alpha\",\"register\":\"field\",\"text\":\"Set of field names.\"}"));
@@ -90,13 +90,13 @@ public class LoadSerializedFunctionalTest {
         assertThat(systemEntries.get(0).getEntryNumber(), is(1));
         assertThat(systemEntries.get(0).getItemHashes().get(0).getValue(), is("955a84bcec7dad1a4d9b05e28ebfa21b17ac9552cc0aabbc459c73d63ab530b0"));
         assertThat(systemEntries.get(1).getEntryNumber(), is(2));
-        assertThat(systemEntries.get(1).getItemHashes().get(0).getValue(), is("243a2dafca693363f99c38487a03d1a241915c47a38ad5627ad941c9e52b4c7b"));
+        assertThat(systemEntries.get(1).getItemHashes().get(0).getValue(), is("ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f"));
         assertThat(systemEntries.get(2).getEntryNumber(), is(3));
         assertThat(systemEntries.get(2).getItemHashes().get(0).getValue(), is("4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2"));
         assertThat(systemEntries.get(3).getEntryNumber(), is(4));
         assertThat(systemEntries.get(3).getItemHashes().get(0).getValue(), is("1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4"));
         assertThat(systemEntries.get(4).getEntryNumber(), is(5));
-        assertThat(systemEntries.get(4).getItemHashes().get(0).getValue(), is("ecbbde36c6a9808b5f116c63f9ca14773ac3fac251b53e21a1d9fd4b2dd1b35c"));
+        assertThat(systemEntries.get(4).getItemHashes().get(0).getValue(), is("c7e5a90c020f7686d9a275cb0cc164636745b10ae168a72538772692cc90d633"));
         assertThat(systemEntries.get(5).getEntryNumber(), is(6));
         assertThat(systemEntries.get(5).getItemHashes().get(0).getValue(), is("61138002a7ae8a53f3ad16bb91ee41fe73cc7ab7c8b24a8afd2569eb0e6a1c26"));
         assertThat(systemEntries.get(6).getEntryNumber(), is(7));
@@ -151,7 +151,7 @@ public class LoadSerializedFunctionalTest {
         Response r = send(input);
 
         assertThat(r.getStatus(), equalTo(400));
-        assertThat(r.readEntity(String.class), equalTo("{\"success\":false,\"message\":\"Exception when executing command: RegisterCommand{commandName='append-entry', arguments=[system, register:address, 2017-06-06T09:54:11Z, sha-256:2f90a43858c366134a070f563697e04a851c977cd27e491c02885a2f4441e190]}\",\"details\":\"Field undefined: register - address\"}"));
+        assertThat(r.readEntity(String.class), equalTo("{\"success\":false,\"message\":\"Exception when executing command: RegisterCommand{commandName='append-entry', arguments=[system, register:address, 2017-06-06T09:54:11Z, sha-256:8d824e2afa57f1a71980237341b0c75d61fdc5c32e52d91e64c6fc3c6265ae63]}\",\"details\":\"Field undefined: register - address\"}"));
     }
     
     @Test
@@ -181,6 +181,30 @@ public class LoadSerializedFunctionalTest {
         String input = new String(Files.readAllBytes(Paths.get("src/test/resources/fixtures/serialized", "register-by-registry.rsf")));
         Response r = send(input);
         assertThat(r.getStatus(), equalTo(200));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenRegisterDefinitionIsMissingFields() throws Exception {
+        Response response = register.loadRsf(TestRegister.postcode,
+            "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
+            "append-entry\tsystem\tfield:postcode\t2017-06-09T12:59:51Z\tsha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a\n" +
+            "add-item\t{\"fields\":[\"postcode\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
+            "append-entry\tsystem\tregister:postcode\t2017-06-06T09:54:11Z\tsha-256:323fb3d9167d55ea8173172d756ddbc653292f8debbb13f251f7057d5cb5e450\n");
+        assertThat(response.getStatus(), equalTo(400));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenLocalFieldDoesNotMatchEnvironmentFieldDefinition() throws Exception {
+        String rsf =
+            "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
+            "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"point\",\"phase\":\"alpha\",\"text\":\"A geographical point\"}\n" +
+            "append-entry\tsystem\tfield:postcode\t2017-06-09T12:59:51Z\tsha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a\n" +
+            "append-entry\tsystem\tfield:point\t2017-06-09T12:59:51Z\tsha-256:48d0ad5afa2502674a2253c62e5af3f9bc10f5c6fbc5d16784c9dcfbc60d066b\n" +
+            "add-item\t{\"fields\":[\"postcode\",\"point\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
+            "append-entry\tsystem\tregister:postcode\t2017-06-06T09:54:11Z\tsha-256:ee2fd6546a8362d98e3cd63d914ca55d93f15801c35fdd108b9294c4f0a1d01e\n";
+
+        Response response = register.loadRsf(TestRegister.postcode, rsf);
+        assertThat(response.getStatus(), equalTo(400));
     }
 
     @After

--- a/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
@@ -183,15 +183,26 @@ public class LoadSerializedFunctionalTest {
         assertThat(r.getStatus(), equalTo(200));
     }
 
+	@Test
+	public void shouldReturnBadRequestWhenRegisterIsMissingFieldsDefinedInEnvironment() throws Exception {
+		Response response = register.loadRsf(TestRegister.postcode,
+				"add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
+						"append-entry\tsystem\tfield:postcode\t2017-06-09T12:59:51Z\tsha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a\n" +
+						"add-item\t{\"fields\":[\"postcode\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
+						"append-entry\tsystem\tregister:postcode\t2017-06-06T09:54:11Z\tsha-256:323fb3d9167d55ea8173172d756ddbc653292f8debbb13f251f7057d5cb5e450\n");
+		assertThat(response.getStatus(), equalTo(400));
+		assertThat(response.readEntity(String.class), equalTo("{\"success\":false,\"message\":\"Exception when executing command: RegisterCommand{commandName='append-entry', arguments=[system, field:postcode, 2017-06-09T12:59:51Z, sha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a]}\",\"details\":\"Definition of field postcode does not match Field Register\"}"));
+	}
+    
     @Test
-    public void shouldReturnBadRequestWhenRegisterIsMissingFieldsDefinedInEnvironment() throws Exception {
+    public void shouldReturnBadRequestWhenLocalFieldDoesNotExistInEnvironment() throws Exception {
         Response response = register.loadRsf(TestRegister.postcode,
-            "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
-            "append-entry\tsystem\tfield:postcode\t2017-06-09T12:59:51Z\tsha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a\n" +
-            "add-item\t{\"fields\":[\"postcode\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
+            "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"test-postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
+            "append-entry\tsystem\tfield:test-postcode\t2017-06-09T12:59:51Z\tsha-256:eb0381c0c768767e60b3edf140e6bdf241f5e6f01a98c3751da488c3e6ffb3fe\n" +
+            "add-item\t{\"fields\":[\"test-postcode\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
             "append-entry\tsystem\tregister:postcode\t2017-06-06T09:54:11Z\tsha-256:323fb3d9167d55ea8173172d756ddbc653292f8debbb13f251f7057d5cb5e450\n");
         assertThat(response.getStatus(), equalTo(400));
-        assertThat(response.readEntity(String.class), equalTo("{\"success\":false,\"message\":\"Exception when executing command: RegisterCommand{commandName='append-entry', arguments=[system, field:postcode, 2017-06-09T12:59:51Z, sha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a]}\",\"details\":\"Definition of field postcode does not match Field Register\"}"));
+        assertThat(response.readEntity(String.class), equalTo("{\"success\":false,\"message\":\"Exception when executing command: RegisterCommand{commandName='append-entry', arguments=[system, field:test-postcode, 2017-06-09T12:59:51Z, sha-256:eb0381c0c768767e60b3edf140e6bdf241f5e6f01a98c3751da488c3e6ffb3fe]}\",\"details\":\"Field test-postcode does not exist in Field Register\"}"));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
@@ -73,7 +73,7 @@ public class RegisterResourceFunctionalTest {
         Map<?, ?> registerRecordMapFromAddressRegister = (Map) registerResourceMapFromAddressRegister.get("register-record");
 
         assertThat(registerRecordMapFromAddressRegister.get("text"), equalTo("Register of addresses"));
-        assertThat((List<String>) registerRecordMapFromAddressRegister.get("fields"), containsInAnyOrder("address", "street", "locality", "town", "area", "postcode", "country", "latitude", "longitude"));
+        assertThat((List<String>) registerRecordMapFromAddressRegister.get("fields"), containsInAnyOrder("address", "street", "locality", "town", "area", "postcode", "country", "latitude", "longitude", "property"));
     }
 
     @Test
@@ -100,7 +100,7 @@ public class RegisterResourceFunctionalTest {
         HashMap<String, Object> result = new HashMap<>();
         result.put("text", "Register of addresses");
         result.put("phase", "alpha");
-        result.put("fields", Arrays.asList("address","street","locality","town","area","postcode","country","latitude","longitude"));
+        result.put("fields", Arrays.asList("address","street","locality","town","area","postcode","country","latitude","longitude","property"));
         result.put("register", "address");
         result.put("registry", "office-for-national-statistics");
         return result;

--- a/src/test/java/uk/gov/register/functional/app/RsfRegisterDefinition.java
+++ b/src/test/java/uk/gov/register/functional/app/RsfRegisterDefinition.java
@@ -6,12 +6,10 @@ public class RsfRegisterDefinition {
             "append-entry\tsystem\tregister-name\t2017-06-01T10:00:00Z\tsha-256:50e3d51c16e203c0124e8bf3a8807abc7693f0d01cb0569499c608f98d2924e9\n";
 
     public static String ADDRESS_REGISTER =
-        "add-item\t{\"fields\":[\"address\",\"street\",\"locality\",\"town\",\"area\",\"postcode\",\"country\",\"latitude\",\"longitude\",\"property\"],\"phase\":\"alpha\",\"register\":\"address\",\"registry\":\"office-for-national-statistics\",\"text\":\"Register of addresses\"}\n" +
-        "append-entry\tsystem\tregister:address\t2017-06-06T09:54:11Z\tsha-256:8d824e2afa57f1a71980237341b0c75d61fdc5c32e52d91e64c6fc3c6265ae63\n";
+            "add-item\t{\"fields\":[\"address\",\"street\",\"locality\",\"town\",\"area\",\"postcode\",\"country\",\"latitude\",\"longitude\",\"property\"],\"phase\":\"alpha\",\"register\":\"address\",\"registry\":\"office-for-national-statistics\",\"text\":\"Register of addresses\"}\n" +
+                    "append-entry\tsystem\tregister:address\t2017-06-06T09:54:11Z\tsha-256:8d824e2afa57f1a71980237341b0c75d61fdc5c32e52d91e64c6fc3c6265ae63\n";
 
-    public static String ADDRESS_FIELDS = "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"extra\",\"phase\":\"alpha\",\"text\":\"extra field to make the test fail initially\"}\n" +
-            "append-entry\tsystem\tfield:extra\t2017-06-09T12:59:51Z\tsha-256:bca2e5228ff9ebc8a2b4553afb46d51dbdf74f2484527c8897df90cbaaa00514\n" +
-            "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"address\",\"phase\":\"alpha\",\"register\":\"address\",\"text\":\"A place in the UK with a postal address.\"}\n" +
+    public static String ADDRESS_FIELDS = "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"address\",\"phase\":\"alpha\",\"register\":\"address\",\"text\":\"A place in the UK with a postal address.\"}\n" +
             "append-entry\tsystem\tfield:address\t2017-06-09T12:59:51Z\tsha-256:cf5700d23d4cd933574fbafb48ba6ace1c3b374b931a6183eeefab6f37106011\n" +
             "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"street\",\"phase\":\"alpha\",\"text\":\"The number and street name of an address.\"}\n" +
             "append-entry\tsystem\tfield:street\t2017-06-09T12:59:51Z\tsha-256:6f3c85090641b9a6b153681de23fa0c7c8ad7ae2cc67acb51bcbb6ba88453b7e\n" +
@@ -33,27 +31,26 @@ public class RsfRegisterDefinition {
             "append-entry\tsystem\tfield:property\t2017-06-09T12:59:51Z\tsha-256:b91ad25f9d6db4b2588ff1724c09e4bf18f13538862efdeb051c7b9c0a5f0eed\n";
 
     public static String POSTCODE_REGISTER =
-        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
-        "append-entry\tsystem\tfield:postcode\t2017-06-09T12:59:51Z\tsha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a\n" +
-        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"point\",\"field\":\"point\",\"phase\":\"alpha\",\"text\":\"A geographical point\"}\n" +
-        "append-entry\tsystem\tfield:point\t2017-06-09T12:59:51Z\tsha-256:7f7f01febb44bada60e4a7a6642f5def6e93f28c043b59eec3a4ccaa44f4ad0b\n" +
-        "add-item\t{\"fields\":[\"postcode\",\"point\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
-        "append-entry\tsystem\tregister:postcode\t2017-06-06T09:54:11Z\tsha-256:ee2fd6546a8362d98e3cd63d914ca55d93f15801c35fdd108b9294c4f0a1d01e\n";
+            "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"register\":\"postcode\",\"text\":\"UK Postcodes.\"}\n" +
+                    "append-entry\tsystem\tfield:postcode\t2017-06-09T12:59:51Z\tsha-256:bc2ac1d18b2172c19372fba27308ed05554fdc6f9d938cff1c903b86313bbab8\n" +
+                    "add-item\t{\"cardinality\":\"1\",\"datatype\":\"point\",\"field\":\"point\",\"phase\":\"alpha\",\"text\":\"A geographical point\"}\n" +
+                    "append-entry\tsystem\tfield:point\t2017-06-09T12:59:51Z\tsha-256:7f7f01febb44bada60e4a7a6642f5def6e93f28c043b59eec3a4ccaa44f4ad0b\n" +
+                    "add-item\t{\"fields\":[\"postcode\",\"point\"],\"phase\":\"alpha\",\"register\":\"postcode\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
+                    "append-entry\tsystem\tregister:postcode\t2017-06-06T09:54:11Z\tsha-256:2439510b4f79a2cdd412660c1110fe7862421f229a0e1069a2a30588f25cf51d\n";
 
     public static String REGISTER_REGISTER =
-        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"register\",\"phase\":\"alpha\",\"register\":\"register\",\"text\":\"A register name.\"}\n" +
-        "append-entry\tsystem\tfield:register\t2017-06-09T12:59:51Z\tsha-256:955a84bcec7dad1a4d9b05e28ebfa21b17ac9552cc0aabbc459c73d63ab530b0\n" +
-        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"text\",\"phase\":\"alpha\",\"text\":\"Description of register entry.\"}\n" +
-        "append-entry\tsystem\tfield:text\t2017-06-09T12:59:51Z\tsha-256:ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f\n" +
-        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"registry\",\"phase\":\"alpha\",\"text\":\"Body responsible for maintaining one or more registers\"}\n" +
-        "append-entry\tsystem\tfield:registry\t2017-06-09T12:59:51Z\tsha-256:4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2\n" +
-        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"phase\",\"phase\":\"alpha\",\"text\":\"Phase of a register or service as defined by the [digital service manual](https://www.gov.uk/service-manual).\"}\n" +
-        "append-entry\tsystem\tfield:phase\t2017-06-09T12:59:51Z\tsha-256:1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4\n" +
-        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"copyright\",\"phase\":\"alpha\",\"text\":\"Copyright for the data in the register.\"}\n" +
-        "append-entry\tsystem\tfield:copyright\t2017-06-09T12:59:51Z\tsha-256:c7e5a90c020f7686d9a275cb0cc164636745b10ae168a72538772692cc90d633\n" +
-        "add-item\t{\"cardinality\":\"n\",\"datatype\":\"string\",\"field\":\"fields\",\"phase\":\"alpha\",\"register\":\"field\",\"text\":\"Set of field names.\"}\n" +
-        "append-entry\tsystem\tfield:fields\t2017-06-09T12:59:51Z\tsha-256:61138002a7ae8a53f3ad16bb91ee41fe73cc7ab7c8b24a8afd2569eb0e6a1c26\n" +
-        "add-item\t{\"fields\":[\"register\",\"text\",\"registry\",\"phase\",\"copyright\",\"fields\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of registers\"}\n" +
-        "append-entry\tsystem\tregister:register\t2017-06-06T09:54:11Z\tsha-256:2238e546c1d9e81a3715d10949dedced0311f596304fbf9bb48c50833f8ab025\n";
+            "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"register\",\"phase\":\"alpha\",\"register\":\"register\",\"text\":\"A register name.\"}\n" +
+                    "append-entry\tsystem\tfield:register\t2017-06-09T12:59:51Z\tsha-256:955a84bcec7dad1a4d9b05e28ebfa21b17ac9552cc0aabbc459c73d63ab530b0\n" +
+                    "add-item\t{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"text\",\"phase\":\"alpha\",\"text\":\"Description of register entry.\"}\n" +
+                    "append-entry\tsystem\tfield:text\t2017-06-09T12:59:51Z\tsha-256:ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f\n" +
+                    "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"registry\",\"phase\":\"alpha\",\"register\":\"public-body\",\"text\":\"Body responsible for maintaining one or more registers\"}\n" +
+                    "append-entry\tsystem\tfield:registry\t2017-06-09T12:59:51Z\tsha-256:8d720e24af4cf63a43b0f9ccd759ed7f36b16617c776124e00faf6ccd30bcc45\n" +
+                    "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"phase\",\"phase\":\"alpha\",\"text\":\"Phase of a register or service as defined by the [digital service manual](https://www.gov.uk/service-manual).\"}\n" +
+                    "append-entry\tsystem\tfield:phase\t2017-06-09T12:59:51Z\tsha-256:1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4\n" +
+                    "add-item\t{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"copyright\",\"phase\":\"alpha\",\"text\":\"Copyright for the data in the register.\"}\n" +
+                    "append-entry\tsystem\tfield:copyright\t2017-06-09T12:59:51Z\tsha-256:c7e5a90c020f7686d9a275cb0cc164636745b10ae168a72538772692cc90d633\n" +
+                    "add-item\t{\"cardinality\":\"n\",\"datatype\":\"string\",\"field\":\"fields\",\"phase\":\"alpha\",\"register\":\"field\",\"text\":\"Set of field names.\"}\n" +
+                    "append-entry\tsystem\tfield:fields\t2017-06-09T12:59:51Z\tsha-256:61138002a7ae8a53f3ad16bb91ee41fe73cc7ab7c8b24a8afd2569eb0e6a1c26\n" +
+                    "add-item\t{\"fields\":[\"register\",\"text\",\"registry\",\"phase\",\"copyright\",\"fields\"],\"phase\":\"alpha\",\"register\":\"register\",\"registry\":\"cabinet-office\",\"text\":\"Register of registers\"}\n" +
+                    "append-entry\tsystem\tregister:register\t2017-06-06T09:54:11Z\tsha-256:f404b4739b51afeb39bba26f3bbf1aa8c6f7d25f0d54444992fc00f24587ef77\n";
 }
-

--- a/src/test/java/uk/gov/register/functional/app/RsfRegisterDefinition.java
+++ b/src/test/java/uk/gov/register/functional/app/RsfRegisterDefinition.java
@@ -6,8 +6,8 @@ public class RsfRegisterDefinition {
             "append-entry\tsystem\tregister-name\t2017-06-01T10:00:00Z\tsha-256:50e3d51c16e203c0124e8bf3a8807abc7693f0d01cb0569499c608f98d2924e9\n";
 
     public static String ADDRESS_REGISTER =
-        "add-item\t{\"fields\":[\"address\",\"street\",\"locality\",\"town\",\"area\",\"postcode\",\"country\",\"latitude\",\"longitude\"],\"phase\":\"alpha\",\"register\":\"address\",\"registry\":\"office-for-national-statistics\",\"text\":\"Register of addresses\"}\n" +
-        "append-entry\tsystem\tregister:address\t2017-06-06T09:54:11Z\tsha-256:2f90a43858c366134a070f563697e04a851c977cd27e491c02885a2f4441e190\n";
+        "add-item\t{\"fields\":[\"address\",\"street\",\"locality\",\"town\",\"area\",\"postcode\",\"country\",\"latitude\",\"longitude\",\"property\"],\"phase\":\"alpha\",\"register\":\"address\",\"registry\":\"office-for-national-statistics\",\"text\":\"Register of addresses\"}\n" +
+        "append-entry\tsystem\tregister:address\t2017-06-06T09:54:11Z\tsha-256:8d824e2afa57f1a71980237341b0c75d61fdc5c32e52d91e64c6fc3c6265ae63\n";
 
     public static String ADDRESS_FIELDS = "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"extra\",\"phase\":\"alpha\",\"text\":\"extra field to make the test fail initially\"}\n" +
             "append-entry\tsystem\tfield:extra\t2017-06-09T12:59:51Z\tsha-256:bca2e5228ff9ebc8a2b4553afb46d51dbdf74f2484527c8897df90cbaaa00514\n" +
@@ -28,25 +28,29 @@ public class RsfRegisterDefinition {
             "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"latitude\",\"phase\":\"alpha\",\"text\":\"Latitude of a place.\"}\n" +
             "append-entry\tsystem\tfield:latitude\t2017-06-09T12:59:51Z\tsha-256:52c98b6782a4631243970b55535cc6b90eb236006ee80a64bd8531d075a9065f\n" +
             "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"longitude\",\"phase\":\"alpha\",\"text\":\"Longitude of a place.\"}\n" +
-            "append-entry\tsystem\tfield:longitude\t2017-06-09T12:59:51Z\tsha-256:105621a1707510d16be14b6a5a11347eda4dab0314a9d9a5f89a50602f7b71c6\n";
+            "append-entry\tsystem\tfield:longitude\t2017-06-09T12:59:51Z\tsha-256:105621a1707510d16be14b6a5a11347eda4dab0314a9d9a5f89a50602f7b71c6\n" +
+            "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"property\",\"phase\":\"alpha\",\"text\":\"A building, institution or house name in an address.\"}\n" +
+            "append-entry\tsystem\tfield:property\t2017-06-09T12:59:51Z\tsha-256:b91ad25f9d6db4b2588ff1724c09e4bf18f13538862efdeb051c7b9c0a5f0eed\n";
 
     public static String POSTCODE_REGISTER =
         "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
         "append-entry\tsystem\tfield:postcode\t2017-06-09T12:59:51Z\tsha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a\n" +
-        "add-item\t{\"fields\":[\"postcode\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
-        "append-entry\tsystem\tregister:postcode\t2017-06-06T09:54:11Z\tsha-256:323fb3d9167d55ea8173172d756ddbc653292f8debbb13f251f7057d5cb5e450\n";
+        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"point\",\"field\":\"point\",\"phase\":\"alpha\",\"text\":\"A geographical point\"}\n" +
+        "append-entry\tsystem\tfield:point\t2017-06-09T12:59:51Z\tsha-256:7f7f01febb44bada60e4a7a6642f5def6e93f28c043b59eec3a4ccaa44f4ad0b\n" +
+        "add-item\t{\"fields\":[\"postcode\",\"point\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
+        "append-entry\tsystem\tregister:postcode\t2017-06-06T09:54:11Z\tsha-256:ee2fd6546a8362d98e3cd63d914ca55d93f15801c35fdd108b9294c4f0a1d01e\n";
 
     public static String REGISTER_REGISTER =
         "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"register\",\"phase\":\"alpha\",\"register\":\"register\",\"text\":\"A register name.\"}\n" +
         "append-entry\tsystem\tfield:register\t2017-06-09T12:59:51Z\tsha-256:955a84bcec7dad1a4d9b05e28ebfa21b17ac9552cc0aabbc459c73d63ab530b0\n" +
-        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"text\",\"phase\":\"alpha\",\"text\":\"Description of register entry.\"}\n" +
-        "append-entry\tsystem\tfield:text\t2017-06-09T12:59:51Z\tsha-256:243a2dafca693363f99c38487a03d1a241915c47a38ad5627ad941c9e52b4c7b\n" +
+        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"text\",\"phase\":\"alpha\",\"text\":\"Description of register entry.\"}\n" +
+        "append-entry\tsystem\tfield:text\t2017-06-09T12:59:51Z\tsha-256:ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f\n" +
         "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"registry\",\"phase\":\"alpha\",\"text\":\"Body responsible for maintaining one or more registers\"}\n" +
         "append-entry\tsystem\tfield:registry\t2017-06-09T12:59:51Z\tsha-256:4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2\n" +
         "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"phase\",\"phase\":\"alpha\",\"text\":\"Phase of a register or service as defined by the [digital service manual](https://www.gov.uk/service-manual).\"}\n" +
         "append-entry\tsystem\tfield:phase\t2017-06-09T12:59:51Z\tsha-256:1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4\n" +
-        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"copyright\",\"phase\":\"alpha\",\"text\":\"Copyright for the data in the register.\"}\n" +
-        "append-entry\tsystem\tfield:copyright\t2017-06-09T12:59:51Z\tsha-256:ecbbde36c6a9808b5f116c63f9ca14773ac3fac251b53e21a1d9fd4b2dd1b35c\n" +
+        "add-item\t{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"copyright\",\"phase\":\"alpha\",\"text\":\"Copyright for the data in the register.\"}\n" +
+        "append-entry\tsystem\tfield:copyright\t2017-06-09T12:59:51Z\tsha-256:c7e5a90c020f7686d9a275cb0cc164636745b10ae168a72538772692cc90d633\n" +
         "add-item\t{\"cardinality\":\"n\",\"datatype\":\"string\",\"field\":\"fields\",\"phase\":\"alpha\",\"register\":\"field\",\"text\":\"Set of field names.\"}\n" +
         "append-entry\tsystem\tfield:fields\t2017-06-09T12:59:51Z\tsha-256:61138002a7ae8a53f3ad16bb91ee41fe73cc7ab7c8b24a8afd2569eb0e6a1c26\n" +
         "add-item\t{\"fields\":[\"register\",\"text\",\"registry\",\"phase\",\"copyright\",\"fields\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of registers\"}\n" +

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -24,6 +24,7 @@ import uk.gov.register.functional.app.WipeDatabaseRule;
 import uk.gov.register.functional.db.TestEntryDAO;
 import uk.gov.register.functional.db.TestItemCommandDAO;
 import uk.gov.register.indexer.IndexDriver;
+import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.ItemValidator;
 import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.store.postgres.PostgresDataAccessLayer;
@@ -195,12 +196,15 @@ public class PostgresRegisterTransactionalFunctionalTest {
         RegistersConfiguration registersConfiguration = mock(RegistersConfiguration.class);
         when(registersConfiguration.getRegisterMetadata(registerName)).thenReturn(new RegisterMetadata(registerName, Arrays.asList("address"), "copyright", "registry", "text", "phase"));
         FieldsConfiguration fieldsConfiguration = mock(FieldsConfiguration.class);
-        when(fieldsConfiguration.getField("address")).thenReturn(new Field("address", "string", registerName, Cardinality.ONE, "A place in the UK with a postal address."));
+        when(fieldsConfiguration.getField("address")).thenReturn(Optional.of(new Field("address", "string", registerName, Cardinality.ONE, "A place in the UK with a postal address.")));
+        
         ConfigManager configManager = mock(ConfigManager.class);
         when(configManager.getRegistersConfiguration()).thenReturn(registersConfiguration);
         when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
         RegisterMetadata registerData = mock(RegisterMetadata.class);
         when(registerData.getRegisterName()).thenReturn(new RegisterName("address"));
+
+        EnvironmentValidator environmentValidator = mock(EnvironmentValidator.class);
 
         return new PostgresRegister(registerData.getRegisterName(),
                 entryLog,
@@ -210,7 +214,7 @@ public class PostgresRegisterTransactionalFunctionalTest {
                 new ArrayList<>(IndexFunctionConfiguration.METADATA.getIndexFunctions()),
                 indexDriver,
                 itemValidator,
-                configManager);
+                environmentValidator);
     }
 
     private PostgresDataAccessLayer getTransactionalDataAccessLayer(Handle handle) {

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -14,7 +14,10 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
+import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.IndexFunctionConfiguration;
+import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.core.*;
 import uk.gov.register.db.*;
 import uk.gov.register.functional.app.WipeDatabaseRule;
@@ -188,6 +191,14 @@ public class PostgresRegisterTransactionalFunctionalTest {
         EntryLog entryLog = new EntryLogImpl(dataAccessLayer, new DoNothing());
         ItemValidator itemValidator = mock(ItemValidator.class);
         ItemStore itemStore = new ItemStoreImpl(dataAccessLayer);
+        RegisterName registerName = new RegisterName("address");
+        RegistersConfiguration registersConfiguration = mock(RegistersConfiguration.class);
+        when(registersConfiguration.getRegisterMetadata(registerName)).thenReturn(new RegisterMetadata(registerName, Arrays.asList("address"), "copyright", "registry", "text", "phase"));
+        FieldsConfiguration fieldsConfiguration = mock(FieldsConfiguration.class);
+        when(fieldsConfiguration.getField("address")).thenReturn(new Field("address", "string", registerName, Cardinality.ONE, "A place in the UK with a postal address."));
+        ConfigManager configManager = mock(ConfigManager.class);
+        when(configManager.getRegistersConfiguration()).thenReturn(registersConfiguration);
+        when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
         RegisterMetadata registerData = mock(RegisterMetadata.class);
         when(registerData.getRegisterName()).thenReturn(new RegisterName("address"));
 
@@ -198,7 +209,8 @@ public class PostgresRegisterTransactionalFunctionalTest {
                 derivationRecordIndex,
                 new ArrayList<>(IndexFunctionConfiguration.METADATA.getIndexFunctions()),
                 indexDriver,
-                itemValidator);
+                itemValidator,
+                configManager);
     }
 
     private PostgresDataAccessLayer getTransactionalDataAccessLayer(Handle handle) {

--- a/src/test/java/uk/gov/register/service/EnvironmentValidatorTest.java
+++ b/src/test/java/uk/gov/register/service/EnvironmentValidatorTest.java
@@ -1,0 +1,100 @@
+package uk.gov.register.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.configuration.FieldsConfiguration;
+import uk.gov.register.configuration.RegistersConfiguration;
+import uk.gov.register.core.Cardinality;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.core.RegisterName;
+import uk.gov.register.exceptions.FieldValidationException;
+import uk.gov.register.exceptions.RegisterValidationException;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EnvironmentValidatorTest {
+    private ConfigManager configManager;
+    private RegisterMetadata localRegisterMetadata;
+    private RegisterMetadata environmentRegisterMetadata;
+	private RegisterName registerName = new RegisterName("postcode");
+
+    @Before
+    public void setUp() {
+        localRegisterMetadata = mock(RegisterMetadata.class);
+		environmentRegisterMetadata = mock(RegisterMetadata.class);
+		configManager = mock(ConfigManager.class);
+        
+        RegistersConfiguration registersConfiguration = mock(RegistersConfiguration.class);
+        when(localRegisterMetadata.getRegisterName()).thenReturn(registerName);
+        when(environmentRegisterMetadata.getFields()).thenReturn(Arrays.asList("postcode", "point"));
+        when(registersConfiguration.getRegisterMetadata(registerName)).thenReturn(environmentRegisterMetadata);
+		when(configManager.getRegistersConfiguration()).thenReturn(registersConfiguration);
+
+		FieldsConfiguration fieldsConfiguration = mock(FieldsConfiguration.class);
+		when(fieldsConfiguration.getField("postcode")).thenReturn(Optional.of(new Field("postcode", "string", registerName, Cardinality.ONE, "A postcode")));
+		when(configManager.getFieldsConfiguration()).thenReturn(fieldsConfiguration);
+    }
+
+    @Test
+    public void validateRegisterDefinitionAgainstEnvironment_shouldThrowException_whenDifferentFieldsAreSpecified() throws Exception {
+		when(localRegisterMetadata.getFields()).thenReturn(Arrays.asList("postcode"));
+        EnvironmentValidator environmentValidator = new EnvironmentValidator(configManager);
+		
+		try {
+			environmentValidator.validateRegisterAgainstEnvironment(localRegisterMetadata);
+			fail();
+		} catch (RegisterValidationException e) {
+			assertThat(e.getMessage(), equalTo("Definition of register postcode does not match Register Register"));
+		}
+    }
+    
+    @Test
+    public void validateRegisterDefinitionAgainstEnvironment_shouldNotThrowException_whenSameFieldsAreSpecified() {
+		when(localRegisterMetadata.getFields()).thenReturn(Arrays.asList("point", "postcode"));
+		EnvironmentValidator environmentValidator = new EnvironmentValidator(configManager);
+		environmentValidator.validateRegisterAgainstEnvironment(localRegisterMetadata);
+	}
+	
+	@Test
+	public void validateFieldDefinitionsAgainstEnvironment_shouldThrowException_whenFieldIsNotDefinedInEnvironment() {
+		EnvironmentValidator environmentValidator = new EnvironmentValidator(configManager);
+		Field localField = new Field("test", "string", registerName, Cardinality.ONE, "A test field");
+
+		try {
+			environmentValidator.validateFieldAgainstEnvironment(localField);
+			fail();
+		} catch (FieldValidationException e) {
+			assertThat(e.getMessage().equalsIgnoreCase("Field test does not exist in Field Register"), equalTo(true));
+		}
+	}
+	
+	@Test
+	public void validateFieldDefinitionsAgainstEnvironment_shouldThrowException_whenFieldDefinitionsAreDifferent() {
+		EnvironmentValidator environmentValidator = new EnvironmentValidator(configManager);
+		Field localField = new Field("postcode", "integer", registerName, Cardinality.ONE, "A postcode");
+		
+		try {
+			environmentValidator.validateFieldAgainstEnvironment(localField);
+			fail();
+		} catch (FieldValidationException e) {
+			assertThat(e.getMessage().equalsIgnoreCase("Definition of field postcode does not match Field Register"), equalTo(true));
+		}
+	}
+	
+	@Test
+	public void validateFieldDefinitionsAgainstEnvironment_shouldNotThrowException_whenFieldDefinitionsAreEquivalent() {
+		EnvironmentValidator environmentValidator = new EnvironmentValidator(configManager);
+		Field localField = new Field("postcode", "string", registerName, Cardinality.ONE, "Postcode in the UK");
+
+		environmentValidator.validateFieldAgainstEnvironment(localField);
+	}
+}

--- a/src/test/java/uk/gov/register/util/FieldComparerTest.java
+++ b/src/test/java/uk/gov/register/util/FieldComparerTest.java
@@ -1,0 +1,61 @@
+package uk.gov.register.util;
+
+import org.junit.Test;
+import uk.gov.register.core.Cardinality;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.RegisterName;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class FieldComparerTest {
+    private FieldComparer fieldComparer = new FieldComparer();
+
+    @Test
+    public void equals_shouldReturnFalse_whenCardinalityIsNotEqual() throws Exception {
+        Field field1 = new Field("town", "string", new RegisterName("town"), Cardinality.ONE, "description");
+        Field field2 = new Field("town", "string", new RegisterName("town"), Cardinality.MANY, "description");
+
+        assertThat(fieldComparer.equals(field1, field2), equalTo(false));
+    }
+
+    @Test
+    public void equals_shouldReturnFalse_whenDatatypeIsNotEqual() throws Exception {
+        Field field1 = new Field("town", "string", new RegisterName("town"), Cardinality.ONE, "description");
+        Field field2 = new Field("town", "integer", new RegisterName("town"), Cardinality.ONE, "description");
+
+        assertThat(fieldComparer.equals(field1, field2), equalTo(false));
+    }
+
+    @Test
+    public void equals_shouldReturnFalse_whenFieldIsNotEqual() throws Exception {
+        Field field1 = new Field("town", "string", new RegisterName("town"), Cardinality.ONE, "description");
+        Field field2 = new Field("postcode", "string", new RegisterName("town"), Cardinality.ONE, "description");
+
+        assertThat(fieldComparer.equals(field1, field2), equalTo(false));
+    }
+
+    @Test
+    public void equals_shouldReturnFalse_whenRegisterNameIsNotEqual() throws Exception {
+        Field field1 = new Field("town", "string", new RegisterName("town"), Cardinality.ONE, "description");
+        Field field2 = new Field("town", "string", new RegisterName("postcode"), Cardinality.ONE, "description");
+
+        assertThat(fieldComparer.equals(field1, field2), equalTo(false));
+    }
+
+    @Test
+    public void equals_shouldReturnTrue_whenFieldsAreEqual() throws Exception {
+        Field field1 = new Field("town", "string", new RegisterName("town"), Cardinality.ONE, "description");
+        Field field2 = new Field("town", "string", new RegisterName("town"), Cardinality.ONE, "description");
+
+        assertThat(fieldComparer.equals(field1, field2), equalTo(true));
+    }
+
+    @Test
+    public void equals_shouldReturnTrue_whenFieldsAreEqualButTextIsDifferent() throws Exception {
+        Field field1 = new Field("town", "string", new RegisterName("town"), Cardinality.ONE, "the town");
+        Field field2 = new Field("town", "string", new RegisterName("town"), Cardinality.ONE, "a town");
+
+        assertThat(fieldComparer.equals(field1, field2), equalTo(true));
+    }
+}

--- a/src/test/resources/fixtures/example1/index.rsf
+++ b/src/test/resources/fixtures/example1/index.rsf
@@ -1,6 +1,6 @@
 assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","text":"Description"}
-add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","text":"Description"}
+add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","register":"local-authority-eng","text":"Description"}
+add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","register":"local-authority-type","text":"Description"}
 add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","text":"Name of field"}
 add-item	{"cardinality":"1","datatype":"string","field":"official-name","phase":"alpha","text":"Official name of country"}
 add-item	{"cardinality":"1","datatype":"datetime","field":"start-date","phase":"alpha","text":"Start datetime for the applicability of a register entry."}
@@ -9,8 +9,8 @@ add-item	{"fields":["local-authority-eng","local-authority-type","name","officia
 add-item	{"local-authority-eng":"Notts","local-authority-type":"MD"}
 add-item	{"local-authority-eng":"London","local-authority-type":"UA"}
 add-item	{"local-authority-eng":"Leics","local-authority-type":"CTY"}
-append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:6582a9fba7d5df86a73b8f6f1b08719c416bab37c1a22908d630227dcb4b10cf
-append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:9dd3c739f2fc34580c95cbfa8eb02a8313a5814b9d03058be3b0d6236aacb33a
+append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:e0bd730fade403032b93a819672f049efca6a808385a0cddda0984ce2ca36d85
+append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:d99cfe6c80b3adaa3e0cab7a87c8179f1cf8cebfbd3ecd8fb4d9ce3447e1b647
 append-entry	system	field:name	2016-04-05T13:23:05Z	sha-256:0b0414ef4211c96339905c3a5f990350537f01bf24c66477c75c2902b4ba52a2
 append-entry	system	field:official-name	2016-04-05T13:23:05Z	sha-256:c71eeef633885fea5c287a8addcf5b541bdd82866abe3834494fc04df2e59da6
 append-entry	system	field:start-date	2016-04-05T13:23:05Z	sha-256:fe5b4abb055cacfb0c71d139b50ec88fa6697e7b094f1d032578914b4bda6526

--- a/src/test/resources/fixtures/example1/index.rsf
+++ b/src/test/resources/fixtures/example1/index.rsf
@@ -1,13 +1,21 @@
 assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","text":"Description"}
 add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","text":"Description"}
-add-item	{"fields":["local-authority-eng","local-authority-type"],"phase":"beta","register":"local-authority-eng","registry":"gds","text":"Register of local authorities in England."}
+add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","text":"Name of field"}
+add-item	{"cardinality":"1","datatype":"string","field":"official-name","phase":"alpha","text":"Official name of country"}
+add-item	{"cardinality":"1","datatype":"datetime","field":"start-date","phase":"alpha","text":"Start datetime for the applicability of a register entry."}
+add-item	{"cardinality":"1","datatype":"datetime","field":"end-date","phase":"alpha","text":"End datetime for the applicability of a register entry."}
+add-item	{"fields":["local-authority-eng","local-authority-type","name","official-name","start-date","end-date"],"phase":"beta","register":"local-authority-eng","registry":"gds","text":"Register of local authorities in England."}
 add-item	{"local-authority-eng":"Notts","local-authority-type":"MD"}
 add-item	{"local-authority-eng":"London","local-authority-type":"UA"}
 add-item	{"local-authority-eng":"Leics","local-authority-type":"CTY"}
 append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:6582a9fba7d5df86a73b8f6f1b08719c416bab37c1a22908d630227dcb4b10cf
 append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:9dd3c739f2fc34580c95cbfa8eb02a8313a5814b9d03058be3b0d6236aacb33a
-append-entry	system	register:local-authority-eng	2016-04-05T13:23:05Z	sha-256:9de769273a8704897e95ef6784eeb2979abaae9262040e117fd4da06b58f7df8
+append-entry	system	field:name	2016-04-05T13:23:05Z	sha-256:0b0414ef4211c96339905c3a5f990350537f01bf24c66477c75c2902b4ba52a2
+append-entry	system	field:official-name	2016-04-05T13:23:05Z	sha-256:c71eeef633885fea5c287a8addcf5b541bdd82866abe3834494fc04df2e59da6
+append-entry	system	field:start-date	2016-04-05T13:23:05Z	sha-256:fe5b4abb055cacfb0c71d139b50ec88fa6697e7b094f1d032578914b4bda6526
+append-entry	system	field:end-date	2016-04-05T13:23:05Z	sha-256:af1ea3d47321ec6ef2f0ab13ad039a130303574188f4a1ce1916703c5c5fa7f1
+append-entry	system	register:local-authority-eng	2016-04-05T13:23:05Z	sha-256:78fe6468a28854287a82e95aad37c37c3f065c6633e9e76f9f354558916b0e9d
 append-entry	user	MD	2016-04-05T13:23:05Z	sha-256:d57e3435709718d26dcc527676bca19583c4309fc1e4c116b2a6ca528f62c125
 append-entry	user	UA	2016-04-05T13:23:05Z	sha-256:7c9cadb17dbdf51ac8d5da5b6f5b55d3ea5332e8eb064c5c7ef7404f08fe74f6
 append-entry	user	CTY	2016-04-05T13:23:05Z	sha-256:a726c24e895a56f15699068ea48d61297eed4fb8cc73c019701fd3e8dd26c15e

--- a/src/test/resources/fixtures/example2/index.rsf
+++ b/src/test/resources/fixtures/example2/index.rsf
@@ -1,6 +1,6 @@
 assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","text":"Description"}
-add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","text":"Description"}
+add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","register":"local-authority-eng","text":"Description"}
+add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","register":"local-authority-type","text":"Description"}
 add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","text":"Name of field"}
 add-item	{"cardinality":"1","datatype":"string","field":"official-name","phase":"alpha","text":"Official name of country"}
 add-item	{"cardinality":"1","datatype":"datetime","field":"start-date","phase":"alpha","text":"Start datetime for the applicability of a register entry."}
@@ -10,8 +10,8 @@ add-item	{"local-authority-eng":"A","local-authority-type":"P"}
 add-item	{"local-authority-eng":"A","local-authority-type":"K"}
 add-item	{"local-authority-eng":"C","local-authority-type":"P"}
 add-item	{"local-authority-eng":"B","local-authority-type":"Q"}
-append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:6582a9fba7d5df86a73b8f6f1b08719c416bab37c1a22908d630227dcb4b10cf
-append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:9dd3c739f2fc34580c95cbfa8eb02a8313a5814b9d03058be3b0d6236aacb33a
+append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:e0bd730fade403032b93a819672f049efca6a808385a0cddda0984ce2ca36d85
+append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:d99cfe6c80b3adaa3e0cab7a87c8179f1cf8cebfbd3ecd8fb4d9ce3447e1b647
 append-entry	system	field:name	2016-04-05T13:23:05Z	sha-256:0b0414ef4211c96339905c3a5f990350537f01bf24c66477c75c2902b4ba52a2
 append-entry	system	field:official-name	2016-04-05T13:23:05Z	sha-256:c71eeef633885fea5c287a8addcf5b541bdd82866abe3834494fc04df2e59da6
 append-entry	system	field:start-date	2016-04-05T13:23:05Z	sha-256:fe5b4abb055cacfb0c71d139b50ec88fa6697e7b094f1d032578914b4bda6526

--- a/src/test/resources/fixtures/example2/index.rsf
+++ b/src/test/resources/fixtures/example2/index.rsf
@@ -1,14 +1,22 @@
 assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","text":"Description"}
 add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","text":"Description"}
-add-item	{"fields":["local-authority-eng","local-authority-type"],"phase":"beta","register":"local-authority-eng","registry":"gds","text":"Register of local authorities in England."}
+add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","text":"Name of field"}
+add-item	{"cardinality":"1","datatype":"string","field":"official-name","phase":"alpha","text":"Official name of country"}
+add-item	{"cardinality":"1","datatype":"datetime","field":"start-date","phase":"alpha","text":"Start datetime for the applicability of a register entry."}
+add-item	{"cardinality":"1","datatype":"datetime","field":"end-date","phase":"alpha","text":"End datetime for the applicability of a register entry."}
+add-item	{"fields":["local-authority-eng","local-authority-type","name","official-name","start-date","end-date"],"phase":"beta","register":"local-authority-eng","registry":"gds","text":"Register of local authorities in England."}
 add-item	{"local-authority-eng":"A","local-authority-type":"P"}
 add-item	{"local-authority-eng":"A","local-authority-type":"K"}
 add-item	{"local-authority-eng":"C","local-authority-type":"P"}
 add-item	{"local-authority-eng":"B","local-authority-type":"Q"}
 append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:6582a9fba7d5df86a73b8f6f1b08719c416bab37c1a22908d630227dcb4b10cf
 append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:9dd3c739f2fc34580c95cbfa8eb02a8313a5814b9d03058be3b0d6236aacb33a
-append-entry	system	register:local-authority-eng	2016-04-05T13:23:05Z	sha-256:9de769273a8704897e95ef6784eeb2979abaae9262040e117fd4da06b58f7df8
+append-entry	system	field:name	2016-04-05T13:23:05Z	sha-256:0b0414ef4211c96339905c3a5f990350537f01bf24c66477c75c2902b4ba52a2
+append-entry	system	field:official-name	2016-04-05T13:23:05Z	sha-256:c71eeef633885fea5c287a8addcf5b541bdd82866abe3834494fc04df2e59da6
+append-entry	system	field:start-date	2016-04-05T13:23:05Z	sha-256:fe5b4abb055cacfb0c71d139b50ec88fa6697e7b094f1d032578914b4bda6526
+append-entry	system	field:end-date	2016-04-05T13:23:05Z	sha-256:af1ea3d47321ec6ef2f0ab13ad039a130303574188f4a1ce1916703c5c5fa7f1
+append-entry	system	register:local-authority-eng	2016-04-05T13:23:05Z	sha-256:78fe6468a28854287a82e95aad37c37c3f065c6633e9e76f9f354558916b0e9d
 append-entry	user	P	2016-04-05T13:23:05Z	sha-256:2ecc268b077eaeececb04025f8c3351c7eb9670026be2e8557043349adde7409
 append-entry	user	Q	2016-04-05T13:23:05Z	sha-256:845fbf8ec0624d7d6ed3b9ec84e69a2a2404f57292f0abeefd0e1e98d13d97bf
 append-entry	user	P	2016-04-05T13:23:05Z	sha-256:7c20f9a73d0c3e398efe6078074d5c018848451a2f98eacc08632de595cfde98;sha-256:2ecc268b077eaeececb04025f8c3351c7eb9670026be2e8557043349adde7409

--- a/src/test/resources/fixtures/example3/index.rsf
+++ b/src/test/resources/fixtures/example3/index.rsf
@@ -1,6 +1,6 @@
 assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","text":"Description"}
-add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","text":"Description"}
+add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","register":"local-authority-eng","text":"Description"}
+add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","register":"local-authority-type","text":"Description"}
 add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","text":"Name of field"}
 add-item	{"cardinality":"1","datatype":"string","field":"official-name","phase":"alpha","text":"Official name of country"}
 add-item	{"cardinality":"1","datatype":"datetime","field":"start-date","phase":"alpha","text":"Start datetime for the applicability of a register entry."}
@@ -9,8 +9,8 @@ add-item	{"fields":["local-authority-eng","local-authority-type","name","officia
 add-item	{"local-authority-eng":"A","local-authority-type":"MD"}
 add-item	{"local-authority-eng":"A","local-authority-type":"CTY"}
 add-item	{"local-authority-eng":"B","local-authority-type":"CTY"}
-append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:6582a9fba7d5df86a73b8f6f1b08719c416bab37c1a22908d630227dcb4b10cf
-append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:9dd3c739f2fc34580c95cbfa8eb02a8313a5814b9d03058be3b0d6236aacb33a
+append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:e0bd730fade403032b93a819672f049efca6a808385a0cddda0984ce2ca36d85
+append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:d99cfe6c80b3adaa3e0cab7a87c8179f1cf8cebfbd3ecd8fb4d9ce3447e1b647
 append-entry	system	field:name	2016-04-05T13:23:05Z	sha-256:0b0414ef4211c96339905c3a5f990350537f01bf24c66477c75c2902b4ba52a2
 append-entry	system	field:official-name	2016-04-05T13:23:05Z	sha-256:c71eeef633885fea5c287a8addcf5b541bdd82866abe3834494fc04df2e59da6
 append-entry	system	field:start-date	2016-04-05T13:23:05Z	sha-256:fe5b4abb055cacfb0c71d139b50ec88fa6697e7b094f1d032578914b4bda6526

--- a/src/test/resources/fixtures/example3/index.rsf
+++ b/src/test/resources/fixtures/example3/index.rsf
@@ -1,13 +1,21 @@
 assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","text":"Description"}
 add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","text":"Description"}
-add-item	{"fields":["local-authority-eng","local-authority-type"],"phase":"beta","register":"local-authority-eng","registry":"gds","text":"Register of local authorities in England."}
+add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","text":"Name of field"}
+add-item	{"cardinality":"1","datatype":"string","field":"official-name","phase":"alpha","text":"Official name of country"}
+add-item	{"cardinality":"1","datatype":"datetime","field":"start-date","phase":"alpha","text":"Start datetime for the applicability of a register entry."}
+add-item	{"cardinality":"1","datatype":"datetime","field":"end-date","phase":"alpha","text":"End datetime for the applicability of a register entry."}
+add-item	{"fields":["local-authority-eng","local-authority-type","name","official-name","start-date","end-date"],"phase":"beta","register":"local-authority-eng","registry":"gds","text":"Register of local authorities in England."}
 add-item	{"local-authority-eng":"A","local-authority-type":"MD"}
 add-item	{"local-authority-eng":"A","local-authority-type":"CTY"}
 add-item	{"local-authority-eng":"B","local-authority-type":"CTY"}
 append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:6582a9fba7d5df86a73b8f6f1b08719c416bab37c1a22908d630227dcb4b10cf
 append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:9dd3c739f2fc34580c95cbfa8eb02a8313a5814b9d03058be3b0d6236aacb33a
-append-entry	system	register:local-authority-eng	2016-04-05T13:23:05Z	sha-256:9de769273a8704897e95ef6784eeb2979abaae9262040e117fd4da06b58f7df8
+append-entry	system	field:name	2016-04-05T13:23:05Z	sha-256:0b0414ef4211c96339905c3a5f990350537f01bf24c66477c75c2902b4ba52a2
+append-entry	system	field:official-name	2016-04-05T13:23:05Z	sha-256:c71eeef633885fea5c287a8addcf5b541bdd82866abe3834494fc04df2e59da6
+append-entry	system	field:start-date	2016-04-05T13:23:05Z	sha-256:fe5b4abb055cacfb0c71d139b50ec88fa6697e7b094f1d032578914b4bda6526
+append-entry	system	field:end-date	2016-04-05T13:23:05Z	sha-256:af1ea3d47321ec6ef2f0ab13ad039a130303574188f4a1ce1916703c5c5fa7f1
+append-entry	system	register:local-authority-eng	2016-04-05T13:23:05Z	sha-256:78fe6468a28854287a82e95aad37c37c3f065c6633e9e76f9f354558916b0e9d
 append-entry	user	MD	2016-04-05T13:23:05Z	sha-256:d72839cd1495fd6d326221820833b5b5f4f5843feac5940d700b068bfe2c9d1e
 append-entry	user	CTY	2016-04-05T13:23:05Z	sha-256:c421ac9f049d6656d863e1739fdfbe04c17b56bbfdd493281e4f894ca21a419e
 append-entry	user	CTY	2016-04-05T13:23:05Z	sha-256:c421ac9f049d6656d863e1739fdfbe04c17b56bbfdd493281e4f894ca21a419e;sha-256:4b45c6d966bbb9c486a74c5fc714145cac96721a114d6e6aef74093369d41c33

--- a/src/test/resources/fixtures/local-authority-eng-metadata.rsf
+++ b/src/test/resources/fixtures/local-authority-eng-metadata.rsf
@@ -1,8 +1,8 @@
 assert-root-hash	sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","text":"Description"}
-append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:6582a9fba7d5df86a73b8f6f1b08719c416bab37c1a22908d630227dcb4b10cf
-add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","text":"Description"}
-append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:9dd3c739f2fc34580c95cbfa8eb02a8313a5814b9d03058be3b0d6236aacb33a
+add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","phase":"beta","register":"local-authority-eng","text":"Description"}
+append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:e0bd730fade403032b93a819672f049efca6a808385a0cddda0984ce2ca36d85
+add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","register":"local-authority-type","text":"Description"}
+append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:d99cfe6c80b3adaa3e0cab7a87c8179f1cf8cebfbd3ecd8fb4d9ce3447e1b647
 add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","text":"Name of field"}
 append-entry	system	field:name	2016-04-05T13:23:05Z	sha-256:0b0414ef4211c96339905c3a5f990350537f01bf24c66477c75c2902b4ba52a2
 add-item	{"cardinality":"1","datatype":"string","field":"official-name","phase":"alpha","text":"Official name of country"}

--- a/src/test/resources/fixtures/local-authority-eng-metadata.rsf
+++ b/src/test/resources/fixtures/local-authority-eng-metadata.rsf
@@ -3,5 +3,13 @@ add-item	{"cardinality":"1","datatype":"string","field":"local-authority-eng","p
 append-entry	system	field:local-authority-eng	2016-04-05T13:23:05Z	sha-256:6582a9fba7d5df86a73b8f6f1b08719c416bab37c1a22908d630227dcb4b10cf
 add-item	{"cardinality":"1","datatype":"string","field":"local-authority-type","phase":"beta","text":"Description"}
 append-entry	system	field:local-authority-type	2016-04-05T13:23:05Z	sha-256:9dd3c739f2fc34580c95cbfa8eb02a8313a5814b9d03058be3b0d6236aacb33a
-add-item	{"fields":["local-authority-eng","local-authority-type"],"phase":"beta","register":"local-authority-eng","registry":"gds","text":"Register of local authorities in England."}
-append-entry	system	register:local-authority-eng	2016-04-05T13:23:05Z	sha-256:9de769273a8704897e95ef6784eeb2979abaae9262040e117fd4da06b58f7df8
+add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","text":"Name of field"}
+append-entry	system	field:name	2016-04-05T13:23:05Z	sha-256:0b0414ef4211c96339905c3a5f990350537f01bf24c66477c75c2902b4ba52a2
+add-item	{"cardinality":"1","datatype":"string","field":"official-name","phase":"alpha","text":"Official name of country"}
+append-entry	system	field:official-name	2016-04-05T13:23:05Z	sha-256:c71eeef633885fea5c287a8addcf5b541bdd82866abe3834494fc04df2e59da6
+add-item	{"cardinality":"1","datatype":"datetime","field":"start-date","phase":"alpha","text":"Start datetime for the applicability of a register entry."}
+append-entry	system	field:start-date	2016-04-05T13:23:05Z	sha-256:fe5b4abb055cacfb0c71d139b50ec88fa6697e7b094f1d032578914b4bda6526
+add-item	{"cardinality":"1","datatype":"datetime","field":"end-date","phase":"alpha","text":"End datetime for the applicability of a register entry."}
+append-entry	system	field:end-date	2016-04-05T13:23:05Z	sha-256:af1ea3d47321ec6ef2f0ab13ad039a130303574188f4a1ce1916703c5c5fa7f1
+add-item	{"fields":["local-authority-eng","local-authority-type","name","official-name","start-date","end-date"],"phase":"beta","register":"local-authority-eng","registry":"gds","text":"Register of local authorities in England."}
+append-entry	system	register:local-authority-eng	2016-04-05T13:23:05Z	sha-256:78fe6468a28854287a82e95aad37c37c3f065c6633e9e76f9f354558916b0e9d

--- a/src/test/resources/fixtures/serialized/register-by-registry.rsf
+++ b/src/test/resources/fixtures/serialized/register-by-registry.rsf
@@ -1,11 +1,3 @@
-add-item	{"fields":["register","text"],"phase":"alpha","register":"register","registry":"registry","text":"Register of Registers"}
-append-entry	system	register:register	2017-06-06T09:54:11Z	sha-256:303f6b8db71cf40b56b1230fb0e6c0d2fad569a184926e80d06ef6acfefabb76
-add-item	{"cardinality":"1","datatype":"text","field":"text","phase":"alpha","text":"Description of register entry."}
-append-entry	system	field:text	2017-06-09T14:56:28Z	sha-256:ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f
-add-item	{"cardinality":"1","datatype":"string","field":"register","phase":"alpha","register":"register","text":"A register name."}
-append-entry	system	field:register	2017-06-09T14:56:28Z	sha-256:955a84bcec7dad1a4d9b05e28ebfa21b17ac9552cc0aabbc459c73d63ab530b0
-add-item	{"cardinality":"1","datatype":"string","field":"registry","phase":"alpha","register":"register","text":"Body responsible for maintaining one or more registers"}
-append-entry	system	field:registry	2017-06-09T14:56:28Z	sha-256:0d6728b77de5a26e90f8948061feb32c4d4146a21f70ae1aecb0793099db4c9b
 add-item	{"register":"address","registry":"government-digital-service","text":"Addresses"}
 add-item	{"register":"food-authority","registry":"government-digital-service","text":"Food Authority"}
 append-entry	user	government-digital-service	2016-11-02T14:45:54Z	sha-256:4bdfee6268fd1365ad9ef378799c1ce567d237c1c0d38d0cf64e64c51aaec559;sha-256:6344e3925465464b317795010fc400ffa8c10380429a3d0260b71ccd9ffc08c7


### PR DESCRIPTION
This PR adds functionality to the register to enable it to validate fields and register definitions, both of an existing register at start-up (through the metadata stored for that register) and when loading an RSF file into an already running register.