### PR TITLE
Accessibility fixes

### DIFF
--- a/src/main/resources/assets/sass/main.scss
+++ b/src/main/resources/assets/sass/main.scss
@@ -315,3 +315,13 @@ dl {
 pre {
     margin: 0;
 }
+
+.open-government-licence {
+  .logo {
+    background: image-url("images/open-government-licence.png") 0 0 no-repeat;
+	@include device-pixel-ratio() {
+	  background-image: image-url("images/open-government-licence_2x.png");
+	  background-size: 41px 17px;
+	}
+  }
+}

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -11,11 +11,7 @@
             <div th:replace="fragments/copyright.html::copyright">Copyright text</div>
           </div>
             <div th:unless="${renderedCopyrightText.present}" class="open-government-licence">
-              <p class="logo">
-                <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">
-                  Open Government Licence
-                </a>
-              </p>
+              <span class="logo"></span>
               <p>
                 All content is available under the
                 <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -23,7 +23,7 @@
               records and includes the following fields:</p>
             <div th:replace="fragments/field-list.html::field-list(${fields})"></div>
 
-            <h3 class="heading-small">Using this register</h3>
+            <h2>Using this register</h2>
             <p th:replace="fragments/download-and-preview-home.html::download-and-preview-home"></p>
             <p>Each register has an open API you can use to access the data without any authentication. There's more
               information about using the register APIs in the <a th:href="${homepageContent.techDocsUrl}"


### PR DESCRIPTION
This commit makes two accessibility fixes: to change the 'Using this register' heading on each register homepage from a `h3` to a `h2`, and to remove the link from the OGL logo in the page footer.

**Heading change:**

Before:

![screen shot 2017-10-16 at 12 03 12](https://user-images.githubusercontent.com/5422487/31609654-f9f69170-b26c-11e7-9f57-dde443ac159c.png)

After:

![screen shot 2017-10-16 at 12 05 20](https://user-images.githubusercontent.com/5422487/31609664-03d19f8c-b26d-11e7-825f-454de30912ec.png)

**OGL logo link change:**

Before:

![screen shot 2017-10-16 at 12 06 26](https://user-images.githubusercontent.com/5422487/31609677-0da34c54-b26d-11e7-93ce-e4f6ed1588a2.png)

After:

![screen shot 2017-10-16 at 12 12 52](https://user-images.githubusercontent.com/5422487/31609685-1738d324-b26d-11e7-9f74-7ef6d3f776a1.png)

