### PR TITLE
Remove font and styling overrides to cardinality n fields

### DIFF
--- a/src/main/resources/assets/sass/main.scss
+++ b/src/main/resources/assets/sass/main.scss
@@ -176,11 +176,9 @@ a:visited {
 // Comma-separated lists
 .field-list {
   ul {
-    font-family: monospace;
-    letter-spacing: -1em;
     list-style: none;
-    padding-left: 0;
-    margin-top: 0;
+    padding: 0;
+    margin: 0;
 
     li {
       display: inline-block;


### PR DESCRIPTION
### Changes proposed in this pull request
Remove `monospace` font and styling overrides

### Guidance to review
- Remove the `openregister-org` class from the body
- View `/records` on any register with cardinality n fields

# After
![screen shot 2018-03-16 at 11 52 37](https://user-images.githubusercontent.com/3071606/37519415-eb222bf8-2910-11e8-8579-912a18d80649.png)
