### PR TITLE
remove /download route

### DIFF
--- a/src/main/java/uk/gov/register/resources/DataDownload.java
+++ b/src/main/java/uk/gov/register/resources/DataDownload.java
@@ -148,13 +148,5 @@ public class DataDownload {
                 .ok((StreamingOutput) output -> rsfService.writeTo(output, rsfFormatter, totalEntries1, totalEntries2))
                 .header("Content-Disposition", rsfFileName).build();
     }
-
-    @GET
-    @Path("/download")
-    @Produces(ExtraMediaType.TEXT_HTML)
-    @Timed
-    public View download() {
-        return viewFactory.downloadPageView(resourceConfiguration.getEnableDownloadResource());
-    }
 }
 


### PR DESCRIPTION
## Context
Follow up to: https://github.com/openregister/openregister-java/commit/356e94be8eafb08292e0a4b888a38de3ebc6ba56
Fixes #453

### Changes proposed in this pull request
Remove `/download` route as associated template was previously removed

### Guidance to review
`/download` should 404 not 500.
