### PR TITLE
'turtle' URLs to 'ttl' URLs

### DIFF
--- a/src/main/java/uk/gov/register/resources/PreviewEntriesResource.java
+++ b/src/main/java/uk/gov/register/resources/PreviewEntriesResource.java
@@ -36,7 +36,7 @@ public class PreviewEntriesResource {
                 : register.getTotalEntries();
         final Collection<Entry> entries = register.getEntries(START, limit);
 
-        return viewFactory.previewEntriesPageView(entries, null, mediaType);
+        return viewFactory.previewEntriesPageView(entries, null, ExtraMediaType.transform(mediaType));
     }
 
     @GET
@@ -46,6 +46,6 @@ public class PreviewEntriesResource {
     public View jsonByKeyPreview(@PathParam("media-type") final String mediaType, @PathParam("entry-key") final int key) {
         final Collection<Entry> entries = Collections.singletonList(register.getEntry(key).orElseThrow(NotFoundException::new));
 
-        return viewFactory.previewEntriesPageView(entries, key, mediaType);
+        return viewFactory.previewEntriesPageView(entries, key, ExtraMediaType.transform(mediaType));
     }
 }

--- a/src/main/java/uk/gov/register/resources/PreviewItemsResource.java
+++ b/src/main/java/uk/gov/register/resources/PreviewItemsResource.java
@@ -33,6 +33,6 @@ public class PreviewItemsResource {
         final Item item = register.getItemBySha256(hash)
                 .orElseThrow(() -> new NotFoundException("No item found with item hash: " + itemHash));
 
-        return viewFactory.previewItemPageView(item, itemHash, mediaType);
+        return viewFactory.previewItemPageView(item, itemHash, ExtraMediaType.transform(mediaType));
     }
 }

--- a/src/main/java/uk/gov/register/resources/PreviewRecordsResource.java
+++ b/src/main/java/uk/gov/register/resources/PreviewRecordsResource.java
@@ -36,7 +36,7 @@ public class PreviewRecordsResource {
                 : register.getTotalRecords();
         final List<Record> records = register.getRecords(limit, DEFAULT_OFFSET);
 
-        return viewFactory.previewRecordsPageView(records, null, mediaType);
+        return viewFactory.previewRecordsPageView(records, null, ExtraMediaType.transform(mediaType));
     }
 
     @GET
@@ -47,6 +47,6 @@ public class PreviewRecordsResource {
         final List<Record> records = Collections.singletonList(register.getRecord(key)
                 .orElseThrow(() -> new NotFoundException("No records found with key: " + key)));
 
-        return viewFactory.previewRecordsPageView(records, key, mediaType);
+        return viewFactory.previewRecordsPageView(records, key, ExtraMediaType.transform(mediaType));
     }
 }

--- a/src/main/java/uk/gov/register/views/representations/ExtraMediaType.java
+++ b/src/main/java/uk/gov/register/views/representations/ExtraMediaType.java
@@ -16,4 +16,8 @@ public class ExtraMediaType {
     public static final MediaType TEXT_YAML_TYPE = new MediaType("text", "yaml", "UTF-8");
     public static final String APPLICATION_RSF = "application/uk-gov-rsf";
     public static final MediaType APPLICATION_RSF_TYPE = new MediaType("application", "uk-gov-rsf", "UTF-8");
+
+    public static String transform(final String mediaType) {
+        return "ttl".equals(mediaType) ? "turtle" : mediaType;
+    }
 }

