### PR TITLE
Ensure home page is wrapped inside main element

### DIFF
--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -6,91 +6,93 @@
     <header th:replace="fragments/global-header.html::global-header"></header>
 
     <div id="wrapper">
-      <th:block th:unless="${register.phase == 'beta'}">
-        <div th:unless="${register.phase == 'beta'}" th:replace="fragments/phase-banner.html::phase"></div>
-      </th:block>
+      <main id="main" role="main">
+        <th:block th:unless="${register.phase == 'beta'}">
+          <div th:unless="${register.phase == 'beta'}" th:replace="fragments/phase-banner.html::phase"></div>
+        </th:block>
 
-      <div class="grid-row">
+        <div class="grid-row">
 
-        <main class="column-two-thirds" id="main" role="main">
-          <h1 class="heading-large" th:utext="${friendlyRegisterName}"></h1>
-          <th:block th:utext="${registerText}"></th:block>
-          <p>
-            <a href="/records" class="button" role="button">View Register</a>
-          </p>
-          <p>The <span th:utext="${friendlyRegisterName}"></span> contains <span th:text="${totalRecords}"></span>
-            records and includes the following fields:</p>
-          <div th:replace="fragments/field-list.html::field-list(${fields})"></div>
+          <main class="column-two-thirds" id="main" role="main">
+            <h1 class="heading-large" th:utext="${friendlyRegisterName}"></h1>
+            <th:block th:utext="${registerText}"></th:block>
+            <p>
+              <a href="/records" class="button" role="button">View Register</a>
+            </p>
+            <p>The <span th:utext="${friendlyRegisterName}"></span> contains <span th:text="${totalRecords}"></span>
+              records and includes the following fields:</p>
+            <div th:replace="fragments/field-list.html::field-list(${fields})"></div>
 
-          <h3 class="heading-small">Using this register</h3>
-          <p th:replace="fragments/download-and-preview-home.html::download-and-preview-home"></p>
-          <p>Each register has an open API you can use to access the data without any authentication. There's more
-            information about using the register APIs in the <a th:href="${homepageContent.techDocsUrl}"
-                                                                target="_blank">technical documentation</a>.</p>
-          <p>If you're building a service, you can use this data to create elements for forms.</p>
-          <p>You might need to combine data from this register with data from another source to do this.</p>
-        </main>
+            <h3 class="heading-small">Using this register</h3>
+            <p th:replace="fragments/download-and-preview-home.html::download-and-preview-home"></p>
+            <p>Each register has an open API you can use to access the data without any authentication. There's more
+              information about using the register APIs in the <a th:href="${homepageContent.techDocsUrl}"
+                                                                  target="_blank">technical documentation</a>.</p>
+            <p>If you're building a service, you can use this data to create elements for forms.</p>
+            <p>You might need to combine data from this register with data from another source to do this.</p>
+          </main>
 
-        <div class="column-third">
-          <aside class="govuk-related-items" role="complementary">
-            <h2 class="heading-medium">About this register</h2>
-            <th:block th:if="${#bools.isTrue(custodianName.isPresent())}">
-              <h3 class="heading-small">Custodian</h3>
-              <p th:text="${custodianName.get()}"></p>
-            </th:block>
-            <th:block th:replace="fragments/attribution.html::attribution"></th:block>
-            <h3 class="heading-small">Last updated</h3>
-            <ul class="list">
-              <li th:text="${lastUpdatedTime}">Last updated</li>
-              <li>
-                <a href="/entries">View recent updates</a>
-              </li>
-            </ul>
-            <th:block th:unless="${registerLinks.registersLinkedTo.empty}">
-              <h3 class="medium-small">Links to</h3>
+          <div class="column-third">
+            <aside class="govuk-related-items" role="complementary">
+              <h2 class="heading-medium">About this register</h2>
+              <th:block th:if="${#bools.isTrue(custodianName.isPresent())}">
+                <h3 class="heading-small">Custodian</h3>
+                <p th:text="${custodianName.get()}"></p>
+              </th:block>
+              <th:block th:replace="fragments/attribution.html::attribution"></th:block>
+              <h3 class="heading-small">Last updated</h3>
               <ul class="list">
-                <li th:each="registerLinkTo : ${registerLinks.registersLinkedTo}">
-                  <a th:href="${registerResolver.baseUriFor(new uk.gov.register.core.RegisterName(registerLinkTo))}"
-                     th:text="${#strings.capitalize(registerLinkTo)} + ' register'"></a>
+                <li th:text="${lastUpdatedTime}">Last updated</li>
+                <li>
+                  <a href="/entries">View recent updates</a>
                 </li>
               </ul>
