### PR TITLE
Use rm -r /var/lib/apt/lists/* in buildspec.yml

### DIFF
--- a/deploy/buildspec.yml
+++ b/deploy/buildspec.yml
@@ -4,6 +4,7 @@ phases:
   install:
     commands:
       - apt-get clean -y
+      - rm -r /var/lib/apt/lists/*
       - apt-get update -y --fix-broken
       - apt-get install -y apt-transport-https
       - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -


### PR DESCRIPTION
### Context

This PR builds on the previous commits to attempt to fix the currently failing deployments. Specifically, it will force the removal of any cached packages under `apt` to ensure that we are downloading new versions every time. This is taken from https://askubuntu.com/questions/760574/sudo-apt-get-update-failes-due-to-hash-sum-mismatch/760839.

### Changes proposed in this pull request

Update `buildspec.yml` to force removal of any cached `apt` packages.

### Guidance to review

We will see if this works upon deployment.