### PR TITLE
Make discovery non zero downtime

### DIFF
--- a/deploy/buildspec.yml
+++ b/deploy/buildspec.yml
@@ -29,7 +29,7 @@ phases:
     commands:
       - 'sed -i "s/    AWS_ACCESS_KEY_ID: change-me/    AWS_ACCESS_KEY_ID: ${AWS_KEY}/" manifests/${ENVIRONMENT}/${REGISTER_GROUP}.yml'
       - 'sed -i "s/    AWS_SECRET_ACCESS_KEY: change-me/    AWS_SECRET_ACCESS_KEY: ${AWS_SECRET}/" manifests/${ENVIRONMENT}/${REGISTER_GROUP}.yml'
-      - cf zero-downtime-push "${ENVIRONMENT}-${REGISTER_GROUP}" -f "manifests/${ENVIRONMENT}/${REGISTER_GROUP}.yml"
+      - [ "$ENVIRONMENT" = "discovery" ] && [ "$REGISTER_GROUP" = "multi" ] && cf push discovery-multi -f "manifests/discovery/multi.yml" || cf zero-downtime-push "${ENVIRONMENT}-${REGISTER_GROUP}" -f "manifests/${ENVIRONMENT}/${REGISTER_GROUP}.yml"
   post_build:
     commands:
       - cf logout


### PR DESCRIPTION
This PR makes discovery push non zero-downtime, as autopilot removes routes which are not in the manifest, and routes will never be in the manifest for discovery registers.