### PR TITLE
Validate consecutive append entries

### DIFF
--- a/src/main/java/uk/gov/register/exceptions/EntryValidationException.java
+++ b/src/main/java/uk/gov/register/exceptions/EntryValidationException.java
@@ -1,0 +1,9 @@
+package uk.gov.register.exceptions;
+
+import uk.gov.register.core.Entry;
+
+public class EntryValidationException extends RuntimeException {
+	public EntryValidationException(Entry entry, String message) { 
+		super("Entry #" + entry.getEntryNumber() + " with key " + entry.getKey() + " - " + message); 
+	}
+}

--- a/src/main/java/uk/gov/register/providers/EntryValidationExceptionMapper.java
+++ b/src/main/java/uk/gov/register/providers/EntryValidationExceptionMapper.java
@@ -1,0 +1,15 @@
+package uk.gov.register.providers;
+
+import uk.gov.register.exceptions.EntryValidationException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class EntryValidationExceptionMapper implements ExceptionMapper<EntryValidationException> {
+	@Override
+	public Response toResponse(EntryValidationException exception) {
+		return Response.status(400).entity("Entry validation exception: " + exception.getMessage()).build();
+	}
+}

--- a/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
@@ -16,7 +16,7 @@ import java.util.*;
 import java.util.function.Function;
 
 public abstract class PostgresReadDataAccessLayer implements DataAccessLayer {
-    private final EntryQueryDAO entryQueryDAO;
+    protected final EntryQueryDAO entryQueryDAO;
     private final ItemQueryDAO itemQueryDAO;
     protected final IndexQueryDAO indexQueryDAO;
     protected final String schema;

--- a/src/test/java/uk/gov/register/db/InMemoryEntryDAO.java
+++ b/src/test/java/uk/gov/register/db/InMemoryEntryDAO.java
@@ -63,6 +63,11 @@ public class InMemoryEntryDAO implements EntryDAO, EntryQueryDAO {
     }
 
     @Override
+    public Collection<Entry> getEntriesByKeys(List<String> entryKeys, String schema, String entryTable, String entryItemTable) {
+        return entries.stream().filter(e -> entryKeys.contains(e.getKey())).collect(Collectors.toList());
+    }
+
+    @Override
     public ResultIterator<Entry> entriesIteratorFrom(int entryNumber, String schema) {
         return new FakeResultIterator(entries.subList(entryNumber-1, entries.size()).iterator());
     }

--- a/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
@@ -42,11 +42,7 @@ public class RegisterResourceFunctionalTest {
                 "add-item\t{\"address\":\"6789\"}\n" +
                 "append-entry\tuser\t6789\t2017-05-23T10:12:34Z\tsha-256:f715806d5b3a85ee3593f53653eb274188cf02de00d4a2064a2c8952617de7fe\n" +
                 "add-item\t{\"address\":\"145678\"}\n" +
-                "append-entry\tuser\t145678\t2017-05-23T10:12:34Z\tsha-256:921c14161f7c13a18a52e8418c0c69ac7211d40cbaf53c58513dc668d68376d8\n" +
-                "add-item\t{\"address\":\"145678\"}\n" +
-                "append-entry\tuser\t145678\t2017-05-23T10:12:34Z\tsha-256:921c14161f7c13a18a52e8418c0c69ac7211d40cbaf53c58513dc668d68376d8\n" +
-                "add-item\t{\"address\":\"6789\"}\n" +
-                "append-entry\tuser\t6789\t2017-05-23T10:12:34Z\tsha-256:f715806d5b3a85ee3593f53653eb274188cf02de00d4a2064a2c8952617de7fe";
+                "append-entry\tuser\t145678\t2017-05-23T10:12:34Z\tsha-256:921c14161f7c13a18a52e8418c0c69ac7211d40cbaf53c58513dc668d68376d8";
 
         register.loadRsf(address, payload);
 
@@ -55,7 +51,7 @@ public class RegisterResourceFunctionalTest {
 
         Map registerResourceMapFromAddressRegister = registerResourceFromAddressRegisterResponse.readEntity(Map.class);
 
-        assertThat(registerResourceMapFromAddressRegister.get("total-entries"), equalTo(5));
+        assertThat(registerResourceMapFromAddressRegister.get("total-entries"), equalTo(3));
         assertThat(registerResourceMapFromAddressRegister.get("total-records"), equalTo(3));
         assertThat(registerResourceMapFromAddressRegister.get("custodian"), equalTo("Stephen McAllister"));
         verifyStringIsAnISODate(registerResourceMapFromAddressRegister.get("last-updated").toString());

--- a/src/test/java/uk/gov/register/indexer/IndexDriverTest.java
+++ b/src/test/java/uk/gov/register/indexer/IndexDriverTest.java
@@ -118,11 +118,11 @@ public class IndexDriverTest {
         when(indexFunction.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(newEntry)))
                 .thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")), new IndexKeyItemPair("P", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
         
-        Map<String, Record> currentRecords = new HashMap<>();
-        currentRecords.put("A", new Record(previousEntry, itemP));
+        Map<String, Entry> currentEntries = new HashMap<>();
+        currentEntries.put("A", previousEntry);
 
         IndexDriver indexDriver = new IndexDriver();
-        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentRecords, 1);
+        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentEntries, 1);
 
         verify(dataAccessLayer, times(1)).start("by-x", "P", "bbb", 2, 2);
         verify(dataAccessLayer, times(1)).start(anyString(), anyString(), anyString(), anyInt(), anyInt());
@@ -147,11 +147,11 @@ public class IndexDriverTest {
         when(indexFunction.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(newEntry)))
                 .thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("P", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
         
-        Map<String, Record> currentRecords = new HashMap<>();
-        currentRecords.put("A", new Record(previousEntry, Arrays.asList(itemP, itemQ)));
+        Map<String, Entry> currentEntries = new HashMap<>();
+        currentEntries.put("A", previousEntry);
 
         IndexDriver indexDriver = new IndexDriver();
-        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentRecords, 2);
+        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentEntries, 2);
 
         verify(dataAccessLayer, times(1)).end("by-x", "A", "P", "aaa", 2, 3, 1);
         verify(dataAccessLayer, times(1)).end(anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
@@ -177,11 +177,11 @@ public class IndexDriverTest {
         when(indexFunction.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(newEntry)))
                 .thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("Q", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
 
-        Map<String, Record> currentRecords = new HashMap<>();
-        currentRecords.put("A", new Record(previousEntry, itemP));
+        Map<String, Entry> currentEntries = new HashMap<>();
+        currentEntries.put("A", previousEntry);
         
         IndexDriver indexDriver = new IndexDriver();
-        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentRecords, 1);
+        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentEntries, 1);
 
         verify(dataAccessLayer, times(1)).end("by-x", "A", "P", "aaa", 2, 2, 1);
         verify(dataAccessLayer, times(1)).start("by-x", "Q", "bbb", 2, 3);
