### PR TITLE
 Fix bug where URL datatypes cause TTL views to return 500

### DIFF
--- a/src/main/java/uk/gov/register/core/LinkResolver.java
+++ b/src/main/java/uk/gov/register/core/LinkResolver.java
@@ -3,10 +3,7 @@ package uk.gov.register.core;
 import java.net.URI;
 
 public interface LinkResolver {
-    default URI resolve(LinkValue linkValue) {
-        return resolve(linkValue.getTargetRegister(), linkValue.getLinkKey());
-    }
     URI resolve(RegisterName register, String linkKey);
 
-    URI resolve(UrlValue urlValue);
+    URI resolve(LinkValue linkValue);
 }

--- a/src/main/java/uk/gov/register/core/LinkValue.java
+++ b/src/main/java/uk/gov/register/core/LinkValue.java
@@ -1,55 +1,16 @@
 package uk.gov.register.core;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
-/**
- * A value representing a link. Its "value" is a string representation. It also knows
- * its target register, and its primary key within the target register.
- *
- * For a regular LinkValue, the "value" and "linkKey" are the same. For a CurieValue, the "value"
- * is the Curie as a string, while the "linkKey" is the second half of the Curie (after the colon).
- */
-public class LinkValue implements FieldValue {
-    private final RegisterName targetRegister;
-    private final String value;
-    private final String linkKey;
-
-    public LinkValue(RegisterName registerName, String value) {
-        this(registerName, value, value);
-    }
-
-    private LinkValue(RegisterName registerName, String value, String linkKey){
-        this.targetRegister = registerName;
-        this.value = value;
-        this.linkKey = linkKey;
-    }
+public abstract class LinkValue implements FieldValue {
 
     @Override
     public boolean isLink() {
         return true;
     }
 
-    @Override
-    @JsonValue
-    public String getValue() {
-        return value;
-    }
+    public abstract boolean isLinkToRegister();
 
+    @Override
     public boolean isList() {
         return false;
-    }
-
-    public RegisterName getTargetRegister() {
-        return targetRegister;
-    }
-
-    public String getLinkKey() {
-        return linkKey;
-    }
-
-    public static class CurieValue extends LinkValue {
-        public CurieValue(String curieValue) {
-            super(new RegisterName(curieValue.split(":")[0]), curieValue, curieValue.split(":")[1]);
-        }
     }
 }

--- a/src/main/java/uk/gov/register/core/ListValue.java
+++ b/src/main/java/uk/gov/register/core/ListValue.java
@@ -14,6 +14,7 @@ public class ListValue implements FieldValue, Iterable<FieldValue> {
         this.elements = ImmutableList.copyOf(elements);
     }
 
+    @Override
     public boolean isList() {
         return true;
     }
@@ -33,6 +34,7 @@ public class ListValue implements FieldValue, Iterable<FieldValue> {
         return elements.stream();
     }
 
+    @Override
     public boolean isLink() {
         return false;
     }

--- a/src/main/java/uk/gov/register/core/RegisterLinkValue.java
+++ b/src/main/java/uk/gov/register/core/RegisterLinkValue.java
@@ -1,0 +1,51 @@
+package uk.gov.register.core;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * A value representing a link. Its "value" is a string representation. It also knows
+ * its target register, and its primary key within the target register.
+ *
+ * For a regular RegisterLinkValue, the "value" and "linkKey" are the same. For a CurieValue, the "value"
+ * is the Curie as a string, while the "linkKey" is the second half of the Curie (after the colon).
+ */
+public class RegisterLinkValue extends LinkValue implements FieldValue {
+    private final RegisterName targetRegister;
+    private final String value;
+    private final String linkKey;
+
+    public RegisterLinkValue(RegisterName registerName, String value) {
+        this(registerName, value, value);
+    }
+
+    private RegisterLinkValue(RegisterName registerName, String value, String linkKey){
+        this.targetRegister = registerName;
+        this.value = value;
+        this.linkKey = linkKey;
+    }
+
+    @Override
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean isLinkToRegister() {
+        return true;
+    }
+
+    public RegisterName getTargetRegister() {
+        return targetRegister;
+    }
+
+    public String getLinkKey() {
+        return linkKey;
+    }
+
+    public static class CurieValue extends RegisterLinkValue {
+        public CurieValue(String curieValue) {
+            super(new RegisterName(curieValue.split(":")[0]), curieValue, curieValue.split(":")[1]);
+        }
+    }
+}

--- a/src/main/java/uk/gov/register/core/UriTemplateLinkResolver.java
+++ b/src/main/java/uk/gov/register/core/UriTemplateLinkResolver.java
@@ -10,21 +10,19 @@ public class UriTemplateLinkResolver implements LinkResolver {
         this.registerResolver = registerResolver;
     }
 
-    // OGNL (Thymeleaf's language) can't find default methods by reflection
     @Override
     public URI resolve(LinkValue linkValue) {
-        return LinkResolver.super.resolve(linkValue);
+        if (linkValue.isLinkToRegister()) {
+            RegisterLinkValue registerLinkValue = (RegisterLinkValue) linkValue;
+            return resolve(registerLinkValue.getTargetRegister(), registerLinkValue.getLinkKey());
+        } else {
+            return URI.create(linkValue.getValue());
+        }
     }
 
-    @Override
     public URI resolve(RegisterName register, String linkKey) {
         URI baseUri = registerResolver.baseUriFor(register);
 
         return UriBuilder.fromUri(baseUri).path("record").path(linkKey).build();
-    }
-
-    @Override
-    public URI resolve(UrlValue urlValue) {
-        return URI.create(urlValue.getValue());
     }
 }

