### PR TITLE
Remove unneeded environment variables

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,3 +9,4 @@ applications:
     JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://change-me/change-me.yaml" }'
     AWS_ACCESS_KEY_ID: change-me
     AWS_SECRET_ACCESS_KEY: change-me
+    AWS_DEFAULT_REGION: change-me

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,12 +7,5 @@ applications:
     - change-me-db
   env:
     JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://change-me/change-me.yaml" }'
-    REGISTER: change-me
-    REGISTER_DOMAIN: change-me.cloudapps.digital
-    USER: change-me
-    PASSWORD: change-me
     AWS_ACCESS_KEY_ID: change-me
     AWS_SECRET_ACCESS_KEY: change-me
-    # Optional
-    # REGISTERS_YAML_LOCATION: https://register.register.gov.uk/records.yaml
-    # FIELDS_YAML_LOCATION: https://field.register.gov.uk/records.yaml


### PR DESCRIPTION
Our configuration is pulled from S3. We no longer need to set these
values here.