### PR TITLE
Remove cloudapps.digital as domain for discovery

### DIFF
--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -9,7 +9,6 @@ applications:
   path: ../../openregister-java.jar
   domains:
     - discovery.openregister.org
-    - cloudapps.digital
   hosts:
     - address
     - charity


### PR DESCRIPTION
### Context
We added cloudapps.digital as the domain for discovery but we now want this to be used in a new discovery space and not in the prod space. This is part of the process of moving the discovery environment into a new space.

### Changes proposed in this pull request
Remove cloudapps.digital as a domain from the prod space so that it does not clash with the same domain that will be used in a new discovery space.

### Guidance to review
