### PR TITLE
Rename DCMS to DDCMS

### DIFF
--- a/src/main/resources/config/public-bodies.yaml
+++ b/src/main/resources/config/public-bodies.yaml
@@ -50,9 +50,9 @@ legal-services-commission:
 civil-service-intelligence-analysis-profession:
   name: "Intelligence Analysis "
   public-body: "civil-service-intelligence-analysis-profession"
-department-for-culture-media-sport:
-  name: "Department for Culture, Media & Sport"
-  public-body: "department-for-culture-media-sport"
+department-for-digital-culture-media-sport:
+  name: "Department for Digital, Culture, Media & Sport"
+  public-body: "department-for-digital-culture-media-sport"
 bridgwater-education-action-zone:
   name: "Bridgwater Education Action Zone"
   public-body: "bridgwater-education-action-zone"


### PR DESCRIPTION
### Context

"Department for Culture, Media & Sport" is now "Department for Digital, Culture, Media & Sport" and has been renamed here https://www.gov.uk/api/organisations

This might be used as the registry of the data-sharing-agreement registers.  It hasn't yet been used as a registry of any other register.

### Changes proposed in this pull request

Rename and re-slug "Department for Culture, Media & Sport" `department-for-culture-media-sport` to "Department for Digital, Culture, Media & Sport" `department-for-digital-culture-media-sport`.

### Guidance to review

Is it okay to rename these things, or should a new entry be appended instead?