### PR TITLE
Use autopilot

### DIFF
--- a/deploy/buildspec.yml
+++ b/deploy/buildspec.yml
@@ -9,13 +9,13 @@ phases:
       - echo 'deb http://packages.cloudfoundry.org/debian stable main' > /etc/apt/sources.list.d/cloudfoundry-cli.list
       - apt-get update -y
       - apt-get install -y cf-cli
-      - export CF_BGD_VERSION="1.2.0"
-      - export CF_BGD_CHECKSUM="a5677bf250077858dc2d39af12f48803a7d852a400efa246887556247e1203c4"
-      - export CF_BGD_TEMPFILE="/tmp/blue-green-deploy.linux64"
-      - wget -q -O "${CF_BGD_TEMPFILE}" "https://github.com/bluemixgaragelondon/cf-blue-green-deploy/releases/download/v${CF_BGD_VERSION}/blue-green-deploy.linux64"
-      - echo "${CF_BGD_CHECKSUM}  ${CF_BGD_TEMPFILE}" | sha256sum -c -
-      - chmod +x "${CF_BGD_TEMPFILE}"
-      - cf install-plugin -f "${CF_BGD_TEMPFILE}"
+      - export CF_AUTOPILOT_VERSION="0.0.3"
+      - export CF_AUTOPILOT_CHECKSUM="c3b5a38ba7a9817e12d6ab4c98418d707c49c1d3eb68e5a79e701531bd8fa1cd"
+      - export CF_AUTOPILOT_TEMPFILE="/tmp/autopilot.linux64"
+      - wget -q -O "${CF_AUTOPILOT_TEMPFILE}" "https://github.com/contraband/autopilot/releases/download/${CF_AUTOPILOT_VERSION}/autopilot-linux"
+      - echo "${CF_AUTOPILOT_CHECKSUM}  ${CF_AUTOPILOT_TEMPFILE}" | sha256sum -c -
+      - chmod +x "${CF_AUTOPILOT_TEMPFILE}"
+      - cf install-plugin -f "${CF_AUTOPILOT_TEMPFILE}"
   pre_build:
     commands:
       - export CF_USER="$(aws ssm get-parameters --name paas-deploy-user --query 'Parameters[0].Value' --output text)"
@@ -29,8 +29,7 @@ phases:
     commands:
       - 'sed -i "s/    AWS_ACCESS_KEY_ID: change-me/    AWS_ACCESS_KEY_ID: $AWS_KEY/" manifests/$ENVIRONMENT/$REGISTER_GROUP.yml'
       - 'sed -i "s/    AWS_SECRET_ACCESS_KEY: change-me/    AWS_SECRET_ACCESS_KEY: $AWS_SECRET/" manifests/$ENVIRONMENT/$REGISTER_GROUP.yml'
-      - cf blue-green-deploy "$ENVIRONMENT-$REGISTER_GROUP" -f "manifests/$ENVIRONMENT/$REGISTER_GROUP.yml"
+      - cf zero-downtime-push "$ENVIRONMENT-$REGISTER_GROUP" -f "manifests/$ENVIRONMENT/$REGISTER_GROUP.yml"
   post_build:
     commands:
-      - cf delete -f "$ENVIRONMENT-$REGISTER_GROUP-old"
       - cf logout

--- a/deploy/buildspec.yml
+++ b/deploy/buildspec.yml
@@ -9,19 +9,19 @@ phases:
       - echo 'deb http://packages.cloudfoundry.org/debian stable main' > /etc/apt/sources.list.d/cloudfoundry-cli.list
       - apt-get update -y
       - apt-get install -y cf-cli
-      - export CF_AUTOPILOT_VERSION="0.0.3"
-      - export CF_AUTOPILOT_CHECKSUM="c3b5a38ba7a9817e12d6ab4c98418d707c49c1d3eb68e5a79e701531bd8fa1cd"
-      - export CF_AUTOPILOT_TEMPFILE="/tmp/autopilot.linux64"
+      - CF_AUTOPILOT_VERSION="0.0.3"
+      - CF_AUTOPILOT_CHECKSUM="c3b5a38ba7a9817e12d6ab4c98418d707c49c1d3eb68e5a79e701531bd8fa1cd"
+      - CF_AUTOPILOT_TEMPFILE="/tmp/autopilot.linux64"
       - wget -q -O "${CF_AUTOPILOT_TEMPFILE}" "https://github.com/contraband/autopilot/releases/download/${CF_AUTOPILOT_VERSION}/autopilot-linux"
       - echo "${CF_AUTOPILOT_CHECKSUM}  ${CF_AUTOPILOT_TEMPFILE}" | sha256sum -c -
       - chmod +x "${CF_AUTOPILOT_TEMPFILE}"
       - cf install-plugin -f "${CF_AUTOPILOT_TEMPFILE}"
   pre_build:
     commands:
