### PR TITLE
Add nhs-digital to list of public-bodies

### DIFF
--- a/src/main/resources/config/public-bodies.yaml
+++ b/src/main/resources/config/public-bodies.yaml
@@ -2860,6 +2860,6 @@ the-electoral-commission:
 department-for-communities-northern-ireland:
   name: "Department for Communities (Northern Ireland)"
   public-body: "department-for-communities-northern-ireland"
-nhs-digital
+nhs-digital:
   name: "NHS Digital"
   public-body: "nhs-digital" 

--- a/src/main/resources/config/public-bodies.yaml
+++ b/src/main/resources/config/public-bodies.yaml
@@ -2859,4 +2859,7 @@ the-electoral-commission:
   public-body: "the-electoral-commission"
 department-for-communities-northern-ireland:
   name: "Department for Communities (Northern Ireland)"
-  public-body: "department-for-communities-northern-ireland" 
+  public-body: "department-for-communities-northern-ireland"
+nhs-digital
+  name: "NHS Digital"
+  public-body: "nhs-digital" 


### PR DESCRIPTION
### Context
A new register owned by NHS Digital is going to be created. This means it needs to be in the list of public-bodies.

Currently ORJ uses the GOV.UK API to get logos etc. The current code checks the list of `public-bodies.yml` and also the GOV.UK API for existence of the registry. In the future we should be using the government-organisation register but we haven't done that work yet.

### Changes proposed in this pull request
nhs-digital exists here https://www.gov.uk/api/organisations/nhs-digital, which means it should be part of our list of available public-bodies.

### Guidance to review
Spelling should match https://www.gov.uk/api/organisations/nhs-digital