### PR TITLE
Change discovery domain

### DIFF
--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -64,7 +64,7 @@ Variable: `fieldsYamlLocation`
 Possible values:
 * beta: `fieldsYamlLocation: https://field.register.gov.uk/records.yaml`
 * alpha: `fieldsYamlLocation: https://field.alpha.openregister.org/records.yaml`
-* discovery: `fieldsYamlLocation: https://field.discovery.cloudapps.digital/records.yaml`
+* discovery: `fieldsYamlLocation: https://field.cloudapps.digital/records.yaml`
 
 Registers locations per environment:
 
@@ -73,7 +73,7 @@ Variable: `registersYamlLocation`
 Possible values:
 * beta: `registersYamlLocation: https://register.register.gov.uk/records.yaml`
 * alpha: `registersYamlLocation: https://register.alpha.openregister.org/records.yaml`
-* discovery: `registersYamlLocation: https://register.discovery.cloudapps.digital/records.yaml`
+* discovery: `registersYamlLocation: https://register.cloudapps.digital/records.yaml`
 
 Now re-run the application using `ENVIRONMENT=myphase REGISTERS=myregister ./run-application.sh`. You should now see the `myregister` register locally at `127.0.0.1:8080`.
 

--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -55,7 +55,7 @@ Change `register: country` to `register: myregister`.
 
 Update the schema in the same way, to `schema: myregister`.
 
-Next, update fields and registers location for environments other than beta in the same way.
+Next, go to `config.docker.basic.yaml` and update the fields and registers location if you are cloning an environment other than beta.
 
 Fields locations per environment:
 
@@ -75,7 +75,7 @@ Possible values:
 * alpha: `registersYamlLocation: https://register.alpha.openregister.org/records.yaml`
 * discovery: `registersYamlLocation: https://register.discovery.openregister.org/records.yaml`
 
-Now re-run the application using `ENVIRONMENT=myphase REGISTERS=myregister ./run-application.sh`. You should now see the School type register locally at `127.0.0.1:8080`.
+Now re-run the application using `ENVIRONMENT=myphase REGISTERS=myregister ./run-application.sh`. You should now see the `myregister` register locally at `127.0.0.1:8080`.
 
 ## Create a new register
 

--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -45,7 +45,7 @@ The `./run-application.sh` script is configured to spin up a clone of the [Count
 Registers available to be cloned can be seen in the Register register in the respective phase:
 * beta: https://register.register.gov.uk/records
 * alpha: https://register.alpha.openregister.org/records
-* discovery: https://register.discovery.openregister.org/records
+* discovery: https://register.cloudapps.digital/records
 
 For example, you might want to clone a register called `myregister` from the `myphase` phase.
 
@@ -64,7 +64,7 @@ Variable: `fieldsYamlLocation`
 Possible values:
 * beta: `fieldsYamlLocation: https://field.register.gov.uk/records.yaml`
 * alpha: `fieldsYamlLocation: https://field.alpha.openregister.org/records.yaml`
-* discovery: `fieldsYamlLocation: https://field.discovery.openregister.org/records.yaml`
+* discovery: `fieldsYamlLocation: https://field.discovery.cloudapps.digital/records.yaml`
 
 Registers locations per environment:
 
@@ -73,7 +73,7 @@ Variable: `registersYamlLocation`
 Possible values:
 * beta: `registersYamlLocation: https://register.register.gov.uk/records.yaml`
 * alpha: `registersYamlLocation: https://register.alpha.openregister.org/records.yaml`
-* discovery: `registersYamlLocation: https://register.discovery.openregister.org/records.yaml`
+* discovery: `registersYamlLocation: https://register.discovery.cloudapps.digital/records.yaml`
 
 Now re-run the application using `ENVIRONMENT=myphase REGISTERS=myregister ./run-application.sh`. You should now see the `myregister` register locally at `127.0.0.1:8080`.
 

--- a/run-application.sh
+++ b/run-application.sh
@@ -4,12 +4,11 @@ set -e
 ENVIRONMENT=${ENVIRONMENT:-beta}
 REGISTERS=${REGISTERS:-"country"}
 
-if [ $ENVIRONMENT == beta ]
-then
-  DOMAIN="register.gov.uk"
-else
-  DOMAIN="$ENVIRONMENT.openregister.org"
-fi
+case ${ENVIRONMENT} in
+  beta)      DOMAIN="register.gov.uk";;
+  discovery) DOMAIN="cloudapps.digital";;
+  *)         DOMAIN="$ENVIRONMENT.openregister.org";;
+esac
 
 function on_exit {
   echo "Stopping and removing containers..."


### PR DESCRIPTION
### Context
The discovery environment is now available at *.cloudapps.digital and will soon no longer be available at *.discovery.openregister.org. This therefore updates the `run-application.sh` script to work for discovery register at the new location.

### Changes proposed in this pull request
Update `run-application.sh` and corresponding `RUNNING_LOCALLY.md` to use new location for discovery registers.

### Guidance to review
Try following `RUNNING_LOCALLY.md` to clone a register from the discovery environment and that you can access that register locally.