### PR TITLE
Iterate on entry table instead of index table to generate RSF

### DIFF
--- a/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
@@ -53,6 +53,9 @@ public abstract class PostgresReadDataAccessLayer implements DataAccessLayer {
 
     @Override
     public Iterator<Entry> getEntryIterator(String indexName) {
+        if (indexName.equals(IndexNames.RECORD)) {
+            entryQueryDAO.getIterator(schema);
+        }
         return indexQueryDAO.getIterator(indexName, schema, indexName.equals(IndexNames.METADATA) ? "entry_system" : "entry");
     }
 

--- a/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
@@ -53,6 +53,9 @@ public abstract class PostgresReadDataAccessLayer implements DataAccessLayer {
 
     @Override
     public Iterator<Entry> getEntryIterator(String indexName) {
+    // TODO: Remove if statement and use indexQueryDAO for RECORD index. This can only be done once the government-service
+    // register no longer contains duplicate consecutive entries. Else we should not make the assumption that duplicate
+    // consecutive entries do not exist.
         if (indexName.equals(IndexNames.RECORD)) {
             entryQueryDAO.getIterator(schema);
         }


### PR DESCRIPTION
### Context
There was a recent refactor to use the indexing code for both index and "register" actions, including creating RSF. The code that reads the index table makes the assumption that there have been no identical consecutive entries appended to the register. This is not true for the existing government-service register and therefore means that RSF is generated incorrectly for this register.

### Changes proposed in this pull request
Revert previous change to use indexing code for generating RSF. This is a temporary solution. Long term we should either fix the history of the government-service register or no longer depend on this rule to generate RSF.

### Guidance to review
Generating RSF for government-service should not generate multi-item entries. I have tested this by loading the government-service RSF locally and commenting out the code that rejects consecutive identical entries.