### PR TITLE
Switch discovery registers to cloudapps domain

### DIFF
--- a/deploy/manifests/discovery/basic.yml
+++ b/deploy/manifests/discovery/basic.yml
@@ -8,7 +8,7 @@ applications:
   health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   domains:
-    - discovery.openregister.org
+    - cloudapps.digital
   hosts:
     - datatype
     - field

--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -8,7 +8,7 @@ applications:
   health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   domains:
-    - discovery.openregister.org
+    - cloudapps.digital
   hosts:
     - address
     - charity


### PR DESCRIPTION
### Context
This PR changes the discovery manifests to ensure that all discovery registers point to `cloudapps.digital` instead of `discovery.openregister.org`.

The existing environment will not be affected by this change as our deployment pipeline has changed.
