### PR TITLE
Address CVE-2018-5968

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ configurations {
 
 dependencies {
     compile dropwizard, stringTemplate, apacheCommonsCodec, apacheCommonsCollections, apacheCommonsLang3, apachePoi, apachePoiOoxml, awsS3
-    compile jacksonCsv, jena, jerseyMedia, markdown, thymeleaf, verifiableLog
+    compile jacksonCsv, jacksonDatabind, jena, jerseyMedia, markdown, thymeleaf, verifiableLog
     compile jdbi, jersey_client
     compile dropwizardLogstash
     compile(postgresClient) {

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -4,6 +4,8 @@ ext {
     jersey_version = '2.25.1'
     jackson_version = '2.8.11'
 
+    jacksonDatabind = 'com.fasterxml.jackson.core:jackson-databind:2.8.11.1'
+
     verifiableLog = 'verifiable-log:verifiable-log:0.2.77'
 
     dropwizard = [


### PR DESCRIPTION
### Context
Dependency checker alerted us to a dependency vulnerability.

### Changes proposed in this pull request
Explicitly use jackson-databind version 2.8.11.1, which addresses
the vulnerability discussed in CVE-2018-5968
(http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-5968).

### Guidance to review
Check everything builds.
