### PR TITLE
Remove history page url from config and views

### DIFF
--- a/config.docker.register.yaml
+++ b/config.docker.register.yaml
@@ -28,8 +28,6 @@ schema: country
 
 enableDownloadResource: true
 
-historyPageUrl: https://registers-history.herokuapp.com/school-eng
-
 externalConfigDirectory: /tmp
 
 downloadConfigs: true

--- a/config.yaml
+++ b/config.yaml
@@ -37,8 +37,6 @@ enableDownloadResource: true
 
 schema: school
 
-historyPageUrl: https://registers-history.herokuapp.com/school-eng
-
 externalConfigDirectory: /tmp
 
 downloadConfigs: true

--- a/src/main/java/uk/gov/register/RegisterConfiguration.java
+++ b/src/main/java/uk/gov/register/RegisterConfiguration.java
@@ -83,11 +83,6 @@ public class RegisterConfiguration extends Configuration implements RegisterDoma
     @JsonProperty
     private boolean enableDownloadResource = false;
 
-    @SuppressWarnings("unused")
-    @Valid
-    @JsonProperty
-    private Optional<String> historyPageUrl = Optional.empty();
-
     @Valid
     @JsonProperty
     private boolean enableRegisterDataDelete = false;
@@ -118,7 +113,7 @@ public class RegisterConfiguration extends Configuration implements RegisterDoma
     private String registersYamlLocation;
 
     public RegisterContextFactory getDefaultRegister() {
-        return new RegisterContextFactory(enableRegisterDataDelete, enableDownloadResource, schema, historyPageUrl, custodianName, similarRegisters, indexes, credentials);
+        return new RegisterContextFactory(enableRegisterDataDelete, enableDownloadResource, schema, custodianName, similarRegisters, indexes, credentials);
     }
 
     public AllTheRegistersFactory getAllTheRegisters() {

--- a/src/main/java/uk/gov/register/configuration/HomepageContent.java
+++ b/src/main/java/uk/gov/register/configuration/HomepageContent.java
@@ -4,12 +4,10 @@ import java.util.List;
 import java.util.Optional;
 
 public class HomepageContent {
-    private final Optional<String> registerHistoryUrl;
     private final List<String> similarRegisters;
     private final List<String> indexes;
 
-    public HomepageContent(Optional<String> registerHistoryUrl, List<String> similarRegisters, List<String> indexes) {
-        this.registerHistoryUrl = registerHistoryUrl;
+    public HomepageContent(List<String> similarRegisters, List<String> indexes) {
         this.similarRegisters = similarRegisters;
         this.indexes = indexes;
     }
@@ -27,11 +25,6 @@ public class HomepageContent {
     @SuppressWarnings("unused, used from template")
     public String getTechDocsUrl() {
         return "https://registers-docs.cloudapps.digital";
-    }
-
-    @SuppressWarnings("unused, used from template")
-    public Optional<String> getRegisterHistoryPageUrl() {
-        return registerHistoryUrl;
     }
 
     public List<String> getSimilarRegisters() { return similarRegisters; }

--- a/src/main/java/uk/gov/register/configuration/HomepageContentConfiguration.java
+++ b/src/main/java/uk/gov/register/configuration/HomepageContentConfiguration.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 
 @Contract
 public interface HomepageContentConfiguration {
-    Optional<String> getRegisterHistoryPageUrl();
     List<String> getSimilarRegisters();
     List<String> getIndexes();
 }

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -45,7 +45,6 @@ public class RegisterContext implements
     private DBI dbi;
     private Flyway flyway;
     private final String schema;
-    private final Optional<String> historyPageUrl;
     private final List<String> similarRegisters;
     private final List<IndexFunctionConfiguration> indexFunctionConfigs;
     private final boolean enableRegisterDataDelete;
@@ -57,7 +56,7 @@ public class RegisterContext implements
     public RegisterContext(RegisterName registerName, ConfigManager configManager, EnvironmentValidator environmentValidator,
                            RegisterLinkService registerLinkService, DBI dbi, Flyway flyway, String schema,
                            boolean enableRegisterDataDelete, boolean enableDownloadResource,
-                           Optional<String> historyPageUrl, List<String> similarRegisters, List<String> indexNames,
+                           List<String> similarRegisters, List<String> indexNames,
                            RegisterAuthenticator authenticator) {
         this.registerName = registerName;
         this.configManager = configManager;
@@ -66,7 +65,6 @@ public class RegisterContext implements
         this.dbi = dbi;
         this.flyway = flyway;
         this.schema = schema;
-        this.historyPageUrl = historyPageUrl;
         this.similarRegisters = similarRegisters;
         this.indexFunctionConfigs = mapIndexes(indexNames);
         this.memoizationStore = new AtomicReference<>(new InMemoryPowOfTwoNoLeaves());
@@ -238,11 +236,6 @@ public class RegisterContext implements
 
     public RegisterAuthenticator getAuthenticator() {
         return authenticator;
-    }
-
-    @Override
-    public Optional<String> getRegisterHistoryPageUrl() {
-        return historyPageUrl;
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/RegisterContextFactory.java
+++ b/src/main/java/uk/gov/register/core/RegisterContextFactory.java
@@ -33,11 +33,6 @@ public class RegisterContextFactory {
     @JsonProperty
     private String schema;
 
-    @SuppressWarnings("unused")
-    @Valid
-    @JsonProperty
-    private Optional<String> historyPageUrl = Optional.empty();
-
     @Valid
     @JsonProperty
     private Optional<String> custodianName = Optional.empty();
@@ -60,7 +55,6 @@ public class RegisterContextFactory {
             @JsonProperty("enableRegisterDataDelete") boolean enableRegisterDataDelete,
             @JsonProperty("enableDownloadResource") boolean enableDownloadResource,
             @JsonProperty("schema") String schema,
-            @JsonProperty("historyPageUrl") Optional<String> historyPageUrl,
             @JsonProperty("custodianName") Optional<String> custodianName,
             @JsonProperty("similarRegisters") List<String> similarRegisters,
             @JsonProperty("indexes") List<String> indexes,
@@ -68,7 +62,6 @@ public class RegisterContextFactory {
         this.enableRegisterDataDelete = enableRegisterDataDelete;
         this.enableDownloadResource = enableDownloadResource;
         this.schema = schema;
-        this.historyPageUrl = historyPageUrl;
         this.custodianName = custodianName;
         this.similarRegisters = similarRegisters != null ? similarRegisters : emptyList();
         this.indexes = indexes != null ? indexes : emptyList();
@@ -97,7 +90,6 @@ public class RegisterContextFactory {
                 schema,
                 enableRegisterDataDelete,
                 enableDownloadResource,
-                historyPageUrl,
                 similarRegisters,
                 indexes,
                 credentials.buildAuthenticator());

--- a/src/main/java/uk/gov/register/views/ViewFactory.java
+++ b/src/main/java/uk/gov/register/views/ViewFactory.java
@@ -86,7 +86,6 @@ public class ViewFactory {
                 lastUpdated,
                 custodianName,
                 new HomepageContent(
-                        homepageContentConfiguration.get().getRegisterHistoryPageUrl(),
                         homepageContentConfiguration.get().getSimilarRegisters(),
                         homepageContentConfiguration.get().getIndexes()),
                 registerResolver,
@@ -158,7 +157,6 @@ public class ViewFactory {
         return new PreviewRecordPageView(requestContext, register.get(), registerResolver,
                 previewType,
                 new HomepageContent(
-                        homepageContentConfiguration.get().getRegisterHistoryPageUrl(),
                         homepageContentConfiguration.get().getSimilarRegisters(),
                         homepageContentConfiguration.get().getIndexes()),
                 getRecordsMediaView(records),
@@ -170,7 +168,6 @@ public class ViewFactory {
         return new PreviewEntryPageView(requestContext, register.get(), registerResolver,
                 previewType,
                 new HomepageContent(
-                        homepageContentConfiguration.get().getRegisterHistoryPageUrl(),
                         homepageContentConfiguration.get().getSimilarRegisters(),
                         homepageContentConfiguration.get().getIndexes()),
                 getEntriesView(entries),
@@ -182,7 +179,6 @@ public class ViewFactory {
         return new PreviewItemPageView(requestContext, register.get(), registerResolver,
                 previewType,
                 new HomepageContent(
-                        homepageContentConfiguration.get().getRegisterHistoryPageUrl(),
                         homepageContentConfiguration.get().getSimilarRegisters(),
                         homepageContentConfiguration.get().getIndexes()),
                 getItemMediaView(item),

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -76,9 +76,6 @@
               </th:block>
               <h3 class="heading-medium">More information</h3>
               <ul class="list">
-                <li th:if="${#bools.isTrue(homepageContent.registerHistoryPageUrl.isPresent())}">
-                  <a th:href="${homepageContent.registerHistoryPageUrl.get()}">Register history</a>
-                </li>
                 <li>
                   <a th:href="${homepageContent.registersIntroductionUrl}">Introducing registers</a>
                 </li>

--- a/src/test/java/uk/gov/register/core/RegisterContextTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterContextTest.java
@@ -47,7 +47,7 @@ public class RegisterContextTest {
 
     @Test
     public void resetRegister_shouldNotResetRegister_whenEnableRegisterDataDeleteIsDisabled() throws IOException, NoSuchConfigException {
-        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, false, false, Optional.empty(), emptyList(), emptyList(), new RegisterAuthenticator("", ""));
+        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, false, false, emptyList(), emptyList(), new RegisterAuthenticator("", ""));
         context.resetRegister();
 
         verify(flyway, never()).clean();
@@ -57,7 +57,7 @@ public class RegisterContextTest {
 
     @Test
     public void resetRegister_shouldResetRegister_whenEnableRegisterDataDeleteIsEnabled() throws IOException, NoSuchConfigException {
-        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, true, false, Optional.empty(), emptyList(), emptyList(), new RegisterAuthenticator("", ""));
+        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, true, false, emptyList(), emptyList(), new RegisterAuthenticator("", ""));
         context.resetRegister();
 
         verify(flyway, times(1)).clean();
@@ -90,7 +90,7 @@ public class RegisterContextTest {
                 .thenReturn(expectedInitialMetadata)
                 .thenReturn(expectedUpdatedMetadata);
 
-        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, true, false, Optional.empty(), emptyList(), emptyList(), new RegisterAuthenticator("", ""));
+        RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema, true, false, emptyList(), emptyList(), new RegisterAuthenticator("", ""));
 
         RegisterMetadata actualInitialMetadata = context.getRegisterMetadata();
         assertThat(actualInitialMetadata, equalTo(expectedInitialMetadata));
@@ -102,7 +102,7 @@ public class RegisterContextTest {
     @Test
     public void shouldSetUserIndexFunctions(){
         RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema,
-                true, false, Optional.empty(), emptyList(), Arrays.asList("current-countries","local-authority-by-type"), new RegisterAuthenticator("", ""));
+                true, false, emptyList(), Arrays.asList("current-countries","local-authority-by-type"), new RegisterAuthenticator("", ""));
         PostgresRegister register = (PostgresRegister)context.buildOnDemandRegister();
         assertThat(register.getIndexFunctionsByEntryType().get(EntryType.user).size(), Is.is(3));
         List<String> indexFunctionNames = register.getIndexFunctionsByEntryType().get(EntryType.user).stream().map(ifn -> ifn.getClass().getName()).collect(toList());
@@ -113,7 +113,7 @@ public class RegisterContextTest {
     @Test
     public void shouldHandleNoUserIndexFunctions(){
         RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema,
-                true, false, Optional.empty(), emptyList(), Collections.emptyList(), new RegisterAuthenticator("", ""));
+                true, false, emptyList(), Collections.emptyList(), new RegisterAuthenticator("", ""));
         PostgresRegister register = (PostgresRegister)context.buildOnDemandRegister();
         assertThat(register.getIndexFunctionsByEntryType().get(EntryType.user).size(), Is.is(1));
     }
@@ -121,7 +121,7 @@ public class RegisterContextTest {
     @Test
     public void shouldSetSystemIndexFunctions(){
         RegisterContext context = new RegisterContext(registerName, configManager, environmentValidator, registerLinkService, dbi, flyway, schema,
-                true, false, Optional.empty(), emptyList(), Arrays.asList("current-countries"), new RegisterAuthenticator("", ""));
+                true, false, emptyList(), Arrays.asList("current-countries"), new RegisterAuthenticator("", ""));
         PostgresRegister register = (PostgresRegister)context.buildOnDemandRegister();
         assertThat(register.getIndexFunctionsByEntryType().get(EntryType.system).size(), Is.is(1));
         List<String> indexFunctionNames = register.getIndexFunctionsByEntryType().get(EntryType.system).stream().map(ifn -> ifn.getClass().getName()).collect(toList());

--- a/src/test/java/uk/gov/register/views/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/views/HomePageViewTest.java
@@ -40,7 +40,7 @@ public class HomePageViewTest {
     @Mock
     RegisterLinkService registerLinkService;
 
-    HomepageContent homepageContent = new HomepageContent(Optional.empty(), emptyList(), emptyList());
+    HomepageContent homepageContent = new HomepageContent(emptyList(), emptyList());
 
     @Test
     public void getRegisterText_rendersRegisterTextAsMarkdown() throws Exception {
@@ -86,32 +86,14 @@ public class HomePageViewTest {
     }
 
     @Test
-    public void shouldGetHistoryPageIfAvailable() {
-        final RegisterReadOnly register = mock(RegisterReadOnly.class);
-
-        HomepageContent homepageContent = new HomepageContent(Optional.empty(), emptyList(), emptyList());
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), Optional.empty(), homepageContent, registerResolver, Arrays.asList(field), registerLinkService, register);
-
-        assertThat(homePageView.getHomepageContent().getRegisterHistoryPageUrl().isPresent(), is(false));
-
-        final String historyUrl = "http://register-history.openregister.org";
-        homepageContent = new HomepageContent(Optional.of(historyUrl), emptyList(), emptyList());
-        homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), Optional.empty(), homepageContent, registerResolver, Arrays.asList(field), registerLinkService, register);
-
-        assertThat(homePageView.getHomepageContent().getRegisterHistoryPageUrl().isPresent(), is(true));
-        assertThat(homePageView.getHomepageContent().getRegisterHistoryPageUrl().get(), is(historyUrl));
-    }
-
-    @Test
     public void shouldGetCustodianNameIfAvailable() {
         final RegisterReadOnly register = mock(RegisterReadOnly.class);
-        HomepageContent homepageContent = new HomepageContent(Optional.empty(), emptyList(), emptyList());
+        HomepageContent homepageContent = new HomepageContent(emptyList(), emptyList());
         HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), Optional.empty(), homepageContent, registerResolver, Arrays.asList(field), registerLinkService, register);
 
         assertThat(homePageView.getCustodianName().isPresent(), is(false));
 
         final String custodianName = "John Smith";
-        homepageContent = new HomepageContent(Optional.of(custodianName), emptyList(), emptyList());
         homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), Optional.of(custodianName), homepageContent, registerResolver, Arrays.asList(field), registerLinkService, register);
 
         assertThat(homePageView.getCustodianName().isPresent(), is(true));
@@ -142,7 +124,7 @@ public class HomePageViewTest {
         when(register.getRegisterName()).thenReturn(registerName);
         when(registerLinkService.getRegisterLinks(registerName)).thenReturn(new RegisterLinks(new ArrayList<>(), new ArrayList<>()));
 
-        final HomepageContent homepageContent = new HomepageContent(Optional.empty(), emptyList(), emptyList());
+        final HomepageContent homepageContent = new HomepageContent(emptyList(), emptyList());
         HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), Optional.empty(), homepageContent, registerResolver, Arrays.asList(field), registerLinkService, register);
 
         assertThat(homePageView.getRegisterLinks().getRegistersLinkedFrom(), is(empty()));
@@ -161,13 +143,13 @@ public class HomePageViewTest {
     @Test
     public void getSimilarRegisters_shouldGetSimilarRegistersIfAvailable() {
         final RegisterReadOnly register = mock(RegisterReadOnly.class);
-        HomepageContent homepageContent = new HomepageContent(Optional.empty(), emptyList(), emptyList());
+        HomepageContent homepageContent = new HomepageContent(emptyList(), emptyList());
         HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), Optional.empty(), homepageContent, registerResolver, Arrays.asList(field), registerLinkService, register);
 
         assertThat(homePageView.getHomepageContent().getSimilarRegisters(), is(empty()));
 
         final List<String> similarRegisters = Arrays.asList("address", "territory");
-        homepageContent = new HomepageContent(Optional.empty(), similarRegisters, emptyList());
+        homepageContent = new HomepageContent(similarRegisters, emptyList());
         homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), Optional.empty(), homepageContent, registerResolver, Arrays.asList(field), registerLinkService, register);
 
         assertThat(homePageView.getHomepageContent().getSimilarRegisters(), IsIterableContainingInOrder.contains("address", "territory"));
@@ -176,13 +158,13 @@ public class HomePageViewTest {
     @Test
     public void getIndexes_shouldGetIndexesIfAvailable() {
         final RegisterReadOnly register = mock(RegisterReadOnly.class);
-        HomepageContent homepageContent = new HomepageContent(Optional.empty(), emptyList(), emptyList());
+        HomepageContent homepageContent = new HomepageContent(emptyList(), emptyList());
         HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), Optional.empty(), homepageContent, registerResolver, Arrays.asList(field), registerLinkService, register);
 
         assertThat(homePageView.getHomepageContent().getIndexes(), is(emptyList()));
 
         final List<String> indexes = Arrays.asList("current-countries", "local-authority-by-type");
-        homepageContent = new HomepageContent(Optional.empty(), emptyList(), indexes);
+        homepageContent = new HomepageContent(emptyList(), indexes);
         homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.empty(), Optional.empty(), homepageContent, registerResolver, Arrays.asList(field), registerLinkService, register);
 
         assertThat(homePageView.getHomepageContent().getIndexes(), IsIterableContainingInOrder.contains("current-countries", "local-authority-by-type"));

--- a/src/test/java/uk/gov/register/views/PreviewEntryPageViewTest.java
+++ b/src/test/java/uk/gov/register/views/PreviewEntryPageViewTest.java
@@ -33,7 +33,7 @@ public class PreviewEntryPageViewTest {
     @Mock
     private RegisterReadOnly registerReadOnly;
 
-    private final HomepageContent homepageContent = new HomepageContent(Optional.empty(), emptyList(), emptyList());
+    private final HomepageContent homepageContent = new HomepageContent(emptyList(), emptyList());
     private final Provider<RegisterName> provider = mock(Provider.class);
 
     @Test

--- a/src/test/java/uk/gov/register/views/PreviewItemPageViewTest.java
+++ b/src/test/java/uk/gov/register/views/PreviewItemPageViewTest.java
@@ -36,7 +36,7 @@ public class PreviewItemPageViewTest {
     @Mock
     private RegisterReadOnly registerReadOnly;
 
-    private final HomepageContent homepageContent = new HomepageContent(Optional.empty(), emptyList(), emptyList());
+    private final HomepageContent homepageContent = new HomepageContent(emptyList(), emptyList());
     private final Provider<RegisterName> provider = mock(Provider.class);
 
     @Test

--- a/src/test/java/uk/gov/register/views/PreviewRecordPageViewTest.java
+++ b/src/test/java/uk/gov/register/views/PreviewRecordPageViewTest.java
@@ -40,7 +40,7 @@ public class PreviewRecordPageViewTest {
     @Mock
     private RegisterReadOnly registerReadOnly;
 
-    private final HomepageContent homepageContent = new HomepageContent(Optional.empty(), emptyList(), emptyList());
+    private final HomepageContent homepageContent = new HomepageContent(emptyList(), emptyList());
     private final Provider<RegisterName> provider = mock(Provider.class);
 
     @Test


### PR DESCRIPTION
### Context
The history no longer exists so there is no need to retain the functionality

### Changes proposed in this pull request
Remove anything relating to `historyPageUrl`

### Guidance to review
Ensure the home page still renders and all tests pass