### PR TITLE
Default to cloning a smaller register when running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A java implementation of a register
 
 You can spin up a local copy of `openregister-java` using Docker with the following:
 
-    ENVIRONMENT=alpha ./run-application.sh
+    ENVIRONMENT=beta REGISTERS=country ./run-application.sh
 
 This will do the following in Docker containers:
 
@@ -25,6 +25,8 @@ If you want to view/change the basic registers you can do that by sending reques
 If the basic registers change you can restart your register so that it sees the changes:
 
     docker restart openregister-register
+
+See detailed steps for experimenting locally [here](RUNNING_LOCALLY.md).
 
 ### Running on Cloud Foundry/PaaS
 

--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -38,6 +38,20 @@ If you want to amend this register, you can:
 * create a new register
 * change the configuration
 
+## Clone a different register
+
+The `./run-application.sh` script is configured to spin up a clone of the [Country beta register](https://country.register.gov.uk/). To clone a different register from another phase, you need to change some configuration.
+
+For example, you might want to clone the [School type register](https://school-type.alpha.openregister.org/) from the alpha phase.
+
+Go to the `config.docker.register.yaml` file.
+
+Change `register: country` to `register: school-type`.
+
+Update the schema in the same way, to `schema: school-type`.
+
+Now re-run the application using `ENVIRONMENT=alpha REGISTERS=school-type ./run-application.sh`. You should now see the School type register locally at `127.0.0.1:8080`.
+
 ## Create a new register
 
 To create a new register, you first need to create a new entry in the register register.

--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -14,11 +14,11 @@ You'll need:
 * curl
 * An understanding of the [register APIs](https://registers-docs.cloudapps.digital/)
 
-This iteration of the script is pre-configured to spin up a register of schools based on the [School eng register](https://school-eng.alpha.openregister.org/), which is currently in alpha.
+This iteration of the script is pre-configured to spin up a register of countries based on the [Country register](https://country.register.gov.uk/), which is currently in beta.
 
 It also uses "basic registers" such as the [register register](https://register.register.gov.uk/), [field register](https://field.register.gov.uk/).
 
-You can amend these details once you have a copy of the School eng register running locally. You can find credential information in the configuration files.
+You can amend these details once you have a copy of the Country and Territory registers running locally. You can find credential information in the configuration files.
 
 ## Run register locally
 
@@ -30,9 +30,9 @@ The command will create Docker containers that will:
 * run the "basic" registers, such as the Register Register and Field Register with `config.register.basic.yaml`
 * run a register configured with `config.docker.register.yaml`
 
-The basic registers will be cloned from a specific phase, such as alpha. You can see them locally at `*.local.openregister.org:8081`. For example, `field.local.openregister.org:8081`.
+The basic registers will be cloned from a specific phase, such as beta. You can see them locally at `*.local.openregister.org:8081`. For example, `field.local.openregister.org:8081`.
 
-You should now see the School eng register locally at `127.0.0.1:8080`.
+You should now see the Country register locally at `127.0.0.1:8080`.
 
 If you want to amend this register, you can:
 * create a new register
@@ -45,14 +45,14 @@ To create a new register, you first need to create a new entry in the register r
 Choose a primary key for your register. This will also be the name of your register. For example, foobar.
 
 Add the name to the field register using:
-`$ echo '[{"field":"foobar", "datatype": "string", "phase": "alpha", "cardinality": "1", "text": "test field"}]' | python3 ./scripts/json-to-rsf/json2rsf.py field | curl field.local.openregister.org:8081/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar`
+`$ echo '[{"field":"foobar", "datatype": "string", "phase": "alpha", "cardinality": "1", "text": "test field"}]' | python3 ./scripts/json-to-rsf/json2rsf.py user field | curl field.local.openregister.org:8081/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar`
 
 Then, you'll need to create an entry in the register register using:
-`$ echo '[{"phase":"alpha","registry":"government-digital-service","text":"A test register","fields":["foobar", "name","start-date","end-date"],"register":"foobar"}]' | python3 ./scripts/json-to-rsf/json2rsf.py register | curl register.local.openregister.org:8081/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar`
+`$ echo '[{"phase":"alpha","registry":"government-digital-service","text":"A test register","fields":["foobar","name","start-date","end-date"],"register":"foobar"}]' | python3 ./scripts/json-to-rsf/json2rsf.py user register | curl register.local.openregister.org:8081/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar`
 
 Check this is successful at `field.local.openregister.org:8081/records` and `register.local.openregister.org:8081/records`. You should see the name of your register, such as `foobar`, as the first record. 
 
-Now you can update your local register to use this.
+Now you can update your local register.
 
 ## Change the configuration
 
@@ -60,25 +60,38 @@ First, you'll need to change the configuration.
 
 Go to the `config.docker.register.yaml` file.
 
-Change `register: school-eng` to the name of your register, for example `register: foobar`.
+Change `register: country` to the name of your register, for example `register: foobar`.
 
 Update the schema in the same way, for example: `schema: foobar`.
 
 Restart your docker container:
 `docker restart openregister-register`
 
-You should see your new empty register at `127.0.0.1:8080`.
+You should see your new undefined register at `127.0.0.1:8080`.
 
 ## Load data into your register
 
 You can now load your own data in the new register.
 
+First, you need to populate the register with its register definition and field definitions. These should be the same as those listed in the field and register registers.
+
+```
+$ echo '[{"name":"foobar"}]' | python3 ./scripts/json-to-rsf/json2rsf.py system name | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
+$ echo '[{"field":"foobar", "datatype": "string", "phase": "alpha", "cardinality": "1", "text": "test field"}]' | python3 ./scripts/json-to-rsf/json2rsf.py system field:foobar | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
+$ echo '[{"field":"name", "datatype": "string", "phase": "beta", "cardinality": "1", "text": "The commonly-used name of a record"}]' | python3 ./scripts/json-to-rsf/json2rsf.py system field:name | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
+$ echo '[{"field":"start-date", "datatype": "datetime", "phase": "beta", "cardinality": "1", "text": "The date a record first became relevant to a register."}]' | python3 ./scripts/json-to-rsf/json2rsf.py system field:start-date | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
+$ echo '[{"field":"end-date", "datatype": "datetime", "phase": "beta", "cardinality": "1", "text": "The date a record stopped being applicable."}]' | python3 ./scripts/json-to-rsf/json2rsf.py system field:end-date | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
+$ echo '[{"phase":"alpha","registry":"government-digital-service","text":"A test register","fields":["foobar","name","start-date","end-date"],"register":"foobar"}]' | python3 ./scripts/json-to-rsf/json2rsf.py system register:foobar | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
+```
+
+You can now load foobar data.
+
 For example:
 
 ```
-$ echo '[{"foobar": "a", "name": "something"}]' | python3 ./scripts/json-to-rsf/json2rsf.py foobar | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
-$ echo '[{"foobar": "b", "name": "something else"}]' | python3 ./scripts/json-to-rsf/json2rsf.py foobar | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
-$ echo '[{"foobar": "c", "name": "another thing"}]' | python3 ./scripts/json-to-rsf/json2rsf.py foobar | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
+$ echo '[{"foobar": "a", "name": "something"}]' | python3 ./scripts/json-to-rsf/json2rsf.py user foobar | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
+$ echo '[{"foobar": "b", "name": "something else"}]' | python3 ./scripts/json-to-rsf/json2rsf.py user foobar | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
+$ echo '[{"foobar": "c", "name": "another thing"}]' | python3 ./scripts/json-to-rsf/json2rsf.py user foobar | curl 127.0.0.1:8080/load-rsf -H "Content-Type: application/uk-gov-rsf" --data-binary @- -u foo:bar
 ```
 
 ## Contact and support

--- a/config.docker.register.yaml
+++ b/config.docker.register.yaml
@@ -23,8 +23,8 @@ server:
 
 registerDomain: openregister.dev:8080
 
-register: school-eng
-schema: school-eng
+register: country
+schema: country
 
 enableDownloadResource: true
 
@@ -54,3 +54,10 @@ logging:
     "org.skife.jdbi.v2": TRACE
   appenders:
     - type: logstash-console
+
+registers:
+  territory:
+    credentials:
+      user: foo
+      password: bar
+    schema: territory

--- a/scripts/json-to-rsf/json2rsf.py
+++ b/scripts/json-to-rsf/json2rsf.py
@@ -4,22 +4,23 @@ import json
 import hashlib
 
 
-def print_rsf(item, key_field):
-    key = item[key_field]
+def print_rsf(item, entry_type, key_field):
+    key = item[key_field] if entry_type == 'user' else key_field
     timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
     item_str = json.dumps(item, separators=(',', ':'), sort_keys=True)
     item_hash = hashlib.sha256(item_str.encode("utf-8")).hexdigest()
     item_line = "add-item\t" + item_str
-    entry_line = "append-entry\tuser\t{0}\t{1}\tsha-256:{2}".format(
-            key, timestamp, item_hash)
+    entry_line = "append-entry\t{0}\t{1}\t{2}\tsha-256:{3}".format(
+            entry_type, key, timestamp, item_hash)
     print(item_line)
     print(entry_line)
 
-
 item_arr = json.load(sys.stdin)
+
 if len(sys.argv) < 2:
-    sys.exit("Usage: cat foo.json | python json2rsf.py [key field name]")
+    sys.exit("Usage: cat foo.json | python json2rsf.py [entry-type key-field-name]")
 if not isinstance(item_arr, list):
     sys.exit("Error: input must be json array")
-key = sys.argv[1]
-[print_rsf(item, key) for item in item_arr]
+entryType = sys.argv[1]
+key = sys.argv[2]
+[print_rsf(item, entryType, key) for item in item_arr]

--- a/scripts/json-to-rsf/readme.md
+++ b/scripts/json-to-rsf/readme.md
@@ -24,9 +24,10 @@ A Python 3 script to convert JSON to RSF. JSON must be an array of objects, the 
 
 ### Usage
 
-JSON will be read from the standard input. 
+JSON will be read from the standard input and there are two required arguments for the Python script. 
 
-The name of the field which is the Key for the item local-authority-eng in the example.
-Must be passed as an argument.
+entry-type: The type of the entry, either `user` or `system`
+key-field-name: If the entry-type is `user`, this should be the name of the primary key field in the JSON (also the name of the register). If the entry-type is `system`, this should be the key of the entry.
 
-    cat la.json | python3 json2rsf.py local-authority-eng
+    cat la.json | python3 json2rsf.py user local-authority-eng
+    cat la-field.json | python3 json2rsf.py system field:local-authority-eng


### PR DESCRIPTION
Previously we cloned the alpha school-eng register when using the `./run-application.sh` script. This is now a reasonably large register that takes a while to load and may also move to the beta environment soon. This change therefore defaults to cloning the beta country register on `./run-application.sh` as this is a smaller and more stable register.

This also adds new documentation on changing the default to clone a different existing register.

The existing documentation for creating a new register locally has been updated to account for metadata changes.