### PR TITLE
Remove register from registry field

### DIFF
--- a/src/main/resources/config/fields.yaml
+++ b/src/main/resources/config/fields.yaml
@@ -483,7 +483,6 @@ registry:
     field: "registry"
     phase: "alpha"
     datatype: "string"
-    register: "public-body"
     cardinality: "1"
 website:
   entry-number: "60"

--- a/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
@@ -61,8 +61,8 @@ public class LoadSerializedFunctionalTest {
                 new HashValue(HashingAlgorithm.SHA256, "ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f"),
                 nodeOf("{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"text\",\"phase\":\"alpha\",\"text\":\"Description of register entry.\"}"));
         TestDBItem expectedItem3 = new TestDBItem(
-                new HashValue(HashingAlgorithm.SHA256, "8d720e24af4cf63a43b0f9ccd759ed7f36b16617c776124e00faf6ccd30bcc45"),
-                nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"registry\",\"phase\":\"alpha\",\"register\":\"public-body\",\"text\":\"Body responsible for maintaining one or more registers\"}"));
+                new HashValue(HashingAlgorithm.SHA256, "4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2"),
+                nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"registry\",\"phase\":\"alpha\",\"text\":\"Body responsible for maintaining one or more registers\"}"));
         TestDBItem expectedItem4 = new TestDBItem(
                 new HashValue(HashingAlgorithm.SHA256, "1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4"),
                 nodeOf("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"phase\",\"phase\":\"alpha\",\"text\":\"Phase of a register or service as defined by the [digital service manual](https://www.gov.uk/service-manual).\"}"));
@@ -92,7 +92,7 @@ public class LoadSerializedFunctionalTest {
         assertThat(systemEntries.get(1).getEntryNumber(), is(2));
         assertThat(systemEntries.get(1).getItemHashes().get(0).getValue(), is("ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f"));
         assertThat(systemEntries.get(2).getEntryNumber(), is(3));
-        assertThat(systemEntries.get(2).getItemHashes().get(0).getValue(), is("8d720e24af4cf63a43b0f9ccd759ed7f36b16617c776124e00faf6ccd30bcc45"));
+        assertThat(systemEntries.get(2).getItemHashes().get(0).getValue(), is("4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2"));
         assertThat(systemEntries.get(3).getEntryNumber(), is(4));
         assertThat(systemEntries.get(3).getItemHashes().get(0).getValue(), is("1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4"));
         assertThat(systemEntries.get(4).getEntryNumber(), is(5));

--- a/src/test/java/uk/gov/register/functional/app/RsfRegisterDefinition.java
+++ b/src/test/java/uk/gov/register/functional/app/RsfRegisterDefinition.java
@@ -43,8 +43,8 @@ public class RsfRegisterDefinition {
                     "append-entry\tsystem\tfield:register\t2017-06-09T12:59:51Z\tsha-256:955a84bcec7dad1a4d9b05e28ebfa21b17ac9552cc0aabbc459c73d63ab530b0\n" +
                     "add-item\t{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"text\",\"phase\":\"alpha\",\"text\":\"Description of register entry.\"}\n" +
                     "append-entry\tsystem\tfield:text\t2017-06-09T12:59:51Z\tsha-256:ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f\n" +
-                    "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"registry\",\"phase\":\"alpha\",\"register\":\"public-body\",\"text\":\"Body responsible for maintaining one or more registers\"}\n" +
-                    "append-entry\tsystem\tfield:registry\t2017-06-09T12:59:51Z\tsha-256:8d720e24af4cf63a43b0f9ccd759ed7f36b16617c776124e00faf6ccd30bcc45\n" +
+                    "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"registry\",\"phase\":\"alpha\",\"text\":\"Body responsible for maintaining one or more registers\"}\n" +
+                    "append-entry\tsystem\tfield:registry\t2017-06-09T12:59:51Z\tsha-256:4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2\n" +
                     "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"phase\",\"phase\":\"alpha\",\"text\":\"Phase of a register or service as defined by the [digital service manual](https://www.gov.uk/service-manual).\"}\n" +
                     "append-entry\tsystem\tfield:phase\t2017-06-09T12:59:51Z\tsha-256:1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4\n" +
                     "add-item\t{\"cardinality\":\"1\",\"datatype\":\"text\",\"field\":\"copyright\",\"phase\":\"alpha\",\"text\":\"Copyright for the data in the register.\"}\n" +


### PR DESCRIPTION
This make the fields.yaml in the project more consistent with the current fields register.
Now we check the field definitions the docker script that launches a local basic instance
was failing as the metadata copied from alpha was not consistent with the internal fields yaml.