### PR TITLE
Decrease memory for basic instances

### DIFF
--- a/deploy/manifests/alpha/basic.yml
+++ b/deploy/manifests/alpha/basic.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: alpha-basic
-  memory: 4GB
+  memory: 2GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/beta/basic.yml
+++ b/deploy/manifests/beta/basic.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: beta-basic
-  memory: 4GB
+  memory: 2GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/discovery/basic.yml
+++ b/deploy/manifests/discovery/basic.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: discovery-basic
-  memory: 4GB
+  memory: 2GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/test/basic.yml
+++ b/deploy/manifests/test/basic.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: test-basic
-  memory: 4GB
+  memory: 2GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http

--- a/deploy/manifests/test/multi.yml
+++ b/deploy/manifests/test/multi.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: test-multi
-  memory: 4GB
+  memory: 2GB
   instances: 2
   buildpack: java_buildpack
   health-check-type: http


### PR DESCRIPTION
    We don't need 4GB for the basic instances. This will also ensure
    that we do not exceed the organisation memory limit for now. I
    have also decreased the memory size in test because there are fewer
    registers here