### PR TITLE
Add Department for Communities (Northern Ireland) as new registry

### DIFF
--- a/src/main/resources/config/public-bodies.yaml
+++ b/src/main/resources/config/public-bodies.yaml
@@ -2854,3 +2854,6 @@ department-for-business-energy-and-industrial-strategy:
 the-electoral-commission:
   name: "The Electoral Commission"
   public-body: "the-electoral-commission"
+department-for-communities-northern-ireland:
+  name: "Department for Communities (Northern Ireland)"
+  public-body: "department-for-communities-northern-ireland" 


### PR DESCRIPTION
This PR adds Department for Communities (Northern Ireland) as a new registry, which is required by the `local-authority-nir` register.