### PR TITLE
Use existing DBIHealthCheck

### DIFF
--- a/deploy/manifests/alpha/basic.yml
+++ b/deploy/manifests/alpha/basic.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   buildpack: java_buildpack
   health-check-type: http
-  health-check-http-endpoint: /records
+  health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   domains:
     - alpha.openregister.org

--- a/deploy/manifests/alpha/multi.yml
+++ b/deploy/manifests/alpha/multi.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   buildpack: java_buildpack
   health-check-type: http
-  health-check-http-endpoint: /records
+  health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   domains:
     - alpha.openregister.org

--- a/deploy/manifests/beta/basic.yml
+++ b/deploy/manifests/beta/basic.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   buildpack: java_buildpack
   health-check-type: http
-  health-check-http-endpoint: /records
+  health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   domains:
     - beta.openregister.org

--- a/deploy/manifests/beta/multi.yml
+++ b/deploy/manifests/beta/multi.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   buildpack: java_buildpack
   health-check-type: http
-  health-check-http-endpoint: /records
+  health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   domains:
     - beta.openregister.org

--- a/deploy/manifests/discovery/basic.yml
+++ b/deploy/manifests/discovery/basic.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   buildpack: java_buildpack
   health-check-type: http
-  health-check-http-endpoint: /records
+  health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   domains:
     - discovery.openregister.org

--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   buildpack: java_buildpack
   health-check-type: http
-  health-check-http-endpoint: /records
+  health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   domains:
     - discovery.openregister.org

--- a/deploy/manifests/test/basic.yml
+++ b/deploy/manifests/test/basic.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   buildpack: java_buildpack
   health-check-type: http
-  health-check-http-endpoint: /records
+  health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   domains:
     - test.openregister.org

--- a/deploy/manifests/test/multi.yml
+++ b/deploy/manifests/test/multi.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   buildpack: java_buildpack
   health-check-type: http
-  health-check-http-endpoint: /records
+  health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   domains:
     - test.openregister.org

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: change-me
   memory: 512M
   buildpack: java_buildpack
-  health-check-http-endpoint: /records
+  health-check-http-endpoint: /healthcheck
   services:
     - change-me-db
   env:

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -1,5 +1,6 @@
 package uk.gov.register;
 
+import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.Application;
@@ -125,11 +126,11 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         environment.servlets()
                 .addFilter("HttpToHttpsRedirectFilter", new HttpToHttpsRedirectFilter())
                 .addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");
-
+        
         jersey.register(new AbstractBinder() {
             @Override
             protected void configure() {
-
+                bind(environment.healthChecks()).to(HealthCheckRegistry.class);
                 bind(allTheRegisters);
                 bindFactory(Factories.RegisterContextProvider.class).to(RegisterContext.class)
                         .to(RegisterTrackingConfiguration.class).to(DeleteRegisterDataConfiguration.class)

--- a/src/main/java/uk/gov/register/resources/HealthCheckResource.java
+++ b/src/main/java/uk/gov/register/resources/HealthCheckResource.java
@@ -1,0 +1,32 @@
+package uk.gov.register.resources;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public class HealthCheckResource {
+	private final HealthCheckRegistry healthCheckRegistry;
+	
+	@Inject
+	public HealthCheckResource(HealthCheckRegistry healthCheckRegistry) {
+		this.healthCheckRegistry = healthCheckRegistry;
+	}
+	
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	@Path("/healthcheck")
+	public Response getCurrentHealth() {
+		HealthCheck.Result result = healthCheckRegistry.runHealthCheck("openregister_java");
+		Response.Status status = result.isHealthy() ? Response.Status.OK : Response.Status.INTERNAL_SERVER_ERROR;
+		Response.ResponseBuilder responseBuilder = Response.status(status);
+		
+		return responseBuilder.entity(result).build();
+	}
+}

--- a/src/main/java/uk/gov/register/resources/HealthCheckResource.java
+++ b/src/main/java/uk/gov/register/resources/HealthCheckResource.java
@@ -25,8 +25,7 @@ public class HealthCheckResource {
 	public Response getCurrentHealth() {
 		HealthCheck.Result result = healthCheckRegistry.runHealthCheck("openregister_java");
 		Response.Status status = result.isHealthy() ? Response.Status.OK : Response.Status.INTERNAL_SERVER_ERROR;
-		Response.ResponseBuilder responseBuilder = Response.status(status);
 		
-		return responseBuilder.entity(result).build();
+		return Response.status(status).entity(result).build();
 	}
 }


### PR DESCRIPTION
### Context

This PR creates a new `healthcheck` endpoint which CloudFoundry will be able to use to determine whether the application is healthy. The new endpoint uses the existing `openregister_java` health check created by JDBI when a new `DBI` instance is created as part of the `DatabaseManager`.

When the `openregister_java` health check runs, it attempts to connect to the backing database within 5 seconds and run a `SELECT 1` query - if this is unsuccessful then the application is deemed unhealthy.

A number of options were considered for exposing the health checks that are available within the admin interface of DropWizard:

The first was to simply have CloudFoundry connect to the admin interface via the separate port, however this is not supported by CloudFoundry - it can only connect to the app's default port if running a HTTP healthcheck (https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html#-health-check-http-endpoints).

The next option considered was to host the admin interface of DropWizard on the same port as the default app, to circumvent the limitations of CloudFoundry, but this has the downside that all parts of the admin interface are exposed publicly. This interface can be password protected but would require CloudFoundry to be able to support this in order to consider the application's health. Intercepting requests to the admin interface and redirecting all to the healthcheck page via a custom filter was also explored, but it was not possible to intercept these requests.

Another option considered was to implement a custom filter to detect any requests to `/healthcheck` and run the health check at this point, however somewhere there exists some middleware which detects that the endpoint does not exist and changes the response accordingly.

The final option explored, which is the contents of this commit, creates a new `HealthcheckResource` and returns a response based on the health reported by the health check. In particular, we register the result of `environment.healthChecks()` to `HealthCheckRegistry.class` in `RegisterApplication` to be able to inject this directly into our resource without the need for the whole environment.

### Changes proposed in this pull request

Add new `HealthcheckResource`.