### PR TITLE
Update gov-domain and statistical-geography registers phases

### DIFF
--- a/deploy/manifests/beta/multi.yml
+++ b/deploy/manifests/beta/multi.yml
@@ -12,6 +12,7 @@ applications:
     - register.gov.uk
   hosts:
     - country
+    - government-domain
     - government-organisation
     - government-service
     - internal-drainage-board
@@ -21,6 +22,8 @@ applications:
     - principal-local-authority
     - prison-estate
     - registration-district
+    - statistical-geography
+    - statistical-geography-unitary-authority-wls
     - territory
   services:
     - beta-db

--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -12,7 +12,6 @@ applications:
   hosts:
     - address
     - clinical-commissioning-group
-    - government-domain
     - green-deal-certification-body
     - jobcentre
     - local-authority-nir
@@ -22,8 +21,6 @@ applications:
     - public-body
     - public-body-classification
     - statistical-geography-council-area-sct
-    - statistical-geography-unitary-authority-wls
-    - statistical-geography
     - street-custodian
     - street
     - uk


### PR DESCRIPTION
This commit removes `government-domain`, `statistical-geography` and `statistical-geography-unitary-authority-wls` from discovery and alpha, and adds them to beta.