### PR TITLE
Associate index functions with either user and system entry types

### DIFF
--- a/src/main/java/uk/gov/register/configuration/IndexFunctionConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/IndexFunctionConfiguration.java
@@ -4,7 +4,7 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.indexer.function.CurrentCountriesIndexFunction;
 import uk.gov.register.indexer.function.IndexFunction;
 import uk.gov.register.indexer.function.LocalAuthorityByTypeIndexFunction;
-import uk.gov.register.indexer.function.AddAllIndexFunction;
+import uk.gov.register.indexer.function.LatestByKeyIndexFunction;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +17,7 @@ public enum IndexFunctionConfiguration {
 
     CURRENT_COUNTRIES(IndexNames.CURRENT_COUNTRIES, EntryType.user, new CurrentCountriesIndexFunction(IndexNames.CURRENT_COUNTRIES)),
     LOCAL_AUTHORITY_BY_TYPE(IndexNames.LOCAL_AUTHORITY_BY_TYPE, EntryType.user, new LocalAuthorityByTypeIndexFunction(IndexNames.LOCAL_AUTHORITY_BY_TYPE)),
-    METADATA(IndexNames.METADATA, EntryType.system, new AddAllIndexFunction(IndexNames.METADATA));
+    METADATA(IndexNames.METADATA, EntryType.system, new LatestByKeyIndexFunction(IndexNames.METADATA));
 
     public static List<IndexFunctionConfiguration> getConfigurations(List<String> indexNames) {
         List<IndexFunctionConfiguration> configurations = indexNames.stream().map(n -> getValueLowerCase(n)).collect(Collectors.toList());

--- a/src/main/java/uk/gov/register/configuration/IndexFunctionConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/IndexFunctionConfiguration.java
@@ -1,9 +1,10 @@
 package uk.gov.register.configuration;
 
+import uk.gov.register.core.EntryType;
 import uk.gov.register.indexer.function.CurrentCountriesIndexFunction;
 import uk.gov.register.indexer.function.IndexFunction;
 import uk.gov.register.indexer.function.LocalAuthorityByTypeIndexFunction;
-import uk.gov.register.indexer.function.MetadataIndexFunction;
+import uk.gov.register.indexer.function.AddAllIndexFunction;
 
 import java.util.Arrays;
 import java.util.List;
@@ -14,9 +15,9 @@ import static java.util.stream.Collectors.toSet;
 
 public enum IndexFunctionConfiguration {
 
-    CURRENT_COUNTRIES(IndexNames.CURRENT_COUNTRIES, new CurrentCountriesIndexFunction(IndexNames.CURRENT_COUNTRIES)),
-    LOCAL_AUTHORITY_BY_TYPE(IndexNames.LOCAL_AUTHORITY_BY_TYPE, new LocalAuthorityByTypeIndexFunction(IndexNames.LOCAL_AUTHORITY_BY_TYPE)),
-    METADATA(IndexNames.METADATA, new MetadataIndexFunction(IndexNames.METADATA));
+    CURRENT_COUNTRIES(IndexNames.CURRENT_COUNTRIES, EntryType.user, new CurrentCountriesIndexFunction(IndexNames.CURRENT_COUNTRIES)),
+    LOCAL_AUTHORITY_BY_TYPE(IndexNames.LOCAL_AUTHORITY_BY_TYPE, EntryType.user, new LocalAuthorityByTypeIndexFunction(IndexNames.LOCAL_AUTHORITY_BY_TYPE)),
+    METADATA(IndexNames.METADATA, EntryType.system, new AddAllIndexFunction(IndexNames.METADATA));
 
     public static List<IndexFunctionConfiguration> getConfigurations(List<String> indexNames) {
         List<IndexFunctionConfiguration> configurations = indexNames.stream().map(n -> getValueLowerCase(n)).collect(Collectors.toList());
@@ -37,15 +38,21 @@ public enum IndexFunctionConfiguration {
     }
 
     private String name;
+    private EntryType entryType;
     private Set<IndexFunction> indexFunctions;
 
-    IndexFunctionConfiguration(String name, IndexFunction... indexFunctions) {
+    IndexFunctionConfiguration(String name, EntryType entryType, IndexFunction... indexFunctions) {
         this.name = name;
+        this.entryType = entryType;
         this.indexFunctions = Arrays.stream(indexFunctions).collect(toSet());
     }
 
     public String getName() {
         return name;
+    }
+
+    public EntryType getEntryType() {
+        return entryType;
     }
 
     public Set<IndexFunction> getIndexFunctions() {

--- a/src/main/java/uk/gov/register/core/PostgresRegister.java
+++ b/src/main/java/uk/gov/register/core/PostgresRegister.java
@@ -85,15 +85,12 @@ public class PostgresRegister implements Register {
 
         entryLog.appendEntry(entry);
 
+        for (IndexFunction indexFunction : indexFunctionsByEntryType.get(entry.getEntryType())) {
+            indexDriver.indexEntry(this, entry, indexFunction);
+        }
+
         if (entry.getEntryType() == EntryType.user) {
-            for (IndexFunction indexFunction : indexFunctionsByEntryType.get(EntryType.user)) {
-                indexDriver.indexEntry(this, entry, indexFunction);
-            }
             recordIndex.updateRecordIndex(entry);
-        } else {
-            for (IndexFunction indexFunction : indexFunctionsByEntryType.get(EntryType.system)) {
-                indexDriver.indexEntry(this, entry, indexFunction);
-            }
         }
     }
 

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -54,10 +54,10 @@ public class RegisterContext implements
     private RegisterAuthenticator authenticator;
     private final ItemValidator itemValidator;
 
-    public RegisterContext(RegisterName registerName, ConfigManager configManager, EnvironmentValidator environmentValidator, 
-                           RegisterLinkService registerLinkService, DBI dbi, Flyway flyway, String schema, 
-                           Optional<String> trackingId, boolean enableRegisterDataDelete, boolean enableDownloadResource, 
-                           Optional<String> historyPageUrl, List<String> similarRegisters, List<String> indexNames, 
+    public RegisterContext(RegisterName registerName, ConfigManager configManager, EnvironmentValidator environmentValidator,
+                           RegisterLinkService registerLinkService, DBI dbi, Flyway flyway, String schema,
+                           Optional<String> trackingId, boolean enableRegisterDataDelete, boolean enableDownloadResource,
+                           Optional<String> historyPageUrl, List<String> similarRegisters, List<String> indexNames,
                            RegisterAuthenticator authenticator) {
         this.registerName = registerName;
         this.configManager = configManager;
@@ -91,8 +91,14 @@ public class RegisterContext implements
         return flyway.migrate();
     }
 
-    private List<IndexFunction> getIndexFunctions() {
-        return indexFunctionConfigs.stream().flatMap(c -> c.getIndexFunctions().stream()).collect(toList());
+    private List<IndexFunction> getUserIndexFunctions() {
+        return indexFunctionConfigs.stream().filter(c -> c.getEntryType() == EntryType.user)
+                .flatMap(c -> c.getIndexFunctions().stream()).collect(toList());
+    }
+
+    private List<IndexFunction> getSystemIndexFunctions() {
+        return indexFunctionConfigs.stream().filter(c -> c.getEntryType() == EntryType.system)
+                .flatMap(c -> c.getIndexFunctions().stream()).collect(toList());
     }
 
     public Register buildOnDemandRegister() {
@@ -103,7 +109,8 @@ public class RegisterContext implements
                 new ItemStoreImpl(dataAccessLayer),
                 new RecordIndexImpl(dataAccessLayer),
                 new DerivationRecordIndex(dataAccessLayer),
-                getIndexFunctions(),
+                getUserIndexFunctions(),
+                getSystemIndexFunctions(),
                 new IndexDriver(dataAccessLayer),
                 itemValidator,
                 environmentValidator);
@@ -115,7 +122,8 @@ public class RegisterContext implements
                 new ItemStoreImpl(dataAccessLayer),
                 new RecordIndexImpl(dataAccessLayer),
                 new DerivationRecordIndex(dataAccessLayer),
-                getIndexFunctions(),
+                getUserIndexFunctions(),
+                getSystemIndexFunctions(),
                 new IndexDriver(dataAccessLayer),
                 itemValidator,
                 environmentValidator);

--- a/src/main/java/uk/gov/register/indexer/IndexDriver.java
+++ b/src/main/java/uk/gov/register/indexer/IndexDriver.java
@@ -19,10 +19,6 @@ public class IndexDriver {
     }
 
     public void indexEntry(Register register, Entry entry, IndexFunction indexFunction) {
-        if (indexFunction.getName().equals(IndexNames.METADATA) && entry.getEntryType().equals(EntryType.user)) {
-            return;
-        }
-
         Optional<Record> currentRecord = (entry.getEntryType() == EntryType.user)
                 ? register.getRecord(entry.getKey())
                 : register.getDerivationRecord(entry.getKey(), IndexNames.METADATA);

--- a/src/main/java/uk/gov/register/indexer/function/AddAllIndexFunction.java
+++ b/src/main/java/uk/gov/register/indexer/function/AddAllIndexFunction.java
@@ -7,15 +7,13 @@ import uk.gov.register.util.HashValue;
 
 import java.util.Set;
 
-public class MetadataIndexFunction extends BaseIndexFunction {
-    public MetadataIndexFunction(String name) {
+public class AddAllIndexFunction extends BaseIndexFunction {
+    public AddAllIndexFunction(String name) {
         super(name);
     }
 
     @Override
     protected void execute(Register register, EntryType type, String key, HashValue itemHash, Set<IndexKeyItemPair> result) {
-        if (type == EntryType.system) {
             result.add(new IndexKeyItemPair(key, itemHash));
-        }
     }
 }

--- a/src/main/java/uk/gov/register/indexer/function/CurrentCountriesIndexFunction.java
+++ b/src/main/java/uk/gov/register/indexer/function/CurrentCountriesIndexFunction.java
@@ -15,10 +15,6 @@ public class CurrentCountriesIndexFunction extends BaseIndexFunction {
 
     @Override
     protected void execute(Register register, EntryType type, String key, HashValue itemHash, Set<IndexKeyItemPair> result) {
-        if (type == EntryType.system) {
-            return;
-        }
-        
         register.getItemBySha256(itemHash).ifPresent(i -> {
             if (!i.getValue("end-date").isPresent()) {
                 result.add(new IndexKeyItemPair(key, i.getSha256hex()));

--- a/src/main/java/uk/gov/register/indexer/function/LatestByKeyIndexFunction.java
+++ b/src/main/java/uk/gov/register/indexer/function/LatestByKeyIndexFunction.java
@@ -7,8 +7,8 @@ import uk.gov.register.util.HashValue;
 
 import java.util.Set;
 
-public class AddAllIndexFunction extends BaseIndexFunction {
-    public AddAllIndexFunction(String name) {
+public class LatestByKeyIndexFunction extends BaseIndexFunction {
+    public LatestByKeyIndexFunction(String name) {
         super(name);
     }
 

--- a/src/main/java/uk/gov/register/indexer/function/LocalAuthorityByTypeIndexFunction.java
+++ b/src/main/java/uk/gov/register/indexer/function/LocalAuthorityByTypeIndexFunction.java
@@ -15,10 +15,6 @@ public class LocalAuthorityByTypeIndexFunction extends BaseIndexFunction {
 
     @Override
     protected void execute(Register register, EntryType type, String key, HashValue itemHash, Set<IndexKeyItemPair> result) {
-        if (type == EntryType.system) {
-            return;
-        }
-        
         register.getItemBySha256(itemHash).ifPresent(i -> {
             if (i.getValue("local-authority-type").isPresent()) {
                 result.add(new IndexKeyItemPair(i.getValue("local-authority-type").get(), i.getSha256hex()));

--- a/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
+++ b/src/test/java/uk/gov/register/core/PostgresRegisterTest.java
@@ -2,6 +2,7 @@ package uk.gov.register.core;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,10 +23,7 @@ import uk.gov.register.util.HashValue;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -65,9 +63,12 @@ public class PostgresRegisterTest {
 
     @Before
     public void setup() throws IOException {
+
+        Map<EntryType, Collection<IndexFunction>> indexFunctionsByEntryType = ImmutableMap.of(EntryType.system, Arrays.asList(systemIndexFunction), EntryType.user, Arrays.asList(indexFunction));
+
         register = new PostgresRegister(new RegisterName("postcode"),
                 inMemoryEntryLog(entryDAO, entryDAO), inMemoryItemStore(itemValidator, entryDAO), recordIndex,
-                derivationRecordIndex, Arrays.asList(indexFunction), Arrays.asList(systemIndexFunction), indexDriver, itemValidator, environmentValidator);
+                derivationRecordIndex, indexFunctionsByEntryType, indexDriver, itemValidator, environmentValidator);
 
         when(registerRecord.getItems()).thenReturn(Arrays.asList(getItem(postcodeRegisterItem)));
 

--- a/src/test/java/uk/gov/register/core/RegisterContextTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterContextTest.java
@@ -126,7 +126,7 @@ public class RegisterContextTest {
         PostgresRegister register = (PostgresRegister)context.buildOnDemandRegister();
         assertThat(register.getIndexFunctionsByEntryType().get(EntryType.system).size(), Is.is(1));
         List<String> indexFunctionNames = register.getIndexFunctionsByEntryType().get(EntryType.system).stream().map(ifn -> ifn.getClass().getName()).collect(toList());
-        assertThat(indexFunctionNames, containsInAnyOrder("uk.gov.register.indexer.function.AddAllIndexFunction"));
+        assertThat(indexFunctionNames, containsInAnyOrder("uk.gov.register.indexer.function.LatestByKeyIndexFunction"));
 
     }
 }

--- a/src/test/java/uk/gov/register/core/RegisterContextTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterContextTest.java
@@ -1,6 +1,7 @@
 package uk.gov.register.core;
 
 import org.flywaydb.core.Flyway;
+import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
@@ -8,10 +9,13 @@ import uk.gov.register.auth.RegisterAuthenticator;
 import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.exceptions.NoSuchConfigException;
+import uk.gov.register.indexer.function.CurrentCountriesIndexFunction;
+import uk.gov.register.indexer.function.AddAllIndexFunction;
 import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.RegisterLinkService;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -92,5 +96,25 @@ public class RegisterContextTest {
 
         RegisterMetadata actualUpdatedMetadata = context.getRegisterMetadata();
         assertThat(actualUpdatedMetadata, equalTo(expectedUpdatedMetadata));
+    }
+
+    @Test
+    public void shouldSetUserIndexFunctions(){
+        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, Optional.empty(),
+                true, false, Optional.empty(), emptyList(), Arrays.asList("current-countries"), new RegisterAuthenticator("", ""));
+        PostgresRegister register = (PostgresRegister)context.buildOnDemandRegister();
+        assertThat(register.getUserIndexFunctions().size(), Is.is(1));
+        assertThat(register.getUserIndexFunctions().get(0).getClass().getName(), Is.is(CurrentCountriesIndexFunction.class.getName()));
+
+    }
+
+    @Test
+    public void shouldSetSystemIndexFunctions(){
+        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, Optional.empty(),
+                true, false, Optional.empty(), emptyList(), Arrays.asList("current-countries"), new RegisterAuthenticator("", ""));
+        PostgresRegister register = (PostgresRegister)context.buildOnDemandRegister();
+        assertThat(register.getSystemIndexFunctions().size(), Is.is(1));
+        assertThat(register.getSystemIndexFunctions().get(0).getClass().getName(), Is.is(AddAllIndexFunction.class.getName()));
+
     }
 }

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -33,10 +33,7 @@ import uk.gov.verifiablelog.store.memoization.DoNothing;
 import uk.gov.register.configuration.IndexFunctionConfiguration.IndexNames;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -211,6 +208,7 @@ public class PostgresRegisterTransactionalFunctionalTest {
                 itemStore,
                 new RecordIndexImpl(dataAccessLayer),
                 derivationRecordIndex,
+                Collections.emptyList(),
                 new ArrayList<>(IndexFunctionConfiguration.METADATA.getIndexFunctions()),
                 indexDriver,
                 itemValidator,

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -17,7 +17,6 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.configuration.FieldsConfiguration;
-import uk.gov.register.configuration.IndexFunctionConfiguration;
 import uk.gov.register.configuration.RegistersConfiguration;
 import uk.gov.register.core.*;
 import uk.gov.register.db.*;
@@ -25,7 +24,7 @@ import uk.gov.register.functional.app.WipeDatabaseRule;
 import uk.gov.register.functional.db.TestEntryDAO;
 import uk.gov.register.functional.db.TestItemCommandDAO;
 import uk.gov.register.indexer.IndexDriver;
-import uk.gov.register.indexer.function.AddAllIndexFunction;
+import uk.gov.register.indexer.function.LatestByKeyIndexFunction;
 import uk.gov.register.indexer.function.IndexFunction;
 import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.ItemValidator;
@@ -240,9 +239,8 @@ public class PostgresRegisterTransactionalFunctionalTest {
         return dataSourceFactory;
     }
 
-    private Map<EntryType, Collection<IndexFunction>> getIndexFunctions(){
-        return ImmutableMap.of(EntryType.user, Collections.emptyList(), EntryType.system, Arrays.asList(new AddAllIndexFunction(IndexNames.METADATA)));
+    private Map<EntryType, Collection<IndexFunction>> getIndexFunctions() {
+        return ImmutableMap.of(EntryType.user, Collections.emptyList(), EntryType.system, Arrays.asList(new LatestByKeyIndexFunction(IndexNames.METADATA)));
     }
-
 }
 

--- a/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/PostgresRegisterTransactionalFunctionalTest.java
@@ -3,6 +3,7 @@ package uk.gov.register.functional.store.postgres;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jdbi.DBIFactory;
@@ -24,6 +25,8 @@ import uk.gov.register.functional.app.WipeDatabaseRule;
 import uk.gov.register.functional.db.TestEntryDAO;
 import uk.gov.register.functional.db.TestItemCommandDAO;
 import uk.gov.register.indexer.IndexDriver;
+import uk.gov.register.indexer.function.AddAllIndexFunction;
+import uk.gov.register.indexer.function.IndexFunction;
 import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.ItemValidator;
 import uk.gov.register.store.DataAccessLayer;
@@ -208,8 +211,7 @@ public class PostgresRegisterTransactionalFunctionalTest {
                 itemStore,
                 new RecordIndexImpl(dataAccessLayer),
                 derivationRecordIndex,
-                Collections.emptyList(),
-                new ArrayList<>(IndexFunctionConfiguration.METADATA.getIndexFunctions()),
+                getIndexFunctions(),
                 indexDriver,
                 itemValidator,
                 environmentValidator);
@@ -236,6 +238,10 @@ public class PostgresRegisterTransactionalFunctionalTest {
         dataSourceFactory.setUser("postgres");
         dataSourceFactory.setPassword("");
         return dataSourceFactory;
+    }
+
+    private Map<EntryType, Collection<IndexFunction>> getIndexFunctions(){
+        return ImmutableMap.of(EntryType.user, Collections.emptyList(), EntryType.system, Arrays.asList(new AddAllIndexFunction(IndexNames.METADATA)));
     }
 
 }


### PR DESCRIPTION
Previously the index functions would check the entry type. This change
associates the index function with an entry type so separate lists of
index functions can be applied as data is loaded.