### PR TITLE
Remove allergen from discovery as it has been promoted to alpha

### DIFF
--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -11,7 +11,6 @@ applications:
     - discovery.openregister.org
   hosts:
     - address
-    - allergen
     - approved-meat-establishment
     - charity
     - charity-class


### PR DESCRIPTION
### Context
The `allergen` register has been promoted to alpha from discovery so can be removed from discovery.

### Changes proposed in this pull request
Remove the `allergen` host from the discovery manifest.

### Guidance to review
