### PR TITLE
Remove workaround that ensures the DB connection is encrypted

### DIFF
--- a/src/main/java/uk/gov/register/configuration/DatabaseManager.java
+++ b/src/main/java/uk/gov/register/configuration/DatabaseManager.java
@@ -32,7 +32,7 @@ public class DatabaseManager {
         return new ObjectMapper()
                 .readTree(System.getenv("VCAP_SERVICES"))
                 .at("/postgres/0/credentials/jdbcuri")
-                .textValue() + "&ssl=true";
+                .textValue();
     }
 
     public ManagedDataSource getDataSource() {


### PR DESCRIPTION
PaaS have deployed a fix which means this is now available in the JDBC
URI stored in `VCAP_SERIVCES`.