--- a/src/main/resources/templates/fragments/download-and-preview-home.html
+++ b/src/main/resources/templates/fragments/download-and-preview-home.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-<div th:fragment="download-and-preview-home">
-  <p class="data-representations">
-    <th:block th:if="${totalRecords} le 5000">Download a copy of this register as</th:block>
-    <th:block th:if="${totalRecords} gt 5000">Download the first 5,000 records as</th:block>
-    <a href="/records.csv?page-size=5000" rel="alternate" class="js-download" data-download-type="CSV">CSV</a>,
-    <a href="/records.tsv?page-size=5000" rel="alternate" class="js-download" data-download-type="TSV">TSV</a> or as a
-    <a href="/records.csv?page-size=5000" rel="alternate" class="js-download" data-download-type="spreadsheet">spreadsheet</a>.
-    <th:block th:if="${totalRecords} le 100">You can also preview as</th:block>
-    <th:block th:if="${totalRecords} gt 100">You can also preview a sample as</th:block>
-    <a href="/preview-records/json">JSON</a>,
-    <a href="/preview-records/yaml">YAML</a> or
-    <a href="/preview-records/turtle">TTL</a>.
-  </p>
-</div>
+  <div th:fragment="download-and-preview-home">
+    <p class="data-representations">
+      <th:block th:if="${totalRecords} le 5000">Download a copy of this register as</th:block>
+      <th:block th:if="${totalRecords} gt 5000">Download the first 5,000 records as</th:block>
+      <a href="/records.csv?page-size=5000" rel="alternate" class="js-download" data-download-type="CSV">CSV</a>,
+      <a href="/records.tsv?page-size=5000" rel="alternate" class="js-download" data-download-type="TSV">TSV</a> or as a
+      <a href="/records.csv?page-size=5000" rel="alternate" class="js-download"
+         data-download-type="spreadsheet">spreadsheet</a>.
+      <th:block th:if="${totalRecords} le 100">You can also preview as</th:block>
+      <th:block th:if="${totalRecords} gt 100">You can also preview a sample as</th:block>
+      <a href="/preview-records/json">JSON</a>,
+      <a href="/preview-records/yaml">YAML</a> or
+      <a href="/preview-records/ttl">TTL</a>.
+    </p>
+  </div>
 </html>

--- a/src/main/resources/templates/fragments/download-and-preview-single.html
+++ b/src/main/resources/templates/fragments/download-and-preview-single.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-<div th:fragment="download-and-preview-single(records_or_entries_or_items_string)">
-  <p class="data-representations">
-    Download a copy as
-    <a th:href="${@uk.gov.register.util.HtmlViewSupport@representationLink(#httpServletRequest, 'csv')}">CSV</a>,
-    <a th:href="${@uk.gov.register.util.HtmlViewSupport@representationLink(#httpServletRequest, 'tsv')}">TSV</a> or as a
-    <a th:href="${@uk.gov.register.util.HtmlViewSupport@representationLink(#httpServletRequest, 'csv')}">spreadsheet</a>.
-    You can also preview as
-    <!--<span th:if="${#strings.equals(records_or_entries_or_items_string, 'records')}">-->
-    <a th:href="${'/preview-' + records_or_entries_or_items_string + '/json/' + (#strings.equals(records_or_entries_or_items_string, 'records') ? content.entryKey : (#strings.equals(records_or_entries_or_items_string, 'entries') ? content.entryNumber : content.itemHash))}">JSON</a>,
-    <a th:href="${'/preview-' + records_or_entries_or_items_string + '/yaml/' + (#strings.equals(records_or_entries_or_items_string, 'records') ? content.entryKey : (#strings.equals(records_or_entries_or_items_string, 'entries') ? content.entryNumber : content.itemHash))}">YAML</a>
-    or
-    <a th:href="${'/preview-' + records_or_entries_or_items_string + '/turtle/' + (#strings.equals(records_or_entries_or_items_string, 'records') ? content.entryKey : (#strings.equals(records_or_entries_or_items_string, 'entries') ? content.entryNumber : content.itemHash))}">TTL</a>
-  </p>
-</div>
+  <div th:fragment="download-and-preview-single(records_or_entries_or_items_string)">
+    <p class="data-representations">
+      Download a copy as
+      <a th:href="${@uk.gov.register.util.HtmlViewSupport@representationLink(#httpServletRequest, 'csv')}">CSV</a>,
+      <a th:href="${@uk.gov.register.util.HtmlViewSupport@representationLink(#httpServletRequest, 'tsv')}">TSV</a> or as a
+      <a th:href="${@uk.gov.register.util.HtmlViewSupport@representationLink(#httpServletRequest, 'csv')}">spreadsheet</a>.
+      You can also preview as
+      <!--<span th:if="${#strings.equals(records_or_entries_or_items_string, 'records')}">-->
+      <a th:href="${'/preview-' + records_or_entries_or_items_string + '/json/' + (#strings.equals(records_or_entries_or_items_string, 'records') ? content.entryKey : (#strings.equals(records_or_entries_or_items_string, 'entries') ? content.entryNumber : content.itemHash))}">JSON</a>,
+      <a th:href="${'/preview-' + records_or_entries_or_items_string + '/yaml/' + (#strings.equals(records_or_entries_or_items_string, 'records') ? content.entryKey : (#strings.equals(records_or_entries_or_items_string, 'entries') ? content.entryNumber : content.itemHash))}">YAML</a>
+      or
+      <a th:href="${'/preview-' + records_or_entries_or_items_string + '/ttl/' + (#strings.equals(records_or_entries_or_items_string, 'records') ? content.entryKey : (#strings.equals(records_or_entries_or_items_string, 'entries') ? content.entryNumber : content.itemHash))}">TTL</a>
+    </p>
+  </div>
 </html>

--- a/src/main/resources/templates/fragments/download-and-preview.html
+++ b/src/main/resources/templates/fragments/download-and-preview.html
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-<div th:fragment="download-and-preview(records_or_entries_string)">
-  <p class="data-representations">
-    <th:block th:if="${pagination.totalEntries} le 5000">Download a copy of this register as</th:block>
-    <th:block th:if="${pagination.totalEntries} gt 5000">Download the first 5,000 records as</th:block>
-    <a th:href="${'/' + records_or_entries_string + '.csv?page-size=5000'}" rel="alternate" class="js-download"
-       data-download-type="CSV">CSV</a>,
-    <a th:href="${'/' + records_or_entries_string + '.tsv?page-size=5000'}" rel="alternate" class="js-download"
-       data-download-type="TSV">TSV</a> or as a
-    <a th:href="${'/' + records_or_entries_string + '.csv?page-size=5000'}" rel="alternate" class="js-download"
-       data-download-type="spreadsheet">spreadsheet</a>.
-    <th:block th:if="${pagination.totalEntries} le 100">You can also preview as</th:block>
-    <th:block th:if="${pagination.totalEntries} gt 100">You can also preview a sample as</th:block>
-    <a th:href="${'/preview-' + records_or_entries_string + '/json'}">JSON</a>,
-    <a th:href="${'/preview-' + records_or_entries_string + '/yaml'}">YAML</a> or
-    <a th:href="${'/preview-' + records_or_entries_string + '/turtle'}">TTL</a>.
-  </p>
-</div>
+  <div th:fragment="download-and-preview(records_or_entries_string)">
+    <p class="data-representations">
+      <th:block th:if="${pagination.totalEntries} le 5000">Download a copy of this register as</th:block>
+      <th:block th:if="${pagination.totalEntries} gt 5000">Download the first 5,000 records as</th:block>
+      <a th:href="${'/' + records_or_entries_string + '.csv?page-size=5000'}" rel="alternate" class="js-download"
+         data-download-type="CSV">CSV</a>,
+      <a th:href="${'/' + records_or_entries_string + '.tsv?page-size=5000'}" rel="alternate" class="js-download"
+         data-download-type="TSV">TSV</a> or as a
+      <a th:href="${'/' + records_or_entries_string + '.csv?page-size=5000'}" rel="alternate" class="js-download"
+         data-download-type="spreadsheet">spreadsheet</a>.
+      <th:block th:if="${pagination.totalEntries} le 100">You can also preview as</th:block>
+      <th:block th:if="${pagination.totalEntries} gt 100">You can also preview a sample as</th:block>
+      <a th:href="${'/preview-' + records_or_entries_string + '/json'}">JSON</a>,
+      <a th:href="${'/preview-' + records_or_entries_string + '/yaml'}">YAML</a> or
+      <a th:href="${'/preview-' + records_or_entries_string + '/ttl'}">TTL</a>.
+    </p>
+  </div>
 </html>


### PR DESCRIPTION
URLs in the HTML pages are using the label 'turtle', they should be using 'ttl' that is the supported format and in this way be more intuitive.