### PR TITLE
Banner should use register ID and not register name

### DIFF
--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
@@ -49,6 +49,11 @@ public class ThymeleafView extends View {
         return register.getRegisterName().orElse(getRegisterId().getFriendlyRegisterName()) + " register";
     }
 
+    @SuppressWarnings("unused, used by templates")
+    public String getFriendlyRegisterId() {
+        return getRegisterId().getFriendlyRegisterName() + " register";
+    }
+
     public RegisterId getRegisterId() {
         return register.getRegisterId();
     }

--- a/src/main/resources/templates/fragments/global-header.html
+++ b/src/main/resources/templates/fragments/global-header.html
@@ -6,12 +6,12 @@
     <header class='header' role='banner'>
       <div class='header__container'>
         <div class='header__brand' data-click-events="" data-click-category="Header" data-click-action="Logo Clicked">
-          <a href="/" th:title="'Go to ' + ${friendlyRegisterName} + ' API home'">
+          <a href="/" th:title="'Go to ' + ${friendlyRegisterId} + ' API home'">
             <span class='govuk-logo'>
               <img src="/assets/images/gov.uk_logotype_crown_invert_trans.png" width="36" height="32" alt="GOV.UK Registers" class="govuk-logo__printable-crown" /> GOV.UK
             </span>
             <span class='header__title'>
-              <span th:text="${friendlyRegisterName}">Registers</span>
+              <span th:text="${friendlyRegisterId}">Registers</span>
               API
             </span>
           </a>


### PR DESCRIPTION
### Context
The banner was using register name when present, which is long for DSA registers. See https://data-sharing-agreement-0001.cloudapps.digital/.

### Changes proposed in this pull request
Use register ID instead of name in the banner.