@@ -209,11 +209,11 @@ public class IndexDriverTest {
         when(dataAccessLayer.getStartIndexEntryNumberAndExistingItemCount("by-x", "Q", "bbb")).thenReturn(new IndexEntryNumberItemCountPair(Optional.of(1), 1));
         when(dataAccessLayer.getStartIndexEntryNumberAndExistingItemCount("by-x", "P", "aaa")).thenReturn(new IndexEntryNumberItemCountPair(Optional.empty(), 0));
 
-        Map<String, Record> currentRecords = new HashMap<>();
-        currentRecords.put("A", new Record(previousEntry, itemQ));
+        Map<String, Entry> currentEntries = new HashMap<>();
+        currentEntries.put("A", previousEntry);
         
         IndexDriver indexDriver = new IndexDriver();
-        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentRecords, 0);
+        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentEntries, 0);
 
         verify(dataAccessLayer, times(1)).start("by-x", "P", "aaa", 2, 1);
         verify(dataAccessLayer, times(1)).end("by-x", "A", "Q", "bbb", 2, 2, 1);
@@ -240,11 +240,11 @@ public class IndexDriverTest {
         when(indexFunction.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(newEntry)))
                 .thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("P", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
         
-        Map<String, Record> currentRecords = new HashMap<>();
-        currentRecords.put("A", new Record(previousEntry, itemP));
+        Map<String, Entry> currentEntries = new HashMap<>();
+        currentEntries.put("A", previousEntry);
         
         IndexDriver indexDriver = new IndexDriver();
-        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentRecords, 1);
+        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentEntries, 1);
 
         verify(dataAccessLayer, times(1)).end("by-x", "A", "P", "aaa", 2, 2, 1);
         verify(dataAccessLayer, times(1)).start("by-x", "P", "bbb", 2, 2);
@@ -271,7 +271,7 @@ public class IndexDriverTest {
                 .thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")))));
         when(indexFunction.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(newEntry2)))
                 .thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("Q", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
-
+        
         IndexDriver indexDriver = new IndexDriver();
         indexDriver.indexEntry(dataAccessLayer, newEntry1, indexFunction, new HashMap<>(), 0);
         indexDriver.indexEntry(dataAccessLayer, newEntry2, indexFunction, new HashMap<>(), 1);
@@ -316,16 +316,16 @@ public class IndexDriverTest {
                 .thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("Q", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
         when(indexFunction.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(newEntry5)))
                 .thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("R", new HashValue(HashingAlgorithm.SHA256, "ccc")))));
