### PR TITLE
Fix download link for entries of a record

### DIFF
--- a/src/main/java/uk/gov/register/views/EntryListView.java
+++ b/src/main/java/uk/gov/register/views/EntryListView.java
@@ -95,6 +95,12 @@ public class EntryListView implements CsvRepresentationView {
         return recordKey;
     }
 
+    @SuppressWarnings("unused, used from templates")
+    public String getDownloadLink() {
+        Optional<String> recordKey = getRecordKey();
+        return recordKey.isPresent() ? String.format("record/%s/entries", recordKey.get()) : "entries"; 
+    }
+
     @Override
     public CsvRepresentation<Collection<Entry>> csvRepresentation() {
         return new CsvRepresentation<>(Entry.csvSchema(), getEntries());

--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -22,7 +22,7 @@
             <span class="heading-secondary"
                   th:include="fragments/pagination.html::pagination-top('entries')"></span>
           </h1>
-          <div th:include="fragments/download-and-preview.html::download-and-preview('entries')"></div>
+          <div th:include="fragments/download-and-preview.html::download-and-preview(${content.downloadLink})"></div>
         </div>
       </div>
 


### PR DESCRIPTION
### Context

This PR fixes the location of downloads for all formats when a user attempts to download the entries for a particular key. Previously, the download would point to `/entries` for the particular format, meaning that all entries would be downloaded, even when the user would be viewing only entries for some key. This PR now points downloads of this type to `/record/KEY/entries` for the particular format.

### Changes proposed in this pull request

Fix download link for entries of a record.

### Guidance to review

Start ORJ, go to any record, view all versions of this record and then try downloading the resulting entries via the different formats.
