### PR TITLE
Create local-authority-nir register in beta

### DIFF
--- a/deploy/manifests/beta/multi.yml
+++ b/deploy/manifests/beta/multi.yml
@@ -17,6 +17,7 @@ applications:
     - government-service
     - internal-drainage-board
     - local-authority-eng
+    - local-authority-nir
     - local-authority-sct
     - local-authority-type
     - principal-local-authority


### PR DESCRIPTION
### Context
We have approval to promote local-authority-nir from alpha to beta.

### Changes proposed in this pull request
Deploy local-authority-nir in beta but leave the alpha one running until we have successfully created it in beta. There will be a separate PR to remove from alpha.

### Guidance to review
This has been added to the PaaS manifest for beta.