### PR TITLE
Remove statistical-geography-council-area-sct from discovery

### DIFF
--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -31,7 +31,6 @@ applications:
     - qualification-level
     - qualification-subject
     - qualification-type
-    - statistical-geography-council-area-sct
     - street-custodian
     - street
     - uk


### PR DESCRIPTION
This register now exists in alpha so no longer needs to exist
in discovery.