-            </th:block>
-            <th:block th:unless="${registerLinks.registersLinkedFrom.empty}">
-              <h3 class="medium-small">Links from</h3>
+              <th:block th:unless="${registerLinks.registersLinkedTo.empty}">
+                <h3 class="medium-small">Links to</h3>
+                <ul class="list">
+                  <li th:each="registerLinkTo : ${registerLinks.registersLinkedTo}">
+                    <a th:href="${registerResolver.baseUriFor(new uk.gov.register.core.RegisterName(registerLinkTo))}"
+                       th:text="${#strings.capitalize(registerLinkTo)} + ' register'"></a>
+                  </li>
+                </ul>
+              </th:block>
+              <th:block th:unless="${registerLinks.registersLinkedFrom.empty}">
+                <h3 class="medium-small">Links from</h3>
+                <ul class="list">
+                  <li th:each="registerLinkFrom : ${registerLinks.registersLinkedFrom}">
+                    <a th:href="${registerResolver.baseUriFor(new uk.gov.register.core.RegisterName(registerLinkFrom))}"
+                       th:text="${#strings.capitalize(registerLinkFrom)} + ' register'"></a>
+                  </li>
+                </ul>
+              </th:block>
+              <th:block th:unless="${homepageContent.similarRegisters.empty}">
+                <h3 class="heading-small">Similar registers</h3>
+                <ul class="list">
+                  <li th:each="similarRegister : ${homepageContent.similarRegisters}">
+                    <a th:href="${registerResolver.baseUriFor(new uk.gov.register.core.RegisterName(similarRegister))}"
+                       th:text="${#strings.capitalize(similarRegister)} + ' register'"></a>
+                  </li>
+                </ul>
+              </th:block>
+              <h3 class="heading-medium">More information</h3>
               <ul class="list">
-                <li th:each="registerLinkFrom : ${registerLinks.registersLinkedFrom}">
-                  <a th:href="${registerResolver.baseUriFor(new uk.gov.register.core.RegisterName(registerLinkFrom))}"
-                     th:text="${#strings.capitalize(registerLinkFrom)} + ' register'"></a>
+                <li th:if="${#bools.isTrue(homepageContent.registerHistoryPageUrl.isPresent())}">
+                  <a th:href="${homepageContent.registerHistoryPageUrl.get()}">Register history</a>
+                </li>
+                <li>
+                  <a th:href="${homepageContent.registersIntroductionUrl}">Introducing registers</a>
+                </li>
+                <li>
+                  <a th:href="${homepageContent.usingRegistersGuidanceUrl}">Guidance for using registers</a>
+                </li>
+                <li>
+                  <a th:href="${homepageContent.techDocsUrl}">Technical documentation</a>
                 </li>
               </ul>
-            </th:block>
-            <th:block th:unless="${homepageContent.similarRegisters.empty}">
-              <h3 class="heading-small">Similar registers</h3>
-              <ul class="list">
-                <li th:each="similarRegister : ${homepageContent.similarRegisters}">
-                  <a th:href="${registerResolver.baseUriFor(new uk.gov.register.core.RegisterName(similarRegister))}"
-                     th:text="${#strings.capitalize(similarRegister)} + ' register'"></a>
-                </li>
-              </ul>
-            </th:block>
-            <h3 class="heading-medium">More information</h3>
-            <ul class="list">
-              <li th:if="${#bools.isTrue(homepageContent.registerHistoryPageUrl.isPresent())}">
-                <a th:href="${homepageContent.registerHistoryPageUrl.get()}">Register history</a>
-              </li>
-              <li>
-                <a th:href="${homepageContent.registersIntroductionUrl}">Introducing registers</a>
-              </li>
-              <li>
-                <a th:href="${homepageContent.usingRegistersGuidanceUrl}">Guidance for using registers</a>
-              </li>
-              <li>
-                <a th:href="${homepageContent.techDocsUrl}">Technical documentation</a>
-              </li>
-            </ul>
-          </aside>
+            </aside>
+          </div>
         </div>
-      </div>
+      </main>
     </div>
 
     <footer th:replace="fragments/footer.html::footer"></footer>


### PR DESCRIPTION
This change was prompted because of the font size compared to the other pages - 16px vs 19px. By wrapping the page inside a `main` element we inherit the correct font size and improve accessibility 👍 

Thanks for spotting this @karlbaker02 

### Before
<img width="928" alt="screen shot 2017-09-25 at 09 44 04" src="https://user-images.githubusercontent.com/3071606/30799839-16a13afc-a1d6-11e7-95c3-cc61f863b15f.png">

### After
<img width="928" alt="screen shot 2017-09-25 at 09 43 18" src="https://user-images.githubusercontent.com/3071606/30799829-0c8d72d8-a1d6-11e7-9b9c-fd9d5316d3d9.png">
