### PR TITLE
Use CodeBuild to deploy to PaaS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,7 @@ task createDeployableBundle(type: Zip) {
     from('deploy/')
     include('*')
     include('scripts/**/*.sh')
+    include('manifests/**/*.yml')
     destinationDir file('deployable_bundle') // directory that you want your archive to be placed in
 }
 

--- a/deploy/buildspec.yml
+++ b/deploy/buildspec.yml
@@ -1,0 +1,28 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - apt-get update -y
+      - apt-get install -y apt-transport-https
+      - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
+      - echo 'deb http://packages.cloudfoundry.org/debian stable main' > /etc/apt/sources.list.d/cloudfoundry-cli.list
+      - apt-get update -y
+      - apt-get install -y cf-cli
+  pre_build:
+    commands:
+      - export CF_USER="$(aws ssm get-parameters --name paas-deploy-user --query 'Parameters[0].Value' --output text)"
+      - export CF_PASSWORD="$(aws ssm get-parameters --name paas-deploy-password --with-decryption --query 'Parameters[0].Value' --output text)"
+      - export AWS_KEY="$(aws ssm get-parameters --name paas-deploy-aws-key --query 'Parameters[0].Value' --output text)"
+      - export AWS_SECRET="$(aws ssm get-parameters --name paas-deploy-aws-secret --with-decryption --query 'Parameters[0].Value' --output text)"
+      - cf api "https://api.cloud.service.gov.uk"
+      - cf auth "$CF_USER" "$CF_PASSWORD"
+      - cf target -o "$CF_ORGANIZATION" -s "$CF_SPACE"
+  build:
+    commands:
+      - 'sed -i "s/    AWS_ACCESS_KEY_ID: change-me/    AWS_ACCESS_KEY_ID: $AWS_KEY/" manifests/$ENVIRONMENT/$REGISTER_GROUP.yml'
+      - 'sed -i "s/    AWS_SECRET_ACCESS_KEY: change-me/    AWS_SECRET_ACCESS_KEY: $AWS_SECRET/" manifests/$ENVIRONMENT/$REGISTER_GROUP.yml'
+      - cf push -p openregister-java.jar -f manifests/$ENVIRONMENT/$REGISTER_GROUP.yml
+  post_build:
+    commands:
+      - cf logout

--- a/deploy/manifests/alpha/basic.yml
+++ b/deploy/manifests/alpha/basic.yml
@@ -1,0 +1,15 @@
+---
+applications:
+- name: alpha-basic
+  memory: 1024M
+  instances: 2
+  buildpack: java_buildpack
+  health-check-http-endpoint: /records
+  random-route: true
+  services:
+    - alpha-db
+  env:
+    JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://openregister.alpha.config/basic/openregister/paas-config.yaml" }'
+    AWS_ACCESS_KEY_ID: change-me
+    AWS_SECRET_ACCESS_KEY: change-me
+    AWS_REGION: eu-west-1

--- a/deploy/manifests/alpha/multi.yml
+++ b/deploy/manifests/alpha/multi.yml
@@ -1,0 +1,15 @@
+---
+applications:
+- name: alpha-multi
+  memory: 1024M
+  instances: 2
+  buildpack: java_buildpack
+  health-check-http-endpoint: /records
+  random-route: true
+  services:
+    - alpha-db
+  env:
+    JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://openregister.alpha.config/multi/openregister/paas-config.yaml" }'
+    AWS_ACCESS_KEY_ID: change-me
+    AWS_SECRET_ACCESS_KEY: change-me
+    AWS_REGION: eu-west-1

--- a/deploy/manifests/beta/basic.yml
+++ b/deploy/manifests/beta/basic.yml
@@ -1,0 +1,15 @@
+---
+applications:
+- name: beta-basic
+  memory: 1024M
+  instances: 2
+  buildpack: java_buildpack
+  health-check-http-endpoint: /records
+  random-route: true
+  services:
+    - beta-db
+  env:
+    JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://openregister.beta.config/basic/openregister/paas-config.yaml" }'
+    AWS_ACCESS_KEY_ID: change-me
+    AWS_SECRET_ACCESS_KEY: change-me
+    AWS_REGION: eu-west-1

