### PR TITLE
Calculate root hash for registers on start-up

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -51,6 +51,7 @@ import javax.servlet.DispatcherType;
 import javax.ws.rs.client.Client;
 import java.util.EnumSet;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 public class RegisterApplication extends Application<RegisterConfiguration> {
     public static void main(String[] args) {
@@ -111,6 +112,8 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         allTheRegisters.stream().forEach(registerContext -> {
             registerContext.migrate();
             registerContext.validate();
+            
+            CompletableFuture.runAsync(() -> registerContext.buildOnDemandRegister().getRegisterProof());
         });
 
         RSFExecutor rsfExecutor = new RSFExecutor();


### PR DESCRIPTION
### Context

This PR aims to warm-up the memoisation store for each register as soon as ORJ starts, by computing the root hash of each register. Through doing this, we will remove the burden of users needing to wait for this computation to take place before being able to download the RSF of a register, which should also have the effect of ensuring our caching layer is able to receive a response before timing out (using the current idle and keep-alive settings).

### Changes proposed in this pull request

Compute root hash for each register on start-up, asynchronously.

### Guidance to review

Start-up ORJ locally using a large register (i.e. charity), wait approximately one minute, then hit `/download-rsf`; download should commence almost instantaneously and complete in < 10s (assuming the full charity register).