### PR TITLE
Add qualification registers to beta

### DIFF
--- a/deploy/manifests/beta/multi.yml
+++ b/deploy/manifests/beta/multi.yml
@@ -26,6 +26,10 @@ applications:
     - local-authority-type
     - principal-local-authority
     - prison-estate
+    - qualification-assessment-method
+    - qualification-level
+    - qualification-sector-subject-area
+    - qualification-type
     - registration-district
     - statistical-geography
     - statistical-geography-county-eng


### PR DESCRIPTION
### Context

This commit adds `qualification-assessment-method`, `qualification-level`, `qualification-sector-subject-area` and `qualification-type` registers to the `beta-multi` manifest.
