### PR TITLE
Remove hosts from discovery manifest

### DIFF
--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -7,18 +7,6 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
-  domains:
-    - cloudapps.digital
-  hosts:
-    - address
-    - charity
-    - charity-class
-    - clinical-commissioning-group
-    - place
-    - street-custodian
-    - street
-    - uk
-    - westminster-parliamentary-constituency
   services:
     - discovery-db
     - logit-ssl-drain


### PR DESCRIPTION
This PR removes the `domain` and `hosts` properties from the `discovery-multi` manifest, as this will now be modified directly by the creation team via PaaS.