### PR TITLE
use .local rather than .dev for local TLD

### DIFF
--- a/config.docker.basic.yaml
+++ b/config.docker.basic.yaml
@@ -24,7 +24,7 @@ server:
     appenders:
       - type: access-logstash-console
 
-registerDomain: openregister.dev:8080
+registerDomain: openregister.local:8080
 
 register: register
 

--- a/config.docker.register.yaml
+++ b/config.docker.register.yaml
@@ -21,7 +21,7 @@ server:
     appenders:
       - type: access-logstash-console
 
-registerDomain: openregister.dev:8080
+registerDomain: openregister.local:8080
 
 register: country
 schema: country

--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,7 @@ server:
     - type: http
       port: 9092
 
-registerDomain: openregister.dev:8080
+registerDomain: openregister.local:8080
 
 register: school
 


### PR DESCRIPTION
### Context
Google has registered `.dev` TLD and put the entire TLD on the HSTS pre-load list. This means in a few weeks once browser updates land non-secure requests to this TLD will start being rejected.
More details: https://medium.engineering/use-a-dev-domain-not-anymore-95219778e6fd

### Changes proposed in this pull request
Switch default local TLD to `.local` as this is TLD is reserved by ICANN. See https://security.stackexchange.com/a/14805

### Guidance to review
Running ORJ locally should link to e.g.  `field.openregister.local` 
You will need to update any entries in your `/etc/hosts` file to resolve this domain.
