### PR TITLE
Rename public-body registers

### DIFF
--- a/deploy/manifests/alpha/multi.yml
+++ b/deploy/manifests/alpha/multi.yml
@@ -15,8 +15,8 @@ applications:
     - local-authority-nir
     - occupation
     - principal-local-authority
-    - public-body
-    - public-body-classification
+    - public-body-account
+    - public-body-account-classification
     - school-eng
     - school-type-eng
     - social-housing-provider-designation


### PR DESCRIPTION
### Context
The public-body custodian has agreed to rename the public-body registers.

### Changes proposed in this pull request
- public-body becomes public-body-account
- public-body-classification becomes public-body-account-classification

### Guidance to review
This should remove the public-body and public-body-classification registers and create public-body-account and public-body-account-classification.
