### PR TITLE
Do not use cloudapps.digital as domain in prod environment

### DIFF
--- a/deploy/manifests/discovery/basic.yml
+++ b/deploy/manifests/discovery/basic.yml
@@ -9,7 +9,6 @@ applications:
   path: ../../openregister-java.jar
   domains:
     - discovery.openregister.org
-    - cloudapps.digital
   hosts:
     - datatype
     - field


### PR DESCRIPTION
### Context
I forgot to remove this from basic as well as multi.

### Changes proposed in this pull request
Don'u use cloudapps.digital as a domain in prod space. This will be moved to discovery space.

### Guidance to review
