### PR TITLE
Load RSF should bypass consistency filter

### DIFF
--- a/src/main/java/uk/gov/register/filters/ConsistencyFilter.java
+++ b/src/main/java/uk/gov/register/filters/ConsistencyFilter.java
@@ -42,6 +42,6 @@ public class ConsistencyFilter implements ContainerRequestFilter {
     }
 
     private boolean skipFilter(final String path) {
-        return path.contains("delete-register-data");
+        return path.contains("delete-register-data") || path.contains("load-rsf");
     }
 }


### PR DESCRIPTION
### Context

This commit updates the `ConsistencyFilter` to allow a call to `load-rsf` to bypass it. This is necessary if we need to update the metadata for a register to make it consistent with the environment, as otherwise we are blocked by all requests to an inconsistent register throwing an exception.