### PR TITLE
Upgrade jackson to 2.8.11

### DIFF
--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -2,7 +2,7 @@ ext {
     dropwizard_version = '1.1.0'
     dropwizard_metrics_version = '3.1.0'
     jersey_version = '2.25.1'
-    jackson_version = '2.8.7'
+    jackson_version = '2.8.11'
 
     verifiableLog = 'verifiable-log:verifiable-log:0.2.77'
 


### PR DESCRIPTION
### Context

This PR upgrades Jackson from version 2.8.7 to 2.8.11. This is in response to the recently flagged vulnerability `CVE-2017-17485` (https://nvd.nist.gov/vuln/detail/CVE-2017-17485) which affects `jackson-databind` prior to 2.8.11, in addition to versions 2.9.0 up to and including 2.9.3. We could be affected by this vulnerability if the JSON that we read using `objectMapper.readValue` is crafted to exploit it, which could be achieved via loading registers with a specific payload.

### Changes proposed in this pull request

Upgrade Jackson from 2.8.7 to 2.8.11, addressing a specific CVE.

### Guidance to review

See [report.pdf](https://github.com/openregister/openregister-java/files/1700029/report.pdf) for the generated report.
