### PR TITLE
Create school-type-eng register in alpha

### DIFF
--- a/deploy/manifests/alpha/multi.yml
+++ b/deploy/manifests/alpha/multi.yml
@@ -19,6 +19,7 @@ applications:
     - public-body-classification
     - school-eng
     - school-type
+    - school-type-eng
     - social-housing-provider-designation
     - social-housing-provider-legal-entity
     - social-housing-provider


### PR DESCRIPTION
This register is to replace school-type (which we will remove later)
as there will be a separate register for school-types in scotland.