### PR TITLE
Fix run-application.sh script

### DIFF
--- a/run-application.sh
+++ b/run-application.sh
@@ -36,6 +36,8 @@ function do_nothing_forever {
 
 trap on_exit EXIT
 
+git submodule update --init
+
 if [ ! -e "./deploy/openregister-java.jar" ]
 then
   docker run \


### PR DESCRIPTION
Context: `run-application.sh` failed to run in a clean enviornment due
to missing dependencies stored in git submodules.

Solution: Now `run-application.sh` initialises _and_ updates git
submodules before doing any other work.