### PR TITLE
Implement RFC 0002 (URI Consolidation)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,8 @@ task runConformanceTests(type: Exec) {
 }
 
 check {
-    dependsOn << runConformanceTests
+// TODO: re-add this once we have updated the conformance tests to reflect RFC 0002
+//  dependsOn << runConformanceTests
     dependsOn << 'dependencyCheckAnalyze'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -180,8 +180,7 @@ task runConformanceTests(type: Exec) {
 }
 
 check {
-// TODO: re-add this once we have updated the conformance tests to reflect RFC 0002
-//  dependsOn << runConformanceTests
+    dependsOn << runConformanceTests
     dependsOn << 'dependencyCheckAnalyze'
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 csvvalidator==1.2
 jsonschema==2.5.1
--e git+https://github.com/openregister/conformance-test.git@9957c858530075729f96cc2505fc2087dd328c1c#egg=openregister_conformance-master
+-e git+https://github.com/openregister/conformance-test.git@5e9adaf6481970bcdc7f644fc631bd190355a29b#egg=openregister_conformance-master
 py==1.4.31
 pytest==2.9.0
 PyYAML==3.11

--- a/src/main/java/uk/gov/register/core/UriTemplateLinkResolver.java
+++ b/src/main/java/uk/gov/register/core/UriTemplateLinkResolver.java
@@ -23,6 +23,6 @@ public class UriTemplateLinkResolver implements LinkResolver {
     public URI resolve(RegisterId register, String linkKey) {
         URI baseUri = registerResolver.baseUriFor(register);
 
-        return UriBuilder.fromUri(baseUri).path("record").path(linkKey).build();
+        return UriBuilder.fromUri(baseUri).path("records").path(linkKey).build();
     }
 }

--- a/src/main/java/uk/gov/register/resources/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/EntryResource.java
@@ -38,7 +38,22 @@ public class EntryResource {
     }
 
     @GET
-    @Path("/entry/{entry-number}")
+    @Path("/entries")
+    @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
+    public PaginatedView<EntryListView> entriesHtml(@QueryParam("start") Optional<IntegerParam> optionalStart, @QueryParam("limit") Optional<IntegerParam> optionalLimit) {
+        int totalEntries = register.getTotalEntries();
+        StartLimitPagination startLimitPagination = new StartLimitPagination(optionalStart.map(IntParam::get), optionalLimit.map(IntParam::get), totalEntries);
+
+        Collection<Entry> entries = register.getEntries(startLimitPagination.start, startLimitPagination.limit);
+
+        setHeaders(startLimitPagination);
+
+        return viewFactory.getEntriesView(entries, startLimitPagination);
+    }
+
+    @GET
+    @Path("/entries/{entry-number}")
     @Produces(ExtraMediaType.TEXT_HTML)
     @Timed
     public AttributionView<Entry> findByEntryNumberHtml(@PathParam("entry-number") int entryNumber) {
@@ -47,7 +62,7 @@ public class EntryResource {
     }
 
     @GET
-    @Path("/entry/{entry-number}")
+    @Path("/entries/{entry-number}")
     @Produces({
             MediaType.APPLICATION_JSON,
             ExtraMediaType.TEXT_YAML,
@@ -62,20 +77,6 @@ public class EntryResource {
         return entry.map(function -> new EntryListView(Collections.singletonList(function)));
     }
 
-    @GET
-    @Path("/entries")
-    @Produces(ExtraMediaType.TEXT_HTML)
-    @Timed
-    public PaginatedView<EntryListView> entriesHtml(@QueryParam("start") Optional<IntegerParam> optionalStart, @QueryParam("limit") Optional<IntegerParam> optionalLimit) {
-        int totalEntries = register.getTotalEntries();
-        StartLimitPagination startLimitPagination = new StartLimitPagination(optionalStart.map(IntParam::get), optionalLimit.map(IntParam::get), totalEntries);
-
-        Collection<Entry> entries = register.getEntries(startLimitPagination.start, startLimitPagination.limit);
-
-        setHeaders(startLimitPagination);
-
-        return viewFactory.getEntriesView(entries, startLimitPagination);
-    }
 
     @GET
     @Path("/entries")

--- a/src/main/java/uk/gov/register/resources/ItemResource.java
+++ b/src/main/java/uk/gov/register/resources/ItemResource.java
@@ -15,7 +15,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.Optional;
 
-@Path("/item")
+@Path("/items")
 public class ItemResource {
     private final RegisterReadOnly register;
     private final ViewFactory viewFactory;

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -10,11 +10,13 @@ import uk.gov.register.views.*;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.*;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+
 
 @Path("/")
 public class RecordResource {
@@ -30,15 +32,17 @@ public class RecordResource {
     }
 
     @GET
-    @Path("/record/{record-key}")
+    @Path("/records/{record-key}")
     @Produces(ExtraMediaType.TEXT_HTML)
     @Timed
     public AttributionView<RecordView> getRecordByKeyHtml(@PathParam("record-key") String key) {
         return viewFactory.getRecordView(getRecordByKey(key));
     }
 
+
+
     @GET
-    @Path("/record/{record-key}")
+    @Path("/records/{record-key}")
     @Produces({
             MediaType.APPLICATION_JSON,
             ExtraMediaType.TEXT_YAML,
@@ -55,8 +59,10 @@ public class RecordResource {
                 .orElseThrow(NotFoundException::new);
     }
 
+
+
     @GET
-    @Path("/record/{record-key}/entries")
+    @Path("/records/{record-key}/entries")
     @Produces(ExtraMediaType.TEXT_HTML)
     @Timed
     public PaginatedView<EntryListView> getAllEntriesOfARecordHtml(@PathParam("record-key") String key) {
@@ -71,7 +77,7 @@ public class RecordResource {
     }
 
     @GET
-    @Path("/record/{record-key}/entries")
+    @Path("/records/{record-key}/entries")
     @Produces({
             MediaType.APPLICATION_JSON,
             ExtraMediaType.TEXT_YAML,

--- a/src/main/java/uk/gov/register/resources/RedirectResource.java
+++ b/src/main/java/uk/gov/register/resources/RedirectResource.java
@@ -33,6 +33,15 @@ public class RedirectResource {
     }
 
     @GET
+    @Path("/proof/entry/{entry-number}/{total-entries}/merkle:sha-256")
+    public Response getProofRedirect(
+            @Context HttpServletRequest request
+    )
+    {
+        return redirectByPath(request, "/entry/", "/entries/");
+    }
+
+    @GET
     @Path("/record/{record-key}")
     public Response getRecordByKeyRedirect(
             @Context HttpServletRequest request
@@ -48,6 +57,8 @@ public class RedirectResource {
     {
         return redirectByPath(request, "/record/", "/records/");
     }
+
+
 
     private static ResponseBuilder movedPermanently(URI location) {
         return status(Response.Status.MOVED_PERMANENTLY).location(location);

--- a/src/main/java/uk/gov/register/resources/RedirectResource.java
+++ b/src/main/java/uk/gov/register/resources/RedirectResource.java
@@ -1,0 +1,62 @@
+package uk.gov.register.resources;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriBuilder;
+
+import java.net.URI;
+
+import static javax.ws.rs.core.Response.status;
+
+@Path("/")
+public class RedirectResource {
+    @GET
+    @Path("/item/sha-256:{item-hash}")
+    public Response getEntryByNumberRedirect(
+            @Context HttpServletRequest request
+    )
+    {
+        return redirectByPath(request, "/item/", "/items/");
+    }
+
+    @GET
+    @Path("/entry/{entry-number}")
+    public Response getItemRedirect(
+            @Context HttpServletRequest request
+    )
+    {
+        return redirectByPath(request, "/entry/", "/entries/");
+    }
+
+    @GET
+    @Path("/record/{record-key}")
+    public Response getRecordByKeyRedirect(
+            @Context HttpServletRequest request
+    )
+    {
+        return redirectByPath(request, "/record/", "/records/");
+    }
+    @GET
+    @Path("/record/{record-key}/entries")
+    public Response getRecordEntriesRedirect(
+            @Context HttpServletRequest request
+    )
+    {
+        return redirectByPath(request, "/record/", "/records/");
+    }
+
+    private static ResponseBuilder movedPermanently(URI location) {
+        return status(Response.Status.MOVED_PERMANENTLY).location(location);
+    }
+
+    private static Response redirectByPath(@Context HttpServletRequest request, String oldPath, String newPath) {
+        String requestUrl = request.getRequestURL().toString();
+        String redirectUrl = requestUrl.replaceFirst(oldPath, newPath);
+        URI uri = UriBuilder.fromUri(redirectUrl).build();
+        return movedPermanently(uri).build();
+    }
+}

--- a/src/main/java/uk/gov/register/resources/RedirectResource.java
+++ b/src/main/java/uk/gov/register/resources/RedirectResource.java
@@ -15,6 +15,15 @@ import static javax.ws.rs.core.Response.status;
 @Path("/")
 public class RedirectResource {
     @GET
+    @Path("/proof/entry/{entry-number}/{total-entries}/merkle:sha-256")
+    public Response getProofRedirect(
+            @Context HttpServletRequest request
+    )
+    {
+        return redirectByPath(request, "/entry/", "/entries/");
+    }
+
+    @GET
     @Path("/item/sha-256:{item-hash}")
     public Response getEntryByNumberRedirect(
             @Context HttpServletRequest request
@@ -32,14 +41,6 @@ public class RedirectResource {
         return redirectByPath(request, "/entry/", "/entries/");
     }
 
-    @GET
-    @Path("/proof/entry/{entry-number}/{total-entries}/merkle:sha-256")
-    public Response getProofRedirect(
-            @Context HttpServletRequest request
-    )
-    {
-        return redirectByPath(request, "/entry/", "/entries/");
-    }
 
     @GET
     @Path("/record/{record-key}")
@@ -64,7 +65,7 @@ public class RedirectResource {
         return status(Response.Status.MOVED_PERMANENTLY).location(location);
     }
 
-    private static Response redirectByPath(@Context HttpServletRequest request, String oldPath, String newPath) {
+    public static Response redirectByPath(@Context HttpServletRequest request, String oldPath, String newPath) {
         String requestUrl = request.getRequestURL().toString();
         String redirectUrl = requestUrl.replaceFirst(oldPath, newPath);
         URI uri = UriBuilder.fromUri(redirectUrl).build();

--- a/src/main/java/uk/gov/register/resources/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/VerifiableLogResource.java
@@ -28,7 +28,7 @@ public class VerifiableLogResource {
     }
 
     @GET
-    @Path("/entry/{entry-number}/{total-entries}/merkle:sha-256")
+    @Path("/entries/{entry-number}/{total-entries}/merkle:sha-256")
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) {

--- a/src/main/java/uk/gov/register/resources/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/VerifiableLogResource.java
@@ -7,8 +7,13 @@ import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
 
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static uk.gov.register.resources.RedirectResource.redirectByPath;
 
 @Path("/proof")
 public class VerifiableLogResource {
@@ -25,6 +30,15 @@ public class VerifiableLogResource {
     @Timed
     public RegisterProof registerProof() {
         return register.getRegisterProof();
+    }
+
+    @GET
+    @Path("/entry/{entry-number}/{total-entries}/merkle:sha-256")
+    public Response getProofRedirect(
+            @Context HttpServletRequest request
+    )
+    {
+        return redirectByPath(request, "/entry/", "/entries/");
     }
 
     @GET

--- a/src/main/java/uk/gov/register/views/representations/turtle/ItemTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/ItemTurtleWriter.java
@@ -43,7 +43,7 @@ public class ItemTurtleWriter extends TurtleRepresentationWriter<ItemView> {
 
     private String fieldUri(String key) {
         URI fieldBaseUri = registerResolver.baseUriFor(new RegisterId("field"));
-        return UriBuilder.fromUri(fieldBaseUri).path("record").path(key).build().toString();
+        return UriBuilder.fromUri(fieldBaseUri).path("records").path(key).build().toString();
     }
 
     private class FieldRenderer {

--- a/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/RecordTurtleWriter.java
@@ -58,6 +58,6 @@ public class RecordTurtleWriter extends TurtleRepresentationWriter<Map.Entry<Ent
     }
 
     protected URI recordUri(String primaryKey) {
-        return UriBuilder.fromUri(ourBaseUri()).path("record").path(primaryKey).build();
+        return UriBuilder.fromUri(ourBaseUri()).path("records").path(primaryKey).build();
     }
 }

--- a/src/main/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriter.java
+++ b/src/main/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriter.java
@@ -34,7 +34,7 @@ public abstract class TurtleRepresentationWriter<T> extends RepresentationWriter
     protected abstract Model rdfModelFor(T view);
 
     protected URI entryUri(String entryNumber) {
-        return UriBuilder.fromUri(ourBaseUri()).path("entry").path(entryNumber).build();
+        return UriBuilder.fromUri(ourBaseUri()).path("entries").path(entryNumber).build();
     }
 
     protected URI ourBaseUri() {
@@ -42,7 +42,7 @@ public abstract class TurtleRepresentationWriter<T> extends RepresentationWriter
     }
 
     protected URI itemUri(String itemHash) {
-        return UriBuilder.fromUri(ourBaseUri()).path("item").path(itemHash).build();
+        return UriBuilder.fromUri(ourBaseUri()).path("items").path(itemHash).build();
     }
 
 }

--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -39,10 +39,10 @@
           <tbody>
             <tr th:each="entry : ${content.entries}">
               <td>
-                <a th:href="${'/entry/' + entry.entryNumber}" th:text="${entry.entryNumber}"></a>
+                <a th:href="${'/entries/' + entry.entryNumber}" th:text="${entry.entryNumber}"></a>
               </td>
               <td>
-                <p th:each="sha : ${entry.itemHashes}"><a th:href="${'/item/' + sha}" th:text="${sha}"></a></p>
+                <p th:each="sha : ${entry.itemHashes}"><a th:href="${'/items/' + sha}" th:text="${sha}"></a></p>
               </td>
               <td th:text="${entry.timestamp}"></td>
               <td th:text="${entry.key}"></td>

--- a/src/main/resources/templates/fragments/entry-table.html
+++ b/src/main/resources/templates/fragments/entry-table.html
@@ -22,7 +22,7 @@
       <tr>
         <td th:text="item-hash"></td>
         <td>
-          <span th:each="sha : ${entry.itemHashes}"><a th:href="${'/item/' + sha}" th:text="${sha}"></a> </span>
+          <span th:each="sha : ${entry.itemHashes}"><a th:href="${'/items/' + sha}" th:text="${sha}"></a> </span>
         </td>
       </tr>
       <tr>

--- a/src/main/resources/templates/fragments/record-table.html
+++ b/src/main/resources/templates/fragments/record-table.html
@@ -15,9 +15,9 @@
     </thead>
     <tbody>
     <th:block th:each="record : ${records}">
-      <tr th:each="item : ${record}" th:with="firstItemColumnLink = ${view.displayEntryKeyColumn()} ? ${null} : ${'../record/' + record.key}">
+      <tr th:each="item : ${record}" th:with="firstItemColumnLink = ${view.displayEntryKeyColumn()} ? ${null} : ${'../records/' + record.key}">
         <td th:if="${view.displayEntryKeyColumn()}">
-          <a th:href="${'./record/' + record.key}" th:text="${record.key}"></a>
+          <a th:href="${'./records/' + record.key}" th:text="${record.key}"></a>
         </td>
         <div th:include="fragments/record-table-item-cells.html :: record-table-item-cells (item = ${item}, fieldNames = ${itemFieldNames}, resolveAllLinks = ${view.resolveAllItemLinks()}, firstColumnLink = ${firstItemColumnLink})"></div>
       </tr>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -32,7 +32,7 @@
 
           <p><code class="code"><a href="/entries">/entries</a></code> returns a list of all entries, ordered by entry number. An entry describes an update to the register and the list of entries can be used to see historic changes or check for new updates to a register. Each entry in a register is linked to an item by a unique item-hash.</p>
 
-          <p><code class="code">/item/{item-hash}</code> returns an individual item. Items are the actual data contained within a register.</p>
+          <p><code class="code">/items/{item-hash}</code> returns an individual item. Items are the actual data contained within a register.</p>
 
           <h3 class="heading-small">Ruby client library</h3>
           <p>We have a <a href="https://github.com/openregister/registers-ruby-client" target="_blank">client library</a> that provides the same API in the Ruby language.</p>

--- a/src/main/resources/templates/record.html
+++ b/src/main/resources/templates/record.html
@@ -27,7 +27,7 @@
           th:include="fragments/record-table.html :: record-table (view = ${content}, records = ${content.recordsSimple})"
           class="table-wrapper"></div>
       <p>
-        <a th:href="${'/record/' + content.entryKey +'/entries'}">View all versions of this record</a>
+        <a th:href="${'/records/' + content.entryKey +'/entries'}">View all versions of this record</a>
       </p>
 
     </main>

--- a/src/test/java/uk/gov/register/core/UriTemplateLinkResolverTest.java
+++ b/src/test/java/uk/gov/register/core/UriTemplateLinkResolverTest.java
@@ -16,8 +16,8 @@ public class UriTemplateLinkResolverTest {
     public void linkValueReturnsLink() {
         RegisterLinkValue registerLinkValue = new RegisterLinkValue(new RegisterId("address"), "1111112");
 
-        assertThat(localResolver.resolve(registerLinkValue), is(URI.create("http://address.openregister.dev:8080/record/1111112")));
-        assertThat(prodResolver.resolve(registerLinkValue), is(URI.create("https://address.register.gov.uk/record/1111112")));
+        assertThat(localResolver.resolve(registerLinkValue), is(URI.create("http://address.openregister.dev:8080/records/1111112")));
+        assertThat(prodResolver.resolve(registerLinkValue), is(URI.create("https://address.register.gov.uk/records/1111112")));
     }
 
     @Test
@@ -33,12 +33,12 @@ public class UriTemplateLinkResolverTest {
         RegisterLinkValue.CurieValue charityCurieValue = new RegisterLinkValue.CurieValue("charity:123456");
         RegisterLinkValue.CurieValue companyCurieValue = new RegisterLinkValue.CurieValue("company:654321");
 
-        assertThat(localResolver.resolve(charityCurieValue), is(URI.create("http://charity.openregister.dev:8080/record/123456")));
-        assertThat(localResolver.resolve(companyCurieValue), is(URI.create("http://company.openregister.dev:8080/record/654321")));
+        assertThat(localResolver.resolve(charityCurieValue), is(URI.create("http://charity.openregister.dev:8080/records/123456")));
+        assertThat(localResolver.resolve(companyCurieValue), is(URI.create("http://company.openregister.dev:8080/records/654321")));
     }
 
     @Test
     public void separateRegisterAndValueReturnsCorrectLink() throws Exception {
-        assertThat(localResolver.resolve(new RegisterId("country"),"CZ"), is(URI.create("http://country.openregister.dev:8080/record/CZ")));
+        assertThat(localResolver.resolve(new RegisterId("country"),"CZ"), is(URI.create("http://country.openregister.dev:8080/records/CZ")));
     }
 }

--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -51,8 +51,8 @@ public class EntryResourceFunctionalTest {
         assertThat(response.getStatus(), equalTo(200));
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
-        String entry1Text = doc.getElementsByTag("table").select("a[href=/item/" + item1Hash + "]").first().text();
-        String entry2Text = doc.getElementsByTag("table").select("a[href=/item/" + item2Hash + "]").first().text();
+        String entry1Text = doc.getElementsByTag("table").select("a[href=/items/" + item1Hash + "]").first().text();
+        String entry2Text = doc.getElementsByTag("table").select("a[href=/items/" + item2Hash + "]").first().text();
 
         assertThat(entry1Text, equalTo(item1Hash));
         assertThat(entry2Text, equalTo(item2Hash));
@@ -90,7 +90,7 @@ public class EntryResourceFunctionalTest {
 
     @Test
     public void getEntryByEntryNumber() throws JSONException, IOException {
-        Response response = register.getRequest(address, "/entry/1.json");
+        Response response = register.getRequest(address, "/entries/1.json");
 
         assertThat(response.getStatus(), equalTo(200));
         JsonNode res = Jackson.newObjectMapper().readValue(response.readEntity(String.class), JsonNode.class);
@@ -100,10 +100,10 @@ public class EntryResourceFunctionalTest {
 
     @Test
     public void entryView_itemHashIsRenderedAsALink() {
-        Response response = register.getRequest(address, "/entry/1", TEXT_HTML);
+        Response response = register.getRequest(address, "/entries/1", TEXT_HTML);
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
-        String text = doc.getElementsByTag("table").select("a[href=/item/" + item1Hash + "]").first().text();
+        String text = doc.getElementsByTag("table").select("a[href=/items/" + item1Hash + "]").first().text();
         assertThat(text, equalTo(item1Hash));
     }
 
@@ -114,17 +114,17 @@ public class EntryResourceFunctionalTest {
 
     @Test
     public void return404ResponseWhenEntryNotExist() {
-        assertThat(register.getRequest(address, "/entry/5001", MediaType.TEXT_HTML).getStatus(), equalTo(404));
+        assertThat(register.getRequest(address, "/entries/5001", MediaType.TEXT_HTML).getStatus(), equalTo(404));
     }
 
     @Test
     public void return404ResponseWhenEntryNumberIsNotAnIntegerValue() {
-        assertThat(register.getRequest(address, "/entry/a2").getStatus(), equalTo(404));
+        assertThat(register.getRequest(address, "/entries/a2").getStatus(), equalTo(404));
     }
 
     @Test
     public void entryResource_retrievesTimestampsInUTC() throws IOException {
-        Response response = register.getRequest(address, "/entry/2.json");
+        Response response = register.getRequest(address, "/entries/2.json");
         Map<String, String> responseData = Jackson.newObjectMapper().convertValue(response.readEntity(JsonNode.class).get(0), Map.class);
         assertThat(responseData.get("entry-timestamp"), is("2017-06-09T10:23:22Z"));
     }

--- a/src/test/java/uk/gov/register/functional/RepresentationsFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RepresentationsFunctionalTest.java
@@ -77,7 +77,7 @@ public class RepresentationsFunctionalTest {
     public void representationIsSupportedForEntryResource() {
         assumeThat(expectedEntryValue, notNullValue());
 
-        Response response = register.getRequest(TestRegister.register, "/entry/1." + extension);
+        Response response = register.getRequest(TestRegister.register, "/entries/1." + extension);
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));
@@ -88,7 +88,7 @@ public class RepresentationsFunctionalTest {
     public void representationIsSupportedForItemResource() {
         assumeThat(expectedItemValue, notNullValue());
 
-        Response response = register.getRequest(TestRegister.register, "/item/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18." + extension);
+        Response response = register.getRequest(TestRegister.register, "/items/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18." + extension);
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));
@@ -99,7 +99,7 @@ public class RepresentationsFunctionalTest {
     public void representationIsSupportedForRecordResource() {
         assumeThat(expectedRecordValue, notNullValue());
 
-        Response response = register.getRequest(TestRegister.register, "/record/value1." + extension);
+        Response response = register.getRequest(TestRegister.register, "/records/value1." + extension);
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));
@@ -132,7 +132,7 @@ public class RepresentationsFunctionalTest {
     public void representationIsSupportedForRecordEntriesResource() {
         assumeThat(expectedRecordEntriesValue, notNullValue());
 
-        Response response = register.getRequest(TestRegister.register, "/record/value1/entries." + extension);
+        Response response = register.getRequest(TestRegister.register, "/records/value1/entries." + extension);
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));

--- a/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
@@ -67,7 +67,7 @@ public class VerifiableLogResourceFunctionalTest {
 
     @Test
     public void getEntryProof() {
-        Response response = register.getRequest(address, "/proof/entry/1/5/" + proofIdentifier);
+        Response response = register.getRequest(address, "/proof/entries/1/5/" + proofIdentifier);
 
         assertThat(response.getStatus(), equalTo(200));
 
@@ -97,8 +97,8 @@ public class VerifiableLogResourceFunctionalTest {
         // This tests that we are mapping entry numbers (one-indexed) to leaf indexes correctly (zero-indexed).
         // In the case that we accidentally map to zero-indexed entry nubers this test would fail
 
-        Response entry1Proof = register.getRequest(address, "/proof/entry/1/2/" + proofIdentifier);
-        Response entry2Proof = register.getRequest(address, "/proof/entry/2/2/" + proofIdentifier);
+        Response entry1Proof = register.getRequest(address, "/proof/entries/1/2/" + proofIdentifier);
+        Response entry2Proof = register.getRequest(address, "/proof/entries/2/2/" + proofIdentifier);
 
         assertThat(entry1Proof.getStatus(), equalTo(200));
         assertThat(entry2Proof.getStatus(), equalTo(200));
@@ -122,9 +122,9 @@ public class VerifiableLogResourceFunctionalTest {
         // We get a proof of the same shape from two different registers, and verify that there are no
         // hashes that exist in both proofs.
 
-        List<String> addressAuditPath = (List<String>) register.getRequest(address, "/proof/entry/3/5/" + proofIdentifier)
+        List<String> addressAuditPath = (List<String>) register.getRequest(address, "/proof/entries/3/5/" + proofIdentifier)
                 .readEntity(Map.class).get("merkle-audit-path");
-        List<String> postcodeAuditPath = (List<String>) register.getRequest(postcode, "/proof/entry/3/5/" + proofIdentifier)
+        List<String> postcodeAuditPath = (List<String>) register.getRequest(postcode, "/proof/entries/3/5/" + proofIdentifier)
                 .readEntity(Map.class).get("merkle-audit-path");
 
         assertThat(addressAuditPath, everyItem(not(isIn(postcodeAuditPath))));

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -31,10 +31,10 @@ public class RegisterRule implements TestRule {
     private final WipeDatabaseRule wipeRule;
     private DropwizardAppRule<RegisterConfiguration> appRule;
 
-    private TestRule wholeRule;
+    protected TestRule wholeRule;
 
-    private Client client;
-    private List<Handle> handles = new ArrayList<>();
+    protected Client client;
+    protected List<Handle> handles = new ArrayList<>();
 
     public RegisterRule() {
         this.appRule = new DropwizardAppRule<>(RegisterApplication.class,
@@ -98,7 +98,7 @@ public class RegisterRule implements TestRule {
         wipeRule.before();
     }
 
-    private JerseyClientBuilder clientBuilder() {
+    protected JerseyClientBuilder clientBuilder() {
         InMemoryDnsResolver customDnsResolver = new InMemoryDnsResolver();
         for (TestRegister register : TestRegister.values()) {
             customDnsResolver.add(register.getHostname(), InetAddress.getLoopbackAddress());

--- a/src/test/java/uk/gov/register/functional/app/RegistersRuleDisableFollowRedirects.java
+++ b/src/test/java/uk/gov/register/functional/app/RegistersRuleDisableFollowRedirects.java
@@ -1,0 +1,23 @@
+package uk.gov.register.functional.app;
+
+import org.glassfish.jersey.client.ClientProperties;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.skife.jdbi.v2.Handle;
+
+public class RegistersRuleDisableFollowRedirects extends RegisterRule
+{
+   @Override
+   public Statement apply(Statement base, Description description) {
+       Statement me = new Statement() {
+           @Override
+           public void evaluate() throws Throwable {
+               client = clientBuilder().build("test client")
+                       .property(ClientProperties.FOLLOW_REDIRECTS, Boolean.FALSE);
+               base.evaluate();
+               handles.forEach(Handle::close);
+           }
+       };
+       return wholeRule.apply(me, description);
+   }
+}

--- a/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
@@ -1,0 +1,76 @@
+package uk.gov.register.resources;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.register.functional.app.RegisterRule;
+import uk.gov.register.functional.app.RegistersRuleDisableFollowRedirects;
+import uk.gov.register.functional.app.RsfRegisterDefinition;
+
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.MediaType.WILDCARD;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.register.functional.app.TestRegister.address;
+
+public class RedirectResourceTest  {
+    @ClassRule
+    public static RegisterRule register = new RegistersRuleDisableFollowRedirects();
+
+    private String addressRsf(){
+        return "add-item\t{\"address\":\"6789\",\"street\":\"elvis\"}\n" +
+                "append-entry\tuser\t6789\t2017-06-09T10:23:22Z\tsha-256:9432331d3343a7ceaaee46308069d01836460294c672223b236727a790acf786\n" +
+                "add-item\t{\"address\":\"6790\",\"street\":\"presley\"}\n" +
+                "append-entry\tuser\t6790\t2017-06-09T10:23:22Z\tsha-256:fdd8a3c301f1e8d117ce284d4e67f3b797f4dc573c8d40de502f540709f03007";
+    }
+
+    @Before
+    public void publishTestMessages() throws Throwable {
+        register.wipe();
+        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER + addressRsf());
+    }
+
+    @Test
+    public void getEntryByNumberRedirect() throws Exception {
+        Response response = register.getRequest(address, "/entry/1", WILDCARD);
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getLocation().getPath(), equalTo("/entries/1"));
+    }
+
+    @Test
+    public void getItemRedirect() throws Exception {
+        Response response = register.getRequest(address, "/item/sha-256:9432331d3343a7ceaaee46308069d01836460294c672223b236727a790acf786", WILDCARD);
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getLocation().getPath(), equalTo("/items/sha-256:9432331d3343a7ceaaee46308069d01836460294c672223b236727a790acf786"));
+    }
+
+    @Test
+    public void getProofRedirect() throws Exception {
+        Response response = register.getRequest(address, "/proof/entry/1/2/merkle:sha-256", WILDCARD);
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getLocation().getPath(), equalTo("/proof/entries/1/2/merkle:sha-256"));
+    }
+
+    @Test
+    public void getRecordByKeyRedirect() throws Exception {
+        Response response = register.getRequest(address, "/record/elvis", WILDCARD);
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getLocation().getPath(), equalTo("/records/elvis"));
+    }
+
+    @Test
+    public void getRecordByKeyRedirectRetainsFormat() throws Exception {
+        Response response = register.getRequest(address, "/record/elvis.json", WILDCARD);
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getLocation().getPath(), equalTo("/records/elvis.json"));
+    }
+
+    @Test
+    public void getRecordEntriesRedirect() throws Exception {
+        Response response = register.getRequest(address, "/record/elvis/entries", WILDCARD);
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getLocation().getPath(), equalTo("/records/elvis/entries"));
+    }
+
+}

--- a/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
@@ -45,7 +45,7 @@ public class TurtleRepresentationWriterTest {
         writer.writeTo(itemView, itemView.getClass(), null, null, null, null, outputStream);
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);
-        assertThat(generatedTtl, containsString("@prefix field:   <http://field.test.register.gov.uk/record/> ."));
+        assertThat(generatedTtl, containsString("@prefix field:   <http://field.test.register.gov.uk/records/> ."));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class TurtleRepresentationWriterTest {
         writer.writeTo(entry, entry.getClass(), null, null, null, null, outputStream);
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);
-        assertThat(generatedTtl, containsString("<http://address.test.register.gov.uk/entry/52>"));
+        assertThat(generatedTtl, containsString("<http://address.test.register.gov.uk/entries/52>"));
     }
 
     @Test
@@ -78,10 +78,10 @@ public class TurtleRepresentationWriterTest {
         writer.writeTo(itemView, itemView.getClass(), null, null, null, null, outputStream);
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);
-        assertThat(generatedTtl, containsString("field:address <http://address.test.register.gov.uk/record/1111111>"));
-        assertThat(generatedTtl, containsString("field:location <http://address.test.register.gov.uk/record/location-value>"));
+        assertThat(generatedTtl, containsString("field:address <http://address.test.register.gov.uk/records/1111111>"));
+        assertThat(generatedTtl, containsString("field:location <http://address.test.register.gov.uk/records/location-value>"));
         assertThat(generatedTtl, containsString("field:name \"foo\""));
-        assertThat(generatedTtl, containsString("<http://address.test.register.gov.uk/item/sha-256:itemhash>"));
+        assertThat(generatedTtl, containsString("<http://address.test.register.gov.uk/items/sha-256:itemhash>"));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class TurtleRepresentationWriterTest {
         byte[] bytes = outputStream.toByteArray();
         String generatedTtl = new String(bytes, StandardCharsets.UTF_8);
 
-        assertThat(generatedTtl, containsString("field:link-values <http://address.test.register.gov.uk/record/1111111> , <http://address.test.register.gov.uk/record/2222222>"));
+        assertThat(generatedTtl, containsString("field:link-values <http://address.test.register.gov.uk/records/1111111> , <http://address.test.register.gov.uk/records/2222222>"));
         assertThat(generatedTtl, containsString("field:string-values \"value2\" , \"value1\""));
         assertThat(generatedTtl, containsString("field:name \"foo\""));
     }

--- a/src/test/resources/fixtures/entries.ttl
+++ b/src/test/resources/fixtures/entries.ttl
@@ -1,21 +1,21 @@
 @prefix register-metadata:  <https://openregister.github.io/specification/#> .
 
-<http://register.test.register.gov.uk/entry/2>
+<http://register.test.register.gov.uk/entries/2>
       register-metadata:entry-number-field
               "2" ;
       register-metadata:entry-timestamp-field
               "2016-03-02T02:03:04Z" ;
       register-metadata:item-resource
-              <http://register.test.register.gov.uk/item/sha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7> ;
+              <http://register.test.register.gov.uk/items/sha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7> ;
       register-metadata:key-field
               "value2" .
 
-<http://register.test.register.gov.uk/entry/1>
+<http://register.test.register.gov.uk/entries/1>
       register-metadata:entry-number-field
               "1" ;
       register-metadata:entry-timestamp-field
               "2016-03-01T01:02:03Z" ;
       register-metadata:item-resource
-              <http://register.test.register.gov.uk/item/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18> ;
+              <http://register.test.register.gov.uk/items/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18> ;
       register-metadata:key-field
               "value1" .

--- a/src/test/resources/fixtures/entry.ttl
+++ b/src/test/resources/fixtures/entry.ttl
@@ -1,11 +1,11 @@
 @prefix register-metadata:  <https://openregister.github.io/specification/#> .
 
-<http://register.test.register.gov.uk/entry/1>
+<http://register.test.register.gov.uk/entries/1>
       register-metadata:entry-number-field
               "1" ;
       register-metadata:entry-timestamp-field
               "2016-03-01T01:02:03Z" ;
       register-metadata:item-resource
-              <http://register.test.register.gov.uk/item/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18> ;
+              <http://register.test.register.gov.uk/items/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18> ;
       register-metadata:key-field
               "value1" .

--- a/src/test/resources/fixtures/item.ttl
+++ b/src/test/resources/fixtures/item.ttl
@@ -1,6 +1,6 @@
-@prefix field:   <http://field.test.register.gov.uk/record/> .
+@prefix field:   <http://field.test.register.gov.uk/records/> .
 
-<http://register.test.register.gov.uk/item/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18>
+<http://register.test.register.gov.uk/items/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18>
       field:fields field:field1 ;
-      field:register <http://register.test.register.gov.uk/record/value1> ;
+      field:register <http://register.test.register.gov.uk/records/value1> ;
       field:text "The Entry 1" .

--- a/src/test/resources/fixtures/list.ttl
+++ b/src/test/resources/fixtures/list.ttl
@@ -1,24 +1,24 @@
-@prefix field:   <http://field.test.register.gov.uk/record/> .
+@prefix field:   <http://field.test.register.gov.uk/records/> .
 @prefix register-metadata:  <https://openregister.github.io/specification/#> .
 
-<http://register.test.register.gov.uk/record/value1>
+<http://register.test.register.gov.uk/records/value1>
       field:fields field:field1 ;
-      field:register <http://register.test.register.gov.uk/record/value1> ;
+      field:register <http://register.test.register.gov.uk/records/value1> ;
       field:text "The Entry 1" ;
       register-metadata:entry-number-field
               "1" ;
       register-metadata:entry-timestamp-field
               "2016-03-01T01:02:03Z" ;
       register-metadata:item-resource
-              <http://register.test.register.gov.uk/item/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18> .
+              <http://register.test.register.gov.uk/items/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18> .
 
-<http://register.test.register.gov.uk/record/value2>
+<http://register.test.register.gov.uk/records/value2>
       field:fields field:field1 , field:field2 ;
-      field:register <http://register.test.register.gov.uk/record/value2> ;
+      field:register <http://register.test.register.gov.uk/records/value2> ;
       field:text "The Entry 2" ;
       register-metadata:entry-number-field
               "2" ;
       register-metadata:entry-timestamp-field
               "2016-03-02T02:03:04Z" ;
       register-metadata:item-resource
-              <http://register.test.register.gov.uk/item/sha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7> .
+              <http://register.test.register.gov.uk/items/sha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7> .

--- a/src/test/resources/fixtures/record-entries.ttl
+++ b/src/test/resources/fixtures/record-entries.ttl
@@ -1,11 +1,11 @@
 @prefix register-metadata:  <https://openregister.github.io/specification/#> .
 
-<http://register.test.register.gov.uk/entry/1>
+<http://register.test.register.gov.uk/entries/1>
       register-metadata:entry-number-field
               "1" ;
       register-metadata:entry-timestamp-field
               "2016-03-01T01:02:03Z" ;
       register-metadata:item-resource
-              <http://register.test.register.gov.uk/item/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18> ;
+              <http://register.test.register.gov.uk/items/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18> ;
       register-metadata:key-field
               "value1" .

--- a/src/test/resources/fixtures/record.ttl
+++ b/src/test/resources/fixtures/record.ttl
@@ -1,13 +1,13 @@
-@prefix field:   <http://field.test.register.gov.uk/record/> .
+@prefix field:   <http://field.test.register.gov.uk/records/> .
 @prefix register-metadata:  <https://openregister.github.io/specification/#> .
 
-<http://register.test.register.gov.uk/record/value1>
+<http://register.test.register.gov.uk/records/value1>
       field:fields field:field1 ;
-      field:register <http://register.test.register.gov.uk/record/value1> ;
+      field:register <http://register.test.register.gov.uk/records/value1> ;
       field:text "The Entry 1" ;
       register-metadata:entry-number-field
               "1" ;
       register-metadata:entry-timestamp-field
               "2016-03-01T01:02:03Z" ;
       register-metadata:item-resource
-              <http://register.test.register.gov.uk/item/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18> .
+              <http://register.test.register.gov.uk/items/sha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18> .

--- a/src/test/resources/fixtures/single.ttl
+++ b/src/test/resources/fixtures/single.ttl
@@ -1,6 +1,6 @@
 @prefix field: <http://field.test.register.gov.uk/field/>.
 
-<http://register.beta.openregister.org/entry/1>
+<http://register.beta.openregister.org/entries/1>
  field:register <http://register.test.register.gov.uk/register/value1> ;
  field:text "The Entry 1" ;
  field:fields <http://field.test.register.gov.uk/field/field1> .


### PR DESCRIPTION
### Context
https://github.com/openregister/registers-rfcs/blob/master/content/uri-consolidation/index.md

### Changes proposed in this pull request
Implement [RFC 0002](https://github.com/openregister/registers-rfcs/blob/master/content/uri-consolidation/index.md)

### Guidance to review
Canonical URLs should be changed as per RFC e.g. http://localhost:8080/records/400673.json should resolve
Old URLs should 301 redirect as per RFC e.g. http://localhost:8080/record/400673 --> http://localhost:8080/records/400673

N.B. Conformance tests are broken because they do not reflect this RFC. Specifically the URLs within the Turtle representation. We should update them after this PR is merged.
