### PR TITLE
Fix /download-rsf/n for registers with identical consecutive entries

### DIFF
--- a/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresReadDataAccessLayer.java
@@ -64,6 +64,12 @@ public abstract class PostgresReadDataAccessLayer implements DataAccessLayer {
 
     @Override
     public Iterator<Entry> getEntryIterator(String indexName, int totalEntries1, int totalEntries2) {
+        // TODO: Remove if statement and use indexQueryDAO for RECORD index. This can only be done once the government-service
+        // register no longer contains duplicate consecutive entries. Else we should not make the assumption that duplicate
+        // consecutive entries do not exist.
+        if (indexName.equals(IndexNames.RECORD)) {
+            return entryQueryDAO.getIterator(totalEntries1, totalEntries2, schema);
+        }
         return indexQueryDAO.getIterator(indexName, totalEntries1, totalEntries2, schema, indexName.equals(IndexNames.METADATA) ? "entry_system" : "entry");
     }
 


### PR DESCRIPTION
### Context
See https://github.com/openregister/openregister-java/pull/468 - this fixed `/download-rsf` but did not fix `/download-rsf/n` or `/download-rsf/n/m`.

### Changes proposed in this pull request
Fix `/download-rsf/n` or `/download-rsf/n/m` for government-service by reverting away from indexing code.

### Guidance to review
This should actually work this time.