### PR TITLE
Increase instance size to 4GB

### DIFF
--- a/deploy/manifests/alpha/basic.yml
+++ b/deploy/manifests/alpha/basic.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: alpha-basic
-  memory: 1024M
+  memory: 4GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/alpha/multi.yml
+++ b/deploy/manifests/alpha/multi.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: alpha-multi
-  memory: 1024M
+  memory: 4GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/beta/basic.yml
+++ b/deploy/manifests/beta/basic.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: beta-basic
-  memory: 1024M
+  memory: 4GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/beta/multi.yml
+++ b/deploy/manifests/beta/multi.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: beta-multi
-  memory: 1024M
+  memory: 4GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/discovery/basic.yml
+++ b/deploy/manifests/discovery/basic.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: discovery-basic
-  memory: 1024M
+  memory: 4GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: discovery-multi
-  memory: 1024M
+  memory: 4GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/test/basic.yml
+++ b/deploy/manifests/test/basic.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: test-basic
-  memory: 1024M
+  memory: 4GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/test/multi.yml
+++ b/deploy/manifests/test/multi.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: test-multi
-  memory: 1024M
+  memory: 4GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http


### PR DESCRIPTION
Before moving to PaaS the size of each AWS EC2 instance was 4GB.
This was reduced to 1GB when we moved to PaaS but for no real
reason. Some instances are almost at their memory limit and
it's suspected that this could be causing some issues with
loading and querying data.