### PR TITLE
Add the-electoral-commission to public-bodies

### DIFF
--- a/src/main/resources/config/public-bodies.yaml
+++ b/src/main/resources/config/public-bodies.yaml
@@ -2851,3 +2851,6 @@ health-and-social-care-information-centre:
 department-for-business-energy-and-industrial-strategy:
   name: "Department for Business, Energy & Industrial Strategy"
   public-body: "department-for-business-energy-and-industrial-strategy"
+the-electoral-commission:
+  name: "The Electoral Commission"
+  public-body: "the-electoral-commission"


### PR DESCRIPTION
This PR adds `the-electoral-commission` to `public-bodies.yaml`, as it is defined as the registry by the new `westminster-parliamentary-constituency` register.