### PR TITLE
Include download analytics JS on all pages

### DIFF
--- a/src/main/resources/templates/download.html
+++ b/src/main/resources/templates/download.html
@@ -57,10 +57,5 @@
     </div>
 
     <footer th:replace="fragments/footer.html::footer"></footer>
-
-    <th:block th:if="${registerTrackingId.present}">
-      <script type="text/javascript" src="/assets/js/analytics-download-type.js"></script>
-    </th:block>
-
   </body>
 </html>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -35,6 +35,7 @@
       <script id="analytics-tracking-id" src="/analytics-code.js"></script>
       <script id="analytics-main" type="text/javascript" src="/assets/js/analytics.js"></script>
       <script id="analytics-external-links" type="text/javascript" src="/assets/js/analytics-external-links.js"></script>
+      <script id="analytics-download-types" type="text/javascript" src="/assets/js/analytics-download-type.js"></script>
     </th:block>
   </footer>
 </body>

--- a/src/test/java/uk/gov/register/functional/AnalyticsFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/AnalyticsFunctionalTest.java
@@ -2,7 +2,9 @@ package uk.gov.register.functional;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import uk.gov.register.functional.app.RegisterRule;
@@ -16,7 +18,6 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.register.views.representations.ExtraMediaType.TEXT_HTML;
 
@@ -103,9 +104,11 @@ public class AnalyticsFunctionalTest {
         Boolean docIncludesAnalyticsId = doc.getElementById("analytics-tracking-id") != null;
         Boolean docIncludesMainAnalytics = doc.getElementById("analytics-main") != null;
         Boolean docIncludesExtLinksAnalytics = doc.getElementById("analytics-external-links") != null;
+        Boolean docIncludesDownloadTypes = doc.getElementById("analytics-download-types") != null;
 
         assertThat(docIncludesAnalyticsId, equalTo(shouldIncludeAnalytics));
         assertThat(docIncludesMainAnalytics, equalTo(shouldIncludeAnalytics));
         assertThat(docIncludesExtLinksAnalytics, equalTo(shouldIncludeAnalytics));
+        assertThat(docIncludesDownloadTypes, equalTo(shouldIncludeAnalytics));
     }
 }


### PR DESCRIPTION
This PR adds `analytics-download-type.js` to all pages as part of the footer, so long as the `trackingId` is present in the register config. It is currently only included in `download.html`, which we have moved away from using, meaning that since this change we have had no analytics for download events; this PR fixes this;