--- a/deploy/manifests/beta/multi.yml
+++ b/deploy/manifests/beta/multi.yml
@@ -1,0 +1,15 @@
+---
+applications:
+- name: beta-multi
+  memory: 1024M
+  instances: 2
+  buildpack: java_buildpack
+  health-check-http-endpoint: /records
+  random-route: true
+  services:
+    - beta-db
+  env:
+    JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://openregister.beta.config/multi/openregister/paas-config.yaml" }'
+    AWS_ACCESS_KEY_ID: change-me
+    AWS_SECRET_ACCESS_KEY: change-me
+    AWS_REGION: eu-west-1

--- a/deploy/manifests/discovery/address.yml
+++ b/deploy/manifests/discovery/address.yml
@@ -1,0 +1,15 @@
+---
+applications:
+- name: discovery-address
+  memory: 1024M
+  instances: 2
+  buildpack: java_buildpack
+  health-check-http-endpoint: /records
+  random-route: true
+  services:
+    - discovery-db
+  env:
+    JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://openregister.discovery.config/address/openregister/paas-config.yaml" }'
+    AWS_ACCESS_KEY_ID: change-me
+    AWS_SECRET_ACCESS_KEY: change-me
+    AWS_REGION: eu-west-1

--- a/deploy/manifests/discovery/basic.yml
+++ b/deploy/manifests/discovery/basic.yml
@@ -1,0 +1,15 @@
+---
+applications:
+- name: discovery-basic
+  memory: 1024M
+  instances: 2
+  buildpack: java_buildpack
+  health-check-http-endpoint: /records
+  random-route: true
+  services:
+    - discovery-db
+  env:
+    JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://openregister.discovery.config/basic/openregister/paas-config.yaml" }'
+    AWS_ACCESS_KEY_ID: change-me
+    AWS_SECRET_ACCESS_KEY: change-me
+    AWS_REGION: eu-west-1

--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -1,0 +1,15 @@
+---
+applications:
+- name: discovery-multi
+  memory: 1024M
+  instances: 2
+  buildpack: java_buildpack
+  health-check-http-endpoint: /records
+  random-route: true
+  services:
+    - discovery-db
+  env:
+    JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://openregister.discovery.config/multi/openregister/paas-config.yaml" }'
+    AWS_ACCESS_KEY_ID: change-me
+    AWS_SECRET_ACCESS_KEY: change-me
+    AWS_REGION: eu-west-1

--- a/deploy/manifests/test/basic.yml
+++ b/deploy/manifests/test/basic.yml
@@ -1,0 +1,15 @@
+---
+applications:
+- name: test-basic
+  memory: 1024M
+  instances: 2
+  buildpack: java_buildpack
+  health-check-http-endpoint: /records
+  random-route: true
+  services:
+    - test-db
+  env:
+    JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://openregister.test.config/basic/openregister/paas-config.yaml" }'
+    AWS_ACCESS_KEY_ID: change-me
+    AWS_SECRET_ACCESS_KEY: change-me
+    AWS_REGION: eu-west-1

--- a/deploy/manifests/test/multi.yml
+++ b/deploy/manifests/test/multi.yml
@@ -1,0 +1,15 @@
+---
+applications:
+- name: test-multi
+  memory: 1024M
+  instances: 2
+  buildpack: java_buildpack
+  health-check-http-endpoint: /records
+  random-route: true
+  services:
+    - test-db
+  env:
+    JBP_CONFIG_JAVA_MAIN: '{ arguments: "server s3://openregister.test.config/multi/openregister/paas-config.yaml" }'
+    AWS_ACCESS_KEY_ID: change-me
+    AWS_SECRET_ACCESS_KEY: change-me
+    AWS_REGION: eu-west-1


### PR DESCRIPTION
This is very much a (mis)use of CodeBuild.

We currently deploy our code as part of a CodePipeline using CodeDeploy.
CodeDeploy works well with AWS-y things but doesn't have a way a neat
way to deploy to something externally like PaaS.

We can use CodeBuild to run a bunch of `cf` commands to push the `.jar`
to PaaS.

In order to do this our input to the CodeBuild project (the `.zip` that
Travis builds) has to contain a `buildspec.yml` and manifests the
describe the PaaS deployment--this is not ideal and our build artifact
has to know too much about its own deployment.

This feels very much like a stopgap solution to deploying to PaaS and
should be replaced if something more appropriate materializes.

There is a lot of duplication across manifests for different
environments. In the future I expect these manifests to define things
like the routes and domains associated with the app. Whilst they appear
similar now I think this is only accidental.

In order for this to work additional changes are required to
CodePipeline but the artifact must change first.