### PR TITLE
Remove statistical geography registers from alpha

### DIFF
--- a/deploy/manifests/alpha/multi.yml
+++ b/deploy/manifests/alpha/multi.yml
@@ -21,14 +21,6 @@ applications:
     - social-housing-provider-legal-entity-eng
     - social-housing-provider-eng
     - statistical-geography-council-area-sct
-    - statistical-geography-county-eng
-    - statistical-geography-london-borough-eng
-    - statistical-geography-metropolitan-counties-eng
-    - statistical-geography-metropolitan-district-eng
-    - statistical-geography-registration-district-eng
-    - statistical-geography-registration-district-wls
-    - statistical-geography-non-metropolitan-district-eng
-    - statistical-geography-unitary-authority-eng
   services:
     - alpha-db
     - logit-ssl-drain


### PR DESCRIPTION
### Context
Remove unrequired registers from alpha.

### Changes proposed in this pull request
Remove the following registers from alpha:

- statistical-geography-county-eng		
- statistical-geography-london-borough-eng		
- statistical-geography-metropolitan-counties-eng		
- statistical-geography-metropolitan-district-eng		
- statistical-geography-registration-district-eng		
- statistical-geography-registration-district-wls		
- statistical-geography-non-metropolitan-district-eng		
- statistical-geography-unitary-authority-eng

### Guidance to review
All registers have been promoted to beta except for `statistical-geography-metropolitan-counties-eng`, which is no longer a register we're working on.