### PR TITLE
Fix docker network name

### DIFF
--- a/docker-compose.register.yml
+++ b/docker-compose.register.yml
@@ -12,8 +12,8 @@ services:
       - ./config.docker.register.yaml:/srv/openregister-java/config.yaml:ro
       - ./deploy/openregister-java.jar:/srv/openregister-java/openregister-java.jar:ro
     networks:
-      - openregisterjava_default
+      - registers_default
 
 networks:
-  openregisterjava_default:
+  registers_default:
     external: true

--- a/run-application.sh
+++ b/run-application.sh
@@ -13,7 +13,7 @@ esac
 function on_exit {
   echo "Stopping and removing containers..."
   docker-compose --file docker-compose.register.yml down
-  docker-compose --file docker-compose.basic.yml down
+  docker-compose -p registers --file docker-compose.basic.yml down
   exit
 }
 
@@ -49,7 +49,7 @@ fi
 
 echo "Starting environment based off \"$ENVIRONMENT\""
 echo "Starting basic registers..."
-docker-compose --file docker-compose.basic.yml up -d
+docker-compose -p registers --file docker-compose.basic.yml up -d
 wait_for_http_on_port 8081 openregister-basic
 
 for register in "register" "datatype" "field"; do


### PR DESCRIPTION
### Context

The dockerised version of ORJ uses two Docker Compose config files. The first sets up the network, the second one attaches to it. The problem is that by default Docker Compose relies on the current directory to determine the network name so if you happen to have the project in a directory with another name the setup will break.

### Changes proposed in this pull request

Fix the Docker Compose project name to `registers` so the shared network is always `registers_default`.

### Guidance to review

Run `./run-application.sh` and expect it to deploy two containers with ORJ (8081 and 8080) and one postgres container (5432). Also expect it to clean up itself after stopping the script.