-
-        Map<String, Record> currentRecordsAtEntry4 = new HashMap<>();
-        currentRecordsAtEntry4.put("C", new Record(newEntry3, itemS));
+        
+        Map<String, Entry> currentEntriesAtEntry4 = new HashMap<>();
+        currentEntriesAtEntry4.put("C", newEntry3);
         
         IndexDriver indexDriver = new IndexDriver();
         indexDriver.indexEntry(dataAccessLayer, newEntry1, indexFunction, new HashMap<>(), 0);
         indexDriver.indexEntry(dataAccessLayer, newEntry2, indexFunction, new HashMap<>(), 1);
         indexDriver.indexEntry(dataAccessLayer, newEntry3, indexFunction, new HashMap<>(), 2);
-        indexDriver.indexEntry(dataAccessLayer, newEntry4, indexFunction, currentRecordsAtEntry4, 3);
-        indexDriver.indexEntry(dataAccessLayer, newEntry5, indexFunction, new HashMap<>(), 4);
+        indexDriver.indexEntry(dataAccessLayer, newEntry4, indexFunction, currentEntriesAtEntry4, 3);
+        indexDriver.indexEntry(dataAccessLayer, newEntry5, indexFunction, currentEntriesAtEntry4, 4);
 
         verify(dataAccessLayer, times(1)).start("by-x", "P", "aaa", 1, 1);
         verify(dataAccessLayer, times(1)).start("by-x", "Q", "bbb", 2, 2);
@@ -359,33 +359,6 @@ public class IndexDriverTest {
         verify(dataAccessLayer, times(1)).start(anyString(), anyString(), anyString(), anyInt(), anyInt());
         verify(dataAccessLayer, times(0)).end(anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
     }
-
-    @Test
-    public void indexEntry_shouldEndIndexUsingNewIndexEntryNumber_whenItemExistsUnderAnExistingSingleIndex() throws IOException {
-        Item item = new Item(new HashValue(HashingAlgorithm.SHA256, "aaa"), objectMapper.readTree("{\"x\":\"P\"}"));
-
-        Entry previousEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "B", EntryType.user);
-        Entry newEntry = new Entry(3, new HashValue(HashingAlgorithm.SHA256, "aaa"), Instant.now(), "B", EntryType.user);
-
-        when(dataAccessLayer.getItemBySha256(new HashValue(HashingAlgorithm.SHA256, "aaa"))).thenReturn(Optional.of(item));
-        when(dataAccessLayer.getStartIndexEntryNumberAndExistingItemCount("by-x", "P", "aaa")).thenReturn(new IndexEntryNumberItemCountPair(Optional.of(2), 1));
-        IndexFunction indexFunction = mock(IndexFunction.class);
-        when(indexFunction.getName()).thenReturn("by-x");
-        when(indexFunction.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(previousEntry)))
-                .thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("P", new HashValue(HashingAlgorithm.SHA256, "aaa")))));
-        when(indexFunction.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(newEntry)))
-                .thenReturn(new HashSet<>());
-        
-        Map<String, Record> currentRecords = new HashMap<>();
-        currentRecords.put("B", new Record(previousEntry, item));
-
-        IndexDriver indexDriver = new IndexDriver();
-        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentRecords, 2);
-
-        verify(dataAccessLayer, times(1)).end("by-x", "B", "P", "aaa", 3, 3, 2);
-        verify(dataAccessLayer, times(1)).end(anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
-        verify(dataAccessLayer, times(0)).start(anyString(), anyString(), anyString(), anyInt(), anyInt());
-    }
     
     @Test
     public void indexEntry_shouldEndIndexUsingStartEntryNumber_whenItemExistsUnderMultipleExistingIndexes() throws IOException {
@@ -408,11 +381,11 @@ public class IndexDriverTest {
         when(indexFunction.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(newEntry)))
                 .thenReturn(new HashSet<>(Arrays.asList(new IndexKeyItemPair("Q", new HashValue(HashingAlgorithm.SHA256, "bbb")))));
 
-        Map<String, Record> currentRecords = new HashMap<>();
-        currentRecords.put("B", new Record(previousEntry1, itemP));
+        Map<String, Entry> currentEntries = new HashMap<>();
+        currentEntries.put("B", previousEntry1);
 
         IndexDriver indexDriver = new IndexDriver();
-        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentRecords, 1);
+        indexDriver.indexEntry(dataAccessLayer, newEntry, indexFunction, currentEntries, 1);
 
         verify(dataAccessLayer, times(1)).end("by-x", "B", "P", "aaa", 4, 1, 1);
         verify(dataAccessLayer, times(1)).start("by-x", "Q", "bbb", 4, 2);


### PR DESCRIPTION
This PR adds validation to ensure that identical `append-entry` commands result in a validation error when calling `load-rsf`. The reason for this is because we do not want to append an entry to a register if there is no change from the item(s) assigned against the previous entry for the same key. Doing this ensures that any consumers of the API do not write duplicate data to registers.