### PR TITLE
Create jobcentre-* and qualification-* registers in alpha

### DIFF
--- a/deploy/manifests/alpha/multi.yml
+++ b/deploy/manifests/alpha/multi.yml
@@ -12,9 +12,16 @@ applications:
   hosts:
     - allergen
     - industrial-classification
+    - jobcentre
+    - jobcentre-district
+    - jobcentre-group
     - occupation
     - public-body-account
     - public-body-account-classification
+    - qualification-assessment-method
+    - qualification-level
+    - qualification-sector-subject-area
+    - qualification-type
     - school-eng
     - school-type-eng
     - social-housing-provider-designation-eng


### PR DESCRIPTION
### Context
Promote `jobcentre-*` and `qualification-*` to alpha. They will be removed from discovery in a separate PR.

### Changes proposed in this pull request
Create the following registers in alpha:

- jobcentre
- jobcentre-district
- jobcentre-group
- qualification-assessment-method
- qualification-level
- qualification-sector-subject-area
- qualification-type

### Guidance to review
https://trello.com/c/mqme6ZLm
https://trello.com/c/LhuqthJP