### PR TITLE
Use `rm -rf /var/lib/apt/lists/*` in `buildspec.yml`

### DIFF
--- a/deploy/buildspec.yml
+++ b/deploy/buildspec.yml
@@ -3,8 +3,9 @@ version: 0.2
 phases:
   install:
     commands:
+      - rm -rf /var/lib/apt/lists/*
       - apt-get clean -y
-      - apt-get update -y --fix-broken
+      - apt-get update -y
       - apt-get install -y apt-transport-https
       - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
       - echo 'deb http://packages.cloudfoundry.org/debian stable main' > /etc/apt/sources.list.d/cloudfoundry-cli.list


### PR DESCRIPTION
### Context
We are not certain that this did not work previously as the `--fix-broken` option was causing issues with the `apt-get update` command.

### Changes proposed in this pull request
As per https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error.