-      - export CF_USER="$(aws ssm get-parameters --name paas-deploy-user --query 'Parameters[0].Value' --output text)"
-      - export CF_PASSWORD="$(aws ssm get-parameters --name paas-deploy-password --with-decryption --query 'Parameters[0].Value' --output text)"
-      - export AWS_KEY="$(aws ssm get-parameters --name paas-deploy-aws-key --query 'Parameters[0].Value' --output text)"
-      - export AWS_SECRET="$(aws ssm get-parameters --name paas-deploy-aws-secret --with-decryption --query 'Parameters[0].Value' --output text)"
+      - CF_USER="$(aws ssm get-parameters --name paas-deploy-user --query 'Parameters[0].Value' --output text)"
+      - CF_PASSWORD="$(aws ssm get-parameters --name paas-deploy-password --with-decryption --query 'Parameters[0].Value' --output text)"
+      - AWS_KEY="$(aws ssm get-parameters --name paas-deploy-aws-key --query 'Parameters[0].Value' --output text)"
+      - AWS_SECRET="$(aws ssm get-parameters --name paas-deploy-aws-secret --with-decryption --query 'Parameters[0].Value' --output text)"
       - cf api "https://api.cloud.service.gov.uk"
       - cf auth "${CF_USER}" "${CF_PASSWORD}"
       - cf target -o "${CF_ORGANIZATION}" -s "${CF_SPACE}"

--- a/deploy/buildspec.yml
+++ b/deploy/buildspec.yml
@@ -23,13 +23,13 @@ phases:
       - export AWS_KEY="$(aws ssm get-parameters --name paas-deploy-aws-key --query 'Parameters[0].Value' --output text)"
       - export AWS_SECRET="$(aws ssm get-parameters --name paas-deploy-aws-secret --with-decryption --query 'Parameters[0].Value' --output text)"
       - cf api "https://api.cloud.service.gov.uk"
-      - cf auth "$CF_USER" "$CF_PASSWORD"
-      - cf target -o "$CF_ORGANIZATION" -s "$CF_SPACE"
+      - cf auth "${CF_USER}" "${CF_PASSWORD}"
+      - cf target -o "${CF_ORGANIZATION}" -s "${CF_SPACE}"
   build:
     commands:
-      - 'sed -i "s/    AWS_ACCESS_KEY_ID: change-me/    AWS_ACCESS_KEY_ID: $AWS_KEY/" manifests/$ENVIRONMENT/$REGISTER_GROUP.yml'
-      - 'sed -i "s/    AWS_SECRET_ACCESS_KEY: change-me/    AWS_SECRET_ACCESS_KEY: $AWS_SECRET/" manifests/$ENVIRONMENT/$REGISTER_GROUP.yml'
-      - cf zero-downtime-push "$ENVIRONMENT-$REGISTER_GROUP" -f "manifests/$ENVIRONMENT/$REGISTER_GROUP.yml"
+      - 'sed -i "s/    AWS_ACCESS_KEY_ID: change-me/    AWS_ACCESS_KEY_ID: ${AWS_KEY}/" manifests/${ENVIRONMENT}/${REGISTER_GROUP}.yml'
+      - 'sed -i "s/    AWS_SECRET_ACCESS_KEY: change-me/    AWS_SECRET_ACCESS_KEY: ${AWS_SECRET}/" manifests/${ENVIRONMENT}/${REGISTER_GROUP}.yml'
+      - cf zero-downtime-push "${ENVIRONMENT}-${REGISTER_GROUP}" -f "manifests/${ENVIRONMENT}/${REGISTER_GROUP}.yml"
   post_build:
     commands:
       - cf logout


### PR DESCRIPTION
We have had a few issues using `cf-blue-green-deploy`[1]; `autopilot`[2]
seems to work better for us. Problems we've seen include:

- Routes are not updated when making changes to `manifest.yaml`. They
appear to be just copied from the existing app. This makes adding new
registers a process that involves adding the routes outside of the
manifest.
- Deploys fail if there is not an app already running. This makes
rebuilding apps or creating apps for the first time awkward.

Apparent downsides to this include having to make sure that your
deployed application and manifest are similar[3]. This really should be
the case anyway as any deployment configuration changes should go
through the manifest.

[1] https://github.com/bluemixgaragelondon/cf-blue-green-deploy
[2] https://github.com/contraband/autopilot
[3] https://github.com/contraband/autopilot/blob/f602d9cbf609b5c99bee0caba452f7eb2bbf58ab/README.md#warning