### PR TITLE
Remove qualification-* and jobcentre registers from discovery

### DIFF
--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -16,7 +16,6 @@ applications:
     - charity-class
     - clinical-commissioning-group
     - green-deal-certification-body
-    - jobcentre
     - meat-establishment-operation
     - meat-establishment-outcome
     - meat-establishment-type
@@ -24,10 +23,6 @@ applications:
     - police-force
     - police-neighbourhood
     - prison
-    - qualification-assessment-method
-    - qualification-level
-    - qualification-subject
-    - qualification-type
     - street-custodian
     - street
     - uk


### PR DESCRIPTION
### Context
`qualification-*` and `jobcentre-*` registers have been promoted to alpha.

### Changes proposed in this pull request
Remove the following registers from discovery:

- jobcentre
- qualification-assessment-method		
- qualification-level		
- qualification-subject		
- qualification-type

### Guidance to review
https://trello.com/c/LhuqthJP
https://trello.com/c/mqme6ZLm