### PR TITLE
Download should use correct page info

### DIFF
--- a/src/main/java/uk/gov/register/resources/IndexSizePagination.java
+++ b/src/main/java/uk/gov/register/resources/IndexSizePagination.java
@@ -91,9 +91,13 @@ public class IndexSizePagination implements Pagination {
     public String getPreviousPageLink() {
         return String.format("?" + INDEX_PARAM + "=%s&" + SIZE_PARAM + "=%s", getPreviousPageNumber(), pageSize());
     }
-
+    
     public int pageSize() {
         return pageSize;
+    }
+    
+    public String getFormattedPageQueryParams() {
+        return String.format("?%s=%s&%s=%s", INDEX_PARAM, pageIndex, SIZE_PARAM, pageSize);
     }
 
     @Override

--- a/src/main/java/uk/gov/register/resources/Pagination.java
+++ b/src/main/java/uk/gov/register/resources/Pagination.java
@@ -22,4 +22,6 @@ public interface Pagination {
     String getPreviousPageLink();
 
     int getTotalPages();
+
+    String getFormattedPageQueryParams();
 }

--- a/src/main/java/uk/gov/register/resources/StartLimitPagination.java
+++ b/src/main/java/uk/gov/register/resources/StartLimitPagination.java
@@ -47,6 +47,11 @@ public class StartLimitPagination implements Pagination {
     }
 
     @Override
+    public String getFormattedPageQueryParams() {
+        return String.format("?start=%s&limit=%s", start, limit);
+    }
+
+    @Override
     public int getFirstEntryNumberOnThisPage() {
         return start > 0 ? start : 1;
     }

--- a/src/main/resources/templates/fragments/download-and-preview.html
+++ b/src/main/resources/templates/fragments/download-and-preview.html
@@ -4,11 +4,11 @@
     <p class="data-representations" data-click-events="" data-click-category="Content" data-click-action="Register Download">
       <th:block th:if="${pagination.totalEntries} le 5000">Get this data as</th:block>
       <th:block th:if="${pagination.totalEntries} gt 5000">Get the first 5,000 records as</th:block>
-      <a th:href="${'/' + records_or_entries_string + '.json'}" data-download-type="JSON">JSON</a>,
-      <a th:href="${'/' + records_or_entries_string + '.yaml'}" data-download-type="YAML">YAML</a>,
-      <a th:href="${'/' + records_or_entries_string + '.ttl'}" data-download-type="TTL">TTL</a>,
-      <a th:href="${'/' + records_or_entries_string + '.csv'}" data-download-type="CSV">CSV</a> or
-      <a th:href="${'/' + records_or_entries_string + '.tsv'}" data-download-type="TSV">TSV</a>.
+      <a th:href="${'/' + records_or_entries_string + '.json' + pagination.formattedPageQueryParams }" data-download-type="JSON">JSON</a>,
+      <a th:href="${'/' + records_or_entries_string + '.yaml' + pagination.formattedPageQueryParams }" data-download-type="YAML">YAML</a>,
+      <a th:href="${'/' + records_or_entries_string + '.ttl' + pagination.formattedPageQueryParams }" data-download-type="TTL">TTL</a>,
+      <a th:href="${'/' + records_or_entries_string + '.csv' + pagination.formattedPageQueryParams }" data-download-type="CSV">CSV</a> or
+      <a th:href="${'/' + records_or_entries_string + '.tsv' + pagination.formattedPageQueryParams }" data-download-type="TSV">TSV</a>.
     </p>
   </div>
 </html>


### PR DESCRIPTION
### Context

This PR fixes a bug for both `/records` and `/entries` which currently leads you to download the wrong data, unless you're viewing page 1 with the default page size of 100 (or for entries, the default `start` of 1 and `limit` of 100).

With this PR, a user wishing to download the particular `/records` they're viewing, say page=3 with page-size=150, will be able to download exactly this data. Similarly, they can download the `/entries` they're viewing, from start=150 with limit=200.

### Changes proposed in this pull request

Fix download links for `/records` and `/entries` to include paging info.

### Guidance to review

Go to `/records`, change `page-index` and `page-size`, then inspect the download URLs and try to download in various formats.

Similarly, for `/entries`, change `start` and `limit`, then inspect the download URLs and try to download in various formats.