### PR TITLE
Check that exceptions from ItemConverter do not affect all registers

### DIFF
--- a/src/main/java/uk/gov/register/exceptions/FieldConversionException.java
+++ b/src/main/java/uk/gov/register/exceptions/FieldConversionException.java
@@ -1,0 +1,7 @@
+package uk.gov.register.exceptions;
+
+public class FieldConversionException extends RuntimeException {
+    public FieldConversionException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/register/providers/ThrowableExceptionMapper.java
+++ b/src/main/java/uk/gov/register/providers/ThrowableExceptionMapper.java
@@ -3,11 +3,11 @@ package uk.gov.register.providers;
 import org.glassfish.jersey.server.ParamException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.register.exceptions.FieldConversionException;
 import uk.gov.register.views.ViewFactory;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.inject.Inject;
-import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -18,20 +18,28 @@ public class ThrowableExceptionMapper implements ExceptionMapper<Throwable> {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(ThrowableExceptionMapper.class);
 
-    private ViewFactory viewFactory;
+    private final ViewFactory viewFactory;
 
     @Inject
-    public ThrowableExceptionMapper(ViewFactory viewFactory) {
+    public ThrowableExceptionMapper(final ViewFactory viewFactory) {
         this.viewFactory = viewFactory;
     }
 
     @Override
-    public Response toResponse(Throwable exception) {
+    public Response toResponse(final Throwable exception) {
         if (exception instanceof ParamException.PathParamException) {
             return Response.status(Response.Status.NOT_FOUND)
                     .header(HttpHeaders.CONTENT_TYPE, ExtraMediaType.TEXT_HTML)
                     .entity(viewFactory.exceptionNotFoundView())
-                    .build();        }
+                    .build();
+        }
+
+        if (exception instanceof FieldConversionException) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .header(HttpHeaders.CONTENT_TYPE, ExtraMediaType.TEXT_HTML)
+                    .entity(viewFactory.exceptionFieldConversionView(exception.getMessage()))
+                    .build();
+        }
 
         LOGGER.error("Uncaught exception: {}", exception);
 

--- a/src/main/java/uk/gov/register/service/ItemConverter.java
+++ b/src/main/java/uk/gov/register/service/ItemConverter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterables;
 import org.jvnet.hk2.annotations.Service;
 import uk.gov.register.core.*;
+import uk.gov.register.exceptions.FieldConversionException;
 
 import java.util.Map;
 
@@ -13,18 +14,18 @@ import static uk.gov.register.core.Cardinality.ONE;
 @Service
 public class ItemConverter {
 
-    public Map<String, FieldValue> convertItem(Item item, final Map<String, Field> fieldsByName) {
+    public Map<String, FieldValue> convertItem(final Item item, final Map<String, Field> fieldsByName) {
         return item.getFieldsStream().collect(toMap(Map.Entry::getKey, e -> convert(e, fieldsByName)));
     }
 
-    FieldValue convert(Map.Entry<String, JsonNode> fieldNameToJson, Map<String, Field> fieldsByName) {
-        String fieldName = fieldNameToJson.getKey();
-        JsonNode value = fieldNameToJson.getValue();
+    FieldValue convert(final Map.Entry<String, JsonNode> fieldNameToJson, final Map<String, Field> fieldsByName) {
+        final String fieldName = fieldNameToJson.getKey();
+        final JsonNode value = fieldNameToJson.getValue();
         return convert(value, fieldsByName.get(fieldName));
     }
 
-    private FieldValue convert(JsonNode propertyJson, final Field field) {
-        Cardinality cardinality = field.getCardinality();
+    private FieldValue convert(final JsonNode propertyJson, final Field field) {
+        final Cardinality cardinality = field.getCardinality();
         if (cardinality == ONE) {
             return convertScalar(propertyJson, field);
         } else {
@@ -32,18 +33,25 @@ public class ItemConverter {
         }
     }
 
-    private FieldValue convertScalar(JsonNode value, Field field) {
-        if (field.getDatatype().getName().equals("curie")) {
-            if (value.textValue().contains(":")) {
-                return new LinkValue.CurieValue(value.textValue());
+    private FieldValue convertScalar(final JsonNode value, final Field field) {
+        try {
+            if (field.getDatatype().getName().equals("curie")) {
+                if (value.textValue().contains(":")) {
+                    return new LinkValue.CurieValue(value.textValue());
+                }
+
+                return new LinkValue(field.getRegister().get(), value.textValue());
+            } else if (field.getRegister().isPresent()) {
+                return new LinkValue(field.getRegister().get(), value.textValue());
+                //Note: the equals check below must be replaced with the specified datatype, instead of doing string comparision
+                // We should replace this once the datatype register is available
+            } else {
+                return new StringValue(value.textValue());
             }
-            return new LinkValue(field.getRegister().get(), value.textValue());
-        } else if (field.getRegister().isPresent()) {
-            return new LinkValue(field.getRegister().get(), value.textValue());
-            //Note: the equals check below must be replaced with the specified datatype, instead of doing string comparision
-            // We should replace this once the datatype register is available
-        } else {
-            return new StringValue(value.textValue());
+        } catch (final Exception exception) {
+            throw new FieldConversionException(
+                    String.format("Not possible to process the field (name, data-type, value): %s, %s, %s.",
+                            field.fieldName, field.getDatatype().getName(), value.textValue()));
         }
     }
 

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -63,6 +63,10 @@ public class ViewFactory {
         return exceptionView("Page not found", "If you entered a web address please check it was correct.");
     }
 
+    public ExceptionView exceptionFieldConversionView(final String message) {
+        return exceptionView("Invalid field value", message);
+    }
+
     public ExceptionView exceptionServerErrorView() {
         return exceptionView("Oops, looks like something went wrong", "500 error");
     }


### PR DESCRIPTION
Catching exception when there is an error converting the data.

Replacing message `500 Error` with `[ERROR] Not possible to process the field (name, data-type, value): organisation, curie, government-organisationD10.`