### PR TITLE
Content updates for 3 register preview pages: JSON, YAML and TTL pages

### DIFF
--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -35,39 +35,35 @@
         <p th:if="${!isSingleKey}">
           There are
           <th:block th:utext="${totalElements}"></th:block>
-          items<th:block th:if="${totalObjects} gt 100">, this sample
-          shows only the first 100</th:block>.
+          items<th:block th:if="${totalObjects} gt 100">, this preview
+          only displays the first 100</th:block>.
         </p>
         <p th:if="${isSingleKey}">
-          There is 1 item.
+          There is one item.
         </p>
         <p>
-          <a th:href="${homepageContent.techDocsUrl}" target="_blank">View the API documentation</a>
-          to access <span th:if="${!isSingleKey}">these items</span><span th:if="${isSingleKey}">this item</span> or
+          To access <span th:text="${isSingleKey ? 'this item' : 'these items'}"></span>,
+          <a th:href="${homepageContent.techDocsUrl}" target="_blank">view the API documentation</a>
+          or
           <span th:if="${!isSingleKey or #strings.isEmpty(key)}">
             <a th:href="${urlMultipleElements + '?page-size=5000'}" rel="alternate" class="js-download"
-               th:attr="data-download-type=${previewTypeTag}">download a <th:block
-                th:utext="${previewTypeTag}"></th:block> file</a>
+               th:attr="data-download-type=${previewTypeTag}">download a <th:block th:utext="${previewTypeTag}"></th:block> file</a>
           </span>
           <span th:if="${isSingleKey and !#strings.isEmpty(key)}">
             <a th:href="${urlSingleElements}" rel="alternate" class="js-download"
-               th:attr="data-download-type=${previewTypeTag}">download a <th:block
-                th:utext="${previewTypeTag}"></th:block> file</a>
+               th:attr="data-download-type=${previewTypeTag}">download a
+              <th:block th:utext="${previewTypeTag}"></th:block> file</a>
           </span>
-          <span th:if="${isSingleKey}">with the item.</span>
-          <span th:if="${!isSingleKey}">
-            <span th:if="${totalObjects} le 5000">with the items.</span>
-            <span th:if="${totalObjects} gt 5000">with the first 5,000.</span>
-          </span>
+          <span th:text="${isSingleKey} ? 'with the item' : (${totalObjects} le 5000 ? 'with the items' : 'with the first 5,000 items')"></span>.
         </p>
       </div>
     </div>
     <div class="grid-row">
       <div class="column-full">
         <pre class="preview-box">
-          <code
-              th:class="${#strings.equals(previewTypeTag, 'YAML')} ? language-yaml : (${#strings.equals(previewTypeTag, 'TTL')} ? language-stylus : language-json)"><th:block
-              th:utext="${registerValues}"></th:block></code>
+          <code th:class="${#strings.equals(previewTypeTag, 'YAML')} ? language-yaml : (${#strings.equals(previewTypeTag, 'TTL')} ? language-stylus : language-json)">
+            <th:block th:utext="${registerValues}"></th:block>
+          </code>
         </pre>
       </div>
     </div>


### PR DESCRIPTION
Content changes:

**Case A**: 1 item
_Before_
<img width="644" alt="before_1" src="https://user-images.githubusercontent.com/6755821/31167032-a0785ada-a8e8-11e7-9a8f-3b632a77812f.png">

_After_
<img width="646" alt="after_1" src="https://user-images.githubusercontent.com/6755821/31167044-a503f2c6-a8e8-11e7-9273-f4e946ef5d76.png">

**Case B**: between 2 and 100 items
_Before_
<img width="635" alt="before_less_than_100" src="https://user-images.githubusercontent.com/6755821/31167086-c2876d64-a8e8-11e7-96a0-c41ae6d4735f.png">

_After_
<img width="643" alt="after_less_than_100" src="https://user-images.githubusercontent.com/6755821/31167090-c5a049f8-a8e8-11e7-8bbe-316fd771166c.png">

**Case C**: between 101 and 5000 items
_Before_
<img width="654" alt="before_1000" src="https://user-images.githubusercontent.com/6755821/31167116-da00e3c6-a8e8-11e7-990b-9d07ebd81040.png">

_After_
<img width="657" alt="after_1000" src="https://user-images.githubusercontent.com/6755821/31167120-df40dd8c-a8e8-11e7-8100-34140e6111ed.png">

**Case D**: More than 5000 items
_Before_
<img width="638" alt="before_more_than_5000" src="https://user-images.githubusercontent.com/6755821/31167485-23531e94-a8ea-11e7-84a6-b1007014dd96.png">

_After_
<img width="655" alt="after_more_than_5000" src="https://user-images.githubusercontent.com/6755821/31167488-27e0ab02-a8ea-11e7-8bef-2960766da9f1.png">

