### PR TITLE
Fix deprecation warning; use Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ If the basic registers change you can restart your register so that it sees the 
 
 - Java 1.8+
 - Postgres DB 9.5+ (and in particular `psql` and `createuser` need to be on your PATH)
-- Python 3 (and in particular the `pyvenv` script needs to be on your
-  PATH)
+- Python 3.6
 
 ### Build and Run project
 

--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ task(loadSchoolDataForConformance, type: Exec) {
 }
 
 task createConformanceTestVenv(type: Exec) {
-    commandLine 'pyvenv-3.5','.venv'
+    commandLine 'python3.6', '-m', 'venv', '.venv'
 }
 
 task installConformanceTestDeps(type: Exec) {


### PR DESCRIPTION
Previously the build would display a warning as [`pyvenv` has been deprecated](https://docs.python.org/3.6/whatsnew/3.6.html#id8) 

This fixes the warning and switches to using Python 3.6 (which is currently the default when you do `brew install python3` by using the new built in `venv` functionality.