### PR TITLE
Update discovery manifests

### DIFF
--- a/deploy/manifests/discovery/basic.yml
+++ b/deploy/manifests/discovery/basic.yml
@@ -9,6 +9,7 @@ applications:
   path: ../../openregister-java.jar
   domains:
     - discovery.openregister.org
+    - cloudapps.digital
   hosts:
     - datatype
     - field

--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -9,6 +9,7 @@ applications:
   path: ../../openregister-java.jar
   domains:
     - discovery.openregister.org
+    - cloudapps.digital
   hosts:
     - address
     - charity


### PR DESCRIPTION
### Context
This PR updates both discovery manifests to add `cloudapps.digital` under as a domain, which will create new routes in paas so that a user can access discovery registers by specifying `<register_name>.cloudapps.digital`. This is a piece of work to enable register creation to happen across the whole team.
