### PR TITLE
link urls if datatype url

### DIFF
--- a/src/main/java/uk/gov/register/core/LinkResolver.java
+++ b/src/main/java/uk/gov/register/core/LinkResolver.java
@@ -7,4 +7,6 @@ public interface LinkResolver {
         return resolve(linkValue.getTargetRegister(), linkValue.getLinkKey());
     }
     URI resolve(RegisterName register, String linkKey);
+
+    URI resolve(UrlValue urlValue);
 }

--- a/src/main/java/uk/gov/register/core/UriTemplateLinkResolver.java
+++ b/src/main/java/uk/gov/register/core/UriTemplateLinkResolver.java
@@ -22,4 +22,9 @@ public class UriTemplateLinkResolver implements LinkResolver {
 
         return UriBuilder.fromUri(baseUri).path("record").path(linkKey).build();
     }
+
+    @Override
+    public URI resolve(UrlValue urlValue) {
+        return URI.create(urlValue.getValue());
+    }
 }

--- a/src/main/java/uk/gov/register/core/UrlValue.java
+++ b/src/main/java/uk/gov/register/core/UrlValue.java
@@ -1,0 +1,28 @@
+package uk.gov.register.core;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import javax.validation.constraints.NotNull;
+
+public class UrlValue implements FieldValue {
+    @NotNull
+    public final String value;
+
+    public UrlValue(@NotNull String value) {
+        this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public boolean isLink() {
+        return true;
+    }
+
+    public boolean isList() {
+        return false;
+    }
+}

--- a/src/main/java/uk/gov/register/service/ItemConverter.java
+++ b/src/main/java/uk/gov/register/service/ItemConverter.java
@@ -41,7 +41,11 @@ public class ItemConverter {
                 }
 
                 return new LinkValue(field.getRegister().get(), value.textValue());
-            } else if (field.getRegister().isPresent()) {
+            }
+            else if (field.getDatatype().getName().equals("url")) {
+                return new UrlValue(value.textValue());
+            }
+            else if (field.getRegister().isPresent()) {
                 return new LinkValue(field.getRegister().get(), value.textValue());
                 //Note: the equals check below must be replaced with the specified datatype, instead of doing string comparision
                 // We should replace this once the datatype register is available

--- a/src/test/java/uk/gov/register/core/UriTemplateLinkResolverTest.java
+++ b/src/test/java/uk/gov/register/core/UriTemplateLinkResolverTest.java
@@ -21,6 +21,14 @@ public class UriTemplateLinkResolverTest {
     }
 
     @Test
+    public void urlValueReturnsLink() {
+        UrlValue urlValue = new UrlValue("http://www.example.com");
+
+        assertThat(localResolver.resolve(urlValue), is(URI.create("http://www.example.com")));
+        assertThat(prodResolver.resolve(urlValue), is(URI.create("http://www.example.com")));
+    }
+
+    @Test
     public void curieValueReturnsCorrectLink() {
         LinkValue.CurieValue charityCurieValue = new LinkValue.CurieValue("charity:123456");
         LinkValue.CurieValue companyCurieValue = new LinkValue.CurieValue("company:654321");

--- a/src/test/java/uk/gov/register/service/ItemConverterTest.java
+++ b/src/test/java/uk/gov/register/service/ItemConverterTest.java
@@ -95,4 +95,22 @@ public class ItemConverterTest {
         assertThat(result, instanceOf(LinkValue.CurieValue.class));
         assertThat(result.getValue(), equalTo("business:13245"));
     }
+    @Test
+    public void convert_shouldConvertEntryToUrlValue() {
+        JsonNode jsonNode = mock(JsonNode.class);
+        when(jsonNode.textValue()).thenReturn("http://www.example.com");
+        Map.Entry<String, JsonNode> entry = mock(Map.Entry.class);
+        when(entry.getKey()).thenReturn("website");
+        when(entry.getValue()).thenReturn(jsonNode);
+        Field websiteField = new Field("website", "url", new RegisterName("company"), Cardinality.ONE, "A Limited Company ...");
+        Map<String, Field> fieldsByName = ImmutableMap.of("website", websiteField);
+
+
+        FieldValue result = itemConverter.convert(entry, fieldsByName);
+
+        assertThat(result, instanceOf(UrlValue.class));
+        assertThat(result.getValue(), equalTo("http://www.example.com"));
+    }
+
+
 }


### PR DESCRIPTION
### Context
As requested by custodian

### Changes proposed in this pull request
Add hyperlink if field datatype is URL. Note, this will only be linked on the `/record` page and not on `/records` as per other link types.

### Guidance to review
Load record page for record with URL field, should link to URL.
<img width="1173" alt="screen shot 2017-12-13 at 14 40 37" src="https://user-images.githubusercontent.com/1764158/33944306-ab919596-e013-11e7-874f-e1402d7daa53.png">

