### PR TITLE
Instruct travis to not timeout after 10 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_script:
 - psql --version
 - psql -c 'create database ft_openregister_java_multi;' -U postgres
 - psql -c 'create database conformance_openregister_java;' -U postgres
+script:
+- travis_wait ./gradlew check
 after_failure:
 - cat $TRAVIS_BUILD_DIR/stderr.txt
 - cat $TRAVIS_BUILD_DIR/stdout.txt


### PR DESCRIPTION
### Context
The travis build times out if it does not receive any output after
10 minutes. The registers build can take a long time sometimes due
to the OWASP dependency checker.

### Changes proposed in this pull request
This change makes explicit that we use `./gradlew check`
(this is default anyway) and asks travis to wait for the check to
complete. We should look at how to split out or speed up this step in a later PR if we can.

### Guidance to review
Hoping that this build will pass on travis!