### PR TITLE
Use `apt-get clean` in `buildspec.yml`

### DIFF
--- a/deploy/buildspec.yml
+++ b/deploy/buildspec.yml
@@ -3,6 +3,7 @@ version: 0.2
 phases:
   install:
     commands:
+      - apt-get clean -y
       - apt-get update -y
       - apt-get install -y apt-transport-https
       - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -


### PR DESCRIPTION
### Context
This should hopefully fix the issue in code deploy where it cannot perform `apt-get upgrade` as per https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error

### Changes proposed in this pull request
Use `apt-get clean` in `buildspec.yml`

### Guidance to review
We will have to see if it works when we deploy.