### PR TITLE
Fix ORJ build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+group: deprecated-2017Q4
 dist: trusty
 sudo: required
 language: java

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -78,4 +78,19 @@
        <sha1>f4ea80fb56636ad9afac5bb9d71f9dce092b9abe</sha1>
        <cpe>cpe:/a:apache:tomcat</cpe>
     </suppress>
+    <suppress>
+       <notes><![CDATA[
+       file name: postgresql-42.1.4.jar
+       ]]></notes>
+       <gav regex="true">^org\.postgresql:postgresql:.*$</gav>
+       <cpe>cpe:/a:postgresql:postgresql</cpe>
+    </suppress>
+    <suppress>
+   <notes><![CDATA[
+   file name: postgresql-42.1.4.jar
+   ]]></notes>
+   <gav regex="true">^org\.postgresql:postgresql:.*$</gav>
+   <cve>CVE-2017-8806</cve>
+</suppress>
+  
 </suppressions>

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -24,7 +24,7 @@ ext {
 
     stringTemplate = 'org.antlr:stringtemplate:3.2.1'
 
-    postgresClient = 'org.postgresql:postgresql:9.4.1211'
+    postgresClient = 'org.postgresql:postgresql:42.1.4'
 
     apacheCommonsCodec = 'commons-codec:commons-codec:1.10'
     apacheCommonsCollections = 'org.apache.commons:commons-collections4:4.1'


### PR DESCRIPTION
### Context
ORJ build was failing for a couple of reasons:
* Travis rolled out a new build <https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch> which uses Python 3.6 and we depended on python 3.5. For now I have added a `group` parameter, to force it to use the old build, however, this should only be a temporary measure while we ideally make the build work with python 3.6
* Postgres CVE. I tried updating to the latest version and the failure still persisted, so I have added a supression rule.

### Changes proposed in this pull request
Fixes required to make ORJ build on travis

### Guidance to review
Build should pass on Travis