### PR TITLE
Remove specific styling for entries table

### DIFF
--- a/src/main/resources/assets/sass/main.scss
+++ b/src/main/resources/assets/sass/main.scss
@@ -237,16 +237,6 @@ table {
   tr:nth-child(2n) {
     background-color: $grey-4;
   }
-
-  &.entry {
-    tr {
-      background-color: $grey-2;
-    }
-
-    th, td {
-      border-bottom: 1px solid $border-colour;
-    }
-  }
 }
 
 // Defintion lists


### PR DESCRIPTION
### Context
The item and entry table was too dark

### Changes proposed in this pull request
Remove specific styling for these tables. All tables should be consistent.

### Guidance to review
e.g. https://register.register.gov.uk/item/sha-256:642873fe3929baade4f7c3934f61074cd534aebc5318d7845d120cfd6b31401d

# Before
<img width="1360" alt="screen shot 2018-02-22 at 10 42 48" src="https://user-images.githubusercontent.com/3071606/36534042-52233fe6-17bd-11e8-8133-3d544c7a626d.png">

# After
<img width="1360" alt="screen shot 2018-02-22 at 10 44 24" src="https://user-images.githubusercontent.com/3071606/36534056-5b68e16e-17bd-11e8-8164-2444a872aded.png">
