### PR TITLE
Use `domains` and `hosts` in manifest

### DIFF
--- a/deploy/manifests/alpha/basic.yml
+++ b/deploy/manifests/alpha/basic.yml
@@ -7,10 +7,12 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /records
   path: ../../openregister-java.jar
-  routes:
-    - route: datatype.alpha.openregister.org
-    - route: field.alpha.openregister.org
-    - route: register.alpha.openregister.org
+  domains:
+    - alpha.openregister.org
+  hosts:
+    - datatype
+    - field
+    - register
   services:
     - alpha-db
     - logit-ssl-drain

--- a/deploy/manifests/alpha/multi.yml
+++ b/deploy/manifests/alpha/multi.yml
@@ -7,19 +7,21 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /records
   path: ../../openregister-java.jar
-  routes:
-    - route: government-domain.alpha.openregister.org
-    - route: industrial-classification.alpha.openregister.org
-    - route: internal-drainage-board.alpha.openregister.org
-    - route: occupation.alpha.openregister.org
-    - route: principal-local-authority.alpha.openregister.org
-    - route: school-eng.alpha.openregister.org
-    - route: school-type.alpha.openregister.org
-    - route: social-housing-provider-designation.alpha.openregister.org
-    - route: social-housing-provider-legal-entity.alpha.openregister.org
-    - route: social-housing-provider.alpha.openregister.org
-    - route: statistical-geography-unitary-authority-wls.alpha.openregister.org
-    - route: statistical-geography.alpha.openregister.org
+  domains:
+    - alpha.openregister.org
+  hosts:
+    - government-domain
+    - industrial-classification
+    - internal-drainage-board
+    - occupation
+    - principal-local-authority
+    - school-eng
+    - school-type
+    - social-housing-provider-designation
+    - social-housing-provider-legal-entity
+    - social-housing-provider
+    - statistical-geography-unitary-authority-wls
+    - statistical-geography
   services:
     - alpha-db
     - logit-ssl-drain

--- a/deploy/manifests/beta/basic.yml
+++ b/deploy/manifests/beta/basic.yml
@@ -7,10 +7,13 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /records
   path: ../../openregister-java.jar
-  routes:
-    - route: datatype.beta.openregister.org
-    - route: field.beta.openregister.org
-    - route: register.beta.openregister.org
+  domains:
+    - beta.openregister.org
+    - register.gov.uk
+  hosts:
+    - datatype
+    - field
+    - register
   services:
     - beta-db
     - logit-ssl-drain

--- a/deploy/manifests/beta/multi.yml
+++ b/deploy/manifests/beta/multi.yml
@@ -7,18 +7,21 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /records
   path: ../../openregister-java.jar
-  routes:
-    - route: country.beta.openregister.org
-    - route: government-organisation.beta.openregister.org
-    - route: government-service.beta.openregister.org
-    - route: internal-drainage-board.beta.openregister.org
-    - route: local-authority-eng.beta.openregister.org
-    - route: local-authority-sct.beta.openregister.org
-    - route: local-authority-type.beta.openregister.org
-    - route: principal-local-authority.beta.openregister.org
-    - route: prison-estate.beta.openregister.org
-    - route: registration-district.beta.openregister.org
-    - route: territory.beta.openregister.org
+  domains:
+    - beta.openregister.org
+    - register.gov.uk
+  hosts:
+    - country
+    - government-organisation
+    - government-service
+    - internal-drainage-board
+    - local-authority-eng
+    - local-authority-sct
+    - local-authority-type
+    - principal-local-authority
+    - prison-estate
+    - registration-district
+    - territory
   services:
     - beta-db
     - logit-ssl-drain

--- a/deploy/manifests/discovery/basic.yml
+++ b/deploy/manifests/discovery/basic.yml
@@ -7,10 +7,12 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /records
   path: ../../openregister-java.jar
-  routes:
-    - route: datatype.discovery.openregister.org
-    - route: field.discovery.openregister.org
-    - route: register.discovery.openregister.org
+  domains:
+    - discovery.openregister.org
+  host:
+    - datatype
+    - field
+    - register
   services:
     - discovery-db
     - logit-ssl-drain

--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -7,22 +7,24 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /records
   path: ../../openregister-java.jar
-  routes:
-    - route: address.discovery.openregister.org
-    - route: clinical-commissioning-group.discovery.openregister.org
-    - route: government-domain.discovery.openregister.org
-    - route: green-deal-certification-body.discovery.openregister.org
-    - route: jobcentre.discovery.openregister.org
-    - route: local-authority-nir.discovery.openregister.org
-    - route: local-authority-type.discovery.openregister.org
-    - route: place.discovery.openregister.org
-    - route: prison.discovery.openregister.org
-    - route: statistical-geography-unitary-authority-wls.discovery.openregister.org
-    - route: statistical-geography.discovery.openregister.org
-    - route: street-custodian.discovery.openregister.org
-    - route: street.discovery.openregister.org
-    - route: uk.discovery.openregister.org
-    - route: vehicle-colour.discovery.openregister.org
+  domains:
+    - discovery.openregister.org
+  hosts:
+    - address
+    - clinical-commissioning-group
+    - government-domain
+    - green-deal-certification-body
+    - jobcentre
+    - local-authority-nir
+    - local-authority-type
+    - place
+    - prison
+    - statistical-geography-unitary-authority-wls
+    - statistical-geography
+    - street-custodian
+    - street
+    - uk
+    - vehicle-colour
   services:
     - discovery-db
     - logit-ssl-drain

--- a/deploy/manifests/test/basic.yml
+++ b/deploy/manifests/test/basic.yml
@@ -7,10 +7,12 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /records
   path: ../../openregister-java.jar
-  routes:
-    - route: datatype.test.openregister.org
-    - route: field.test.openregister.org
-    - route: register.test.openregister.org
+  domains:
+    - test.openregister.org
+  hosts:
+    - datatype
+    - field
+    - register
   services:
     - test-db
     - logit-ssl-drain

--- a/deploy/manifests/test/multi.yml
+++ b/deploy/manifests/test/multi.yml
@@ -7,8 +7,10 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /records
   path: ../../openregister-java.jar
-  routes:
-    - route: country.test.openregister.org
+  domains:
+    - test.openregister.org
+  hosts:
+    - country
   services:
     - test-db
     - logit-ssl-drain


### PR DESCRIPTION
This makes it harder to accidentally forget to add a route to both
`beta.openregister.org` and `register.gov.uk`. It also helps DRY things
up a bit.