### PR TITLE
Ensure that breadcrumbs sit below header

### DIFF
--- a/src/main/resources/assets/sass/_breadcrumbs.scss
+++ b/src/main/resources/assets/sass/_breadcrumbs.scss
@@ -3,6 +3,7 @@
 
 .breadcrumbs {
   @include breadcrumbs;
+  padding-bottom: 0;
 
   ol {
     margin: 0;

--- a/src/main/resources/templates/download.html
+++ b/src/main/resources/templates/download.html
@@ -7,12 +7,21 @@
 
   <div id="wrapper">
     <main id="main" role="main">
+      <div class="breadcrumbs">
+        <ol>
+          <li>
+            <a href="/" th:utext="${friendlyRegisterName}">Home</a>
+          </li>
+          <li>Download</li>
+        </ol>
+      </div>
+
       <th:block th:unless="${register.phase == 'beta'}">
         <div th:replace="fragments/phase-banner.html::phase"></div>
       </th:block>
+
       <div class="grid-row">
         <div class="column-two-thirds">
-          <a href="/" class="link-back">Back</a>
 
           <h1 class="heading-large">
             Download register data

--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -7,10 +7,6 @@
 
     <div id="wrapper">
       <main id="main" role="main">
-        <th:block th:unless="${register.phase == 'beta'}">
-          <div th:replace="fragments/phase-banner.html::phase"></div>
-        </th:block>
-
         <div class="breadcrumbs">
           <ol>
             <li>
@@ -26,6 +22,10 @@
             <li>Entries</li>
           </ol>
         </div>
+
+        <th:block th:unless="${register.phase == 'beta'}">
+          <div th:replace="fragments/phase-banner.html::phase"></div>
+        </th:block>
 
         <div class="grid-row">
           <div class="column-two-thirds">

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -7,10 +7,6 @@
 
     <div id="wrapper">
       <main id="main" role="main">
-        <th:block th:unless="${register.phase == 'beta'}">
-          <div th:replace="fragments/phase-banner.html::phase"></div>
-        </th:block>
-
         <div class="breadcrumbs">
           <ol>
             <li>
@@ -22,6 +18,10 @@
             <li th:text="${'Entry ' + content.entryNumber}"></li>
           </ol>
         </div>
+
+        <th:block th:unless="${register.phase == 'beta'}">
+          <div th:replace="fragments/phase-banner.html::phase"></div>
+        </th:block>
 
         <div class="grid-row">
           <div class="column-two-thirds">

--- a/src/main/resources/templates/item.html
+++ b/src/main/resources/templates/item.html
@@ -7,10 +7,6 @@
 
     <div id="wrapper">
       <main id="main" role="main">
-        <th:block th:unless="${register.phase == 'beta'}">
-          <div th:replace="fragments/phase-banner.html::phase"></div>
-        </th:block>
-
         <div class="breadcrumbs">
           <ol>
             <li>
@@ -19,6 +15,10 @@
             <li th:utext="${'Item ' + content.itemHash}"></li>
           </ol>
         </div>
+
+        <th:block th:unless="${register.phase == 'beta'}">
+          <div th:replace="fragments/phase-banner.html::phase"></div>
+        </th:block>
 
         <div class="grid-row">
           <div class="column-two-thirds">

--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -6,10 +6,7 @@
 <header th:replace="fragments/global-header.html::global-header"></header>
 
 <div id="wrapper">
-
   <main id="main" role="main">
-    <div th:replace="fragments/phase-banner.html::phase"></div>
-
     <div class="breadcrumbs">
       <ol>
         <li>
@@ -24,6 +21,10 @@
         </li>
       </ol>
     </div>
+
+    <th:block th:unless="${register.phase == 'beta'}">
+      <div th:replace="fragments/phase-banner.html::phase"></div>
+    </th:block>
 
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/src/main/resources/templates/record.html
+++ b/src/main/resources/templates/record.html
@@ -7,10 +7,6 @@
 
 <div id="wrapper">
   <main id="main" role="main">
-    <th:block th:unless="${register.phase == 'beta'}">
-      <div th:replace="fragments/phase-banner.html::phase"></div>
-    </th:block>
-
     <div class="breadcrumbs">
       <ol>
         <li>
@@ -22,6 +18,10 @@
         <li th:utext="${'Record ' + content.entryKey}"></li>
       </ol>
     </div>
+
+    <th:block th:unless="${register.phase == 'beta'}">
+      <div th:replace="fragments/phase-banner.html::phase"></div>
+    </th:block>
 
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/src/main/resources/templates/records.html
+++ b/src/main/resources/templates/records.html
@@ -6,12 +6,7 @@
 <header th:replace="fragments/global-header.html::global-header"></header>
 
 <div id="wrapper">
-
   <main id="main" role="main">
-    <th:block th:unless="${register.phase == 'beta'}">
-      <div th:replace="fragments/phase-banner.html::phase"></div>
-    </th:block>
-
     <div class="breadcrumbs">
       <ol>
         <li>
@@ -20,6 +15,10 @@
         <li>Records</li>
       </ol>
     </div>
+
+    <th:block th:unless="${register.phase == 'beta'}">
+      <div th:replace="fragments/phase-banner.html::phase"></div>
+    </th:block>
 
     <div class="grid-row">
       <div class="column-two-thirds">


### PR DESCRIPTION
- Moves breadcrumbs above "in progress" message below header
- Adds breadcrumbs to the downloads page and removes the back link so the page is consistent with the rest of the pages.
- Also ensures that the "in progress" info on the preview pages only shows for non-beta registers

### Before
<img width="928" alt="screen shot 2017-09-25 at 09 35 51" src="https://user-images.githubusercontent.com/3071606/30799491-f071c35c-a1d4-11e7-86c5-aba9961ac84e.png">
<img width="928" alt="screen shot 2017-09-25 at 09 35 43" src="https://user-images.githubusercontent.com/3071606/30799490-f070f508-a1d4-11e7-9165-f5af2c9ed905.png">



### After
<img width="928" alt="screen shot 2017-09-25 at 09 34 45" src="https://user-images.githubusercontent.com/3071606/30799466-d776d57c-a1d4-11e7-8477-aa8c348a5849.png">
<img width="928" alt="screen shot 2017-09-25 at 09 34 38" src="https://user-images.githubusercontent.com/3071606/30799467-d77adf64-a1d4-11e7-9ed5-90b8f3b97771.png">
