### PR TITLE
Update DCLG to Ministry of Housing, Communities & Local Government

### DIFF
--- a/src/main/resources/config/public-bodies.yaml
+++ b/src/main/resources/config/public-bodies.yaml
@@ -363,6 +363,9 @@ civil-service-government-science-engineering:
 department-for-communities-and-local-government:
   name: "Department for Communities and Local Government"
   public-body: "department-for-communities-and-local-government"
+ministry-of-housing-communities-and-local-government:
+  name: "Ministry of Housing, Communities & Local Government"
+  public-body: "ministry-of-housing-communities-and-local-government"
 working-ventures-uk:
   name: "Working Ventures UK"
   public-body: "working-ventures-uk"


### PR DESCRIPTION
### Context
This PR updates _Department for Communities and Local Government_ to _Ministry of Housing, Communities & Local Government_.