--- a/src/main/java/uk/gov/register/core/UrlValue.java
+++ b/src/main/java/uk/gov/register/core/UrlValue.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import javax.validation.constraints.NotNull;
 
-public class UrlValue implements FieldValue {
+public class UrlValue extends LinkValue implements FieldValue {
     @NotNull
     public final String value;
 
@@ -18,11 +18,8 @@ public class UrlValue implements FieldValue {
         return value;
     }
 
-    public boolean isLink() {
-        return true;
-    }
-
-    public boolean isList() {
+    @Override
+    public boolean isLinkToRegister() {
         return false;
     }
 }

--- a/src/main/java/uk/gov/register/service/ItemConverter.java
+++ b/src/main/java/uk/gov/register/service/ItemConverter.java
@@ -37,16 +37,16 @@ public class ItemConverter {
         try {
             if (field.getDatatype().getName().equals("curie")) {
                 if (value.textValue().contains(":")) {
-                    return new LinkValue.CurieValue(value.textValue());
+                    return new RegisterLinkValue.CurieValue(value.textValue());
                 }
 
-                return new LinkValue(field.getRegister().get(), value.textValue());
+                return new RegisterLinkValue(field.getRegister().get(), value.textValue());
             }
             else if (field.getDatatype().getName().equals("url")) {
                 return new UrlValue(value.textValue());
             }
             else if (field.getRegister().isPresent()) {
-                return new LinkValue(field.getRegister().get(), value.textValue());
+                return new RegisterLinkValue(field.getRegister().get(), value.textValue());
                 //Note: the equals check below must be replaced with the specified datatype, instead of doing string comparision
                 // We should replace this once the datatype register is available
             } else {

--- a/src/test/java/uk/gov/register/core/UriTemplateLinkResolverTest.java
+++ b/src/test/java/uk/gov/register/core/UriTemplateLinkResolverTest.java
@@ -14,10 +14,10 @@ public class UriTemplateLinkResolverTest {
 
     @Test
     public void linkValueReturnsLink() {
-        LinkValue linkValue = new LinkValue(new RegisterName("address"), "1111112");
+        RegisterLinkValue registerLinkValue = new RegisterLinkValue(new RegisterName("address"), "1111112");
 
-        assertThat(localResolver.resolve(linkValue), is(URI.create("http://address.openregister.dev:8080/record/1111112")));
-        assertThat(prodResolver.resolve(linkValue), is(URI.create("https://address.register.gov.uk/record/1111112")));
+        assertThat(localResolver.resolve(registerLinkValue), is(URI.create("http://address.openregister.dev:8080/record/1111112")));
+        assertThat(prodResolver.resolve(registerLinkValue), is(URI.create("https://address.register.gov.uk/record/1111112")));
     }
 
     @Test
@@ -30,8 +30,8 @@ public class UriTemplateLinkResolverTest {
 
     @Test
     public void curieValueReturnsCorrectLink() {
-        LinkValue.CurieValue charityCurieValue = new LinkValue.CurieValue("charity:123456");
-        LinkValue.CurieValue companyCurieValue = new LinkValue.CurieValue("company:654321");
+        RegisterLinkValue.CurieValue charityCurieValue = new RegisterLinkValue.CurieValue("charity:123456");
+        RegisterLinkValue.CurieValue companyCurieValue = new RegisterLinkValue.CurieValue("company:654321");
 
         assertThat(localResolver.resolve(charityCurieValue), is(URI.create("http://charity.openregister.dev:8080/record/123456")));
         assertThat(localResolver.resolve(companyCurieValue), is(URI.create("http://company.openregister.dev:8080/record/654321")));

--- a/src/test/java/uk/gov/register/service/ItemConverterTest.java
+++ b/src/test/java/uk/gov/register/service/ItemConverterTest.java
@@ -4,18 +4,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.jackson.Jackson;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import uk.gov.register.configuration.ConfigManager;
-import uk.gov.register.configuration.RegisterConfigConfiguration;
 import uk.gov.register.core.*;
 import uk.gov.register.exceptions.NoSuchConfigException;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -75,7 +69,7 @@ public class ItemConverterTest {
 
         FieldValue result = itemConverter.convert(entry, fieldsByName);
 
-        assertThat(result, instanceOf(LinkValue.class));
+        assertThat(result, instanceOf(RegisterLinkValue.class));
         assertThat(result.getValue(), equalTo("A school in the UK."));
     }
 
@@ -92,9 +86,10 @@ public class ItemConverterTest {
 
         FieldValue result = itemConverter.convert(entry, fieldsByName);
 
-        assertThat(result, instanceOf(LinkValue.CurieValue.class));
+        assertThat(result, instanceOf(RegisterLinkValue.CurieValue.class));
         assertThat(result.getValue(), equalTo("business:13245"));
     }
+
     @Test
     public void convert_shouldConvertEntryToUrlValue() {
         JsonNode jsonNode = mock(JsonNode.class);
@@ -111,6 +106,4 @@ public class ItemConverterTest {
         assertThat(result, instanceOf(UrlValue.class));
         assertThat(result.getValue(), equalTo("http://www.example.com"));
     }
-
-
 }

--- a/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
@@ -63,8 +63,8 @@ public class TurtleRepresentationWriterTest {
     public void rendersLinksCorrectlyAsUrls() throws Exception {
         Map<String, FieldValue> map =
                 ImmutableMap.of(
-                        "address", new LinkValue(new RegisterName("address"), "1111111"),
-                        "location", new LinkValue(new RegisterName("address"), "location-value"),
+                        "address", new RegisterLinkValue(new RegisterName("address"), "1111111"),
+                        "location", new RegisterLinkValue(new RegisterName("address"), "location-value"),
                         "name", new StringValue("foo")
                 );
 
@@ -86,7 +86,7 @@ public class TurtleRepresentationWriterTest {
     public void rendersLists() throws Exception {
         Map<String, FieldValue> map =
                 ImmutableMap.of(
-                        "link-values", new ListValue(asList(new LinkValue(new RegisterName("address"), "1111111"), new LinkValue(new RegisterName("address"), "2222222"))),
+                        "link-values", new ListValue(asList(new RegisterLinkValue(new RegisterName("address"), "1111111"), new RegisterLinkValue(new RegisterName("address"), "2222222"))),
                         "string-values", new ListValue(asList(new StringValue("value1"), new StringValue("value2"))),
                         "name", new StringValue("foo")
                 );


### PR DESCRIPTION
### Context
Currently fields with URL datatype cause TTL endpoints to 500. This is due to the below error.

```
"ERROR","level_value":40000,"stack_trace":"java.lang.ClassCastException: uk.gov.register.core.UrlValue cannot be cast to uk.gov.register.core.LinkValue\n\tat uk.gov.register.views.representations.turtle.ItemTurtleWriter$FieldRenderer.renderScalar(ItemTurtleWriter.java:77)
```

### Changes proposed in this pull request
This prevents a `ClassCastException` occurring in `ItemTurtleWriter`, which was previously trying to cast a `UrlValue` to a `LinkValue`. This change renames `LinkValue` to `RegisterLinkValue`. Both `UrlValue` and `RegisterLinkValue` now extend the new `LinkValue` class. The UrlTemplateLinkResolver` now resolves `LinkValues`, which prevents casting problems.

### Guidance to review
Ensure /records.ttl and /item/sha-256:abcde.ttl return a 200 for registers that contain a URL datatype (e.g. government-organisation and local-authority-nir). URLs should also be expressed as resources rather than properties. I.e.

Resource:
```
<https://www.gov.uk>
```

Property:
```
"https://www.gov.uk"
```