### PR TITLE
Call getEntriesByKeys for each key batch

### DIFF
--- a/src/main/java/uk/gov/register/store/postgres/PostgresDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDataAccessLayer.java
@@ -297,7 +297,7 @@ public class PostgresDataAccessLayer extends PostgresReadDataAccessLayer impleme
 
         List<List<String>> entryKeyBatches = Lists.partition(entryKeys, 1000);
         entryKeyBatches.stream().forEach(keyBatches -> {
-            entries.addAll(entryQueryDAO.getEntriesByKeys(entryKeys, schema, entryTable, entryItemTable));
+            entries.addAll(entryQueryDAO.getEntriesByKeys(keyBatches, schema, entryTable, entryItemTable));
         });
 
         return entries.stream().collect(Collectors.toMap(k -> k.getKey(), e -> e, (e1, e2) -> e2));


### PR DESCRIPTION
This PR changes the invocation of `getEntriesByKeys` to pass in the entry keys that have been generated in batches of 1000, as opposed to passing in all of the entry keys (as this defeats the purpose of batching for performace reasons).