### PR TITLE
Instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See detailed steps for experimenting locally [here](RUNNING_LOCALLY.md).
 - `File > Open` your checkout directory
 - `Run > Edit Configurations`
 - Edit `RegisterRunner`
-- Use classpath of module: `openregister-java_main`
+- Use classpath of module: `openregister-java`
 - JRE: *select your installed JRE e.g.* `1.8`
 - `Run > Run... > RegisterRunner`
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See detailed steps for experimenting locally [here](RUNNING_LOCALLY.md).
 - `File > Open` your checkout directory
 - `Run > Edit Configurations`
 - Edit `RegisterRunner`
-- Use classpath of module: `openregister-java`
+- Use classpath of module: `openregister-java_main`
 - JRE: *select your installed JRE e.g.* `1.8`
 - `Run > Run... > RegisterRunner`
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A java implementation of a register
 
 You can spin up a local copy of `openregister-java` using Docker with the following:
 
-    ENVIRONMENT=beta REGISTERS=country ./run-application.sh
+    bash -c 'ENVIRONMENT=beta REGISTERS=country ./run-application.sh'
 
 This will do the following in Docker containers:
 

--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ task(loadSchoolDataForConformance, type: Exec) {
 }
 
 task createConformanceTestVenv(type: Exec) {
-    commandLine 'pyvenv-3.5', '.venv'
+    commandLine 'pyvenv', '.venv'
 }
 
 task installConformanceTestDeps(type: Exec) {


### PR DESCRIPTION
### Context

New user getting set up

### Changes proposed in this pull request

- make `run-application.sh` script usable even if you use an incompatible shell
- use the correct classpath of module (`openregister-java` without `_main`)
- be agnostic about the pyvenv version (in case you have 3.6 for instance)

### Guidance to review

The last 2 points are open to discussions, but they're changes I've had to make to get set up.