### PR TITLE
Fix spacing issue

### DIFF
--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -35,9 +35,8 @@
         <p th:if="${!isSingleKey}">
           The are
           <th:block th:utext="${totalElements}"></th:block>
-          items
-          <th:block th:if="${totalObjects} gt 100">, this sample shows only the first 100</th:block>
-          .
+          items<th:block th:if="${totalObjects} gt 100">, this sample
+          shows only the first 100</th:block>.
         </p>
         <p th:if="${isSingleKey}">
           There is 1 item.


### PR DESCRIPTION
This page resulted in output with unusual spacing before the comma and
full stop:

     The are 4,848 items , this sample shows only the first 100 .

This example text is from:
https://public-body.alpha.openregister.org/preview-records/json

The spacing appears because there is a newline between the comma/full
stop and the previous word in each case.

This commit fixes the issue by ensuring that there is no whitespace
between the previous word and the tag, and no whitespace between the
tag and the comma/full stop.

(I haven't actually tested this - i got a weird compile error when trying to build locally)