### PR TITLE
bump version of dropwizard-logstash again

### DIFF
--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -45,7 +45,7 @@ ext {
 
     thymeleaf = 'org.thymeleaf:thymeleaf:2.1.5.RELEASE'
 
-    dropwizardLogstash = "uk.gov.ida:dropwizard-logstash:1.1.2-build_45"
+    dropwizardLogstash = "uk.gov.ida:dropwizard-logstash:1.1.2-build_46"
     
     jetty = [
             "org.eclipse.jetty:jetty-continuation:9.4.6.v20170531",


### PR DESCRIPTION
this pulls in alphagov/dropwizard-logstash#9 which adds `referrer`,
`agent` and `host` fields to the JSON output.  It should be completely
forward-compatible.