### PR TITLE
Remove Flyway migration parallelism

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -107,7 +107,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         RegisterLinkService registerLinkService = new RegisterLinkService(configManager);
 
         AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(configManager, databaseManager, registerLinkService, environmentValidator, configuration);
-        allTheRegisters.stream().parallel().forEach(registerContext -> {
+        allTheRegisters.stream().forEach(registerContext -> {
             registerContext.migrate();
             environmentValidator.validateExistingMetadataAgainstEnvironment(registerContext);
         });


### PR DESCRIPTION
The amount of parallelism is a function of the number of CPU cores
available[1]. When running on our current, but soon to be replaced AWS
infrastructure, the number of available cores is 2. When running on PaaS
the number of available cores is 4. When running on PaaS we see Flyway
sometimes fail to get a database connection from the connection pool
(currently set to 4 in production). This is due to the level of
parallelism consuming all available connections. This manifests itself
as a call to `DataSource.getConnection()` within Flyway returning `null`
and throwing a `FlywayException`[2].

From reading logs it appears that the worker pool on our current AWS
never grows larger than one. It would seem that this hasn't be doing
anything useful on our current infrastructure and we have considered the
performance to be acceptable.

Given that it doesn't appear that this has being doing anything useful
we are going to try running without any parallelism. We can look at
introducing it back, but with a level of parallelism derived from the
database connection pool size[3], if our deploys become too slow.

[1] https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ForkJoinPool.html
[2] https://github.com/flyway/flyway/blob/d977aeb9d90ce18a1abaa0f33aba3fba488b88f2/flyway-core/src/main/java/org/flywaydb/core/internal/util/jdbc/JdbcUtils.java#L53
[3] https://stackoverflow.com/a/22269778