### PR TITLE
fix encoding of /records/ key link

### DIFF
--- a/src/main/java/uk/gov/register/core/UriTemplateLinkResolver.java
+++ b/src/main/java/uk/gov/register/core/UriTemplateLinkResolver.java
@@ -1,7 +1,10 @@
 package uk.gov.register.core;
 
 import javax.ws.rs.core.UriBuilder;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 public class UriTemplateLinkResolver implements LinkResolver {
     private final RegisterResolver registerResolver;
@@ -23,6 +26,10 @@ public class UriTemplateLinkResolver implements LinkResolver {
     public URI resolve(RegisterId register, String linkKey) {
         URI baseUri = registerResolver.baseUriFor(register);
 
-        return UriBuilder.fromUri(baseUri).path("records").path(linkKey).build();
+        try {
+            return UriBuilder.fromUri(baseUri).path("records").path(URLEncoder.encode(linkKey, StandardCharsets.UTF_8.name())).build();
+        } catch (UnsupportedEncodingException e) {
+            return UriBuilder.fromUri(baseUri).path("records").path(linkKey).build();
+        }
     }
 }

--- a/src/main/java/uk/gov/register/views/RecordsView.java
+++ b/src/main/java/uk/gov/register/views/RecordsView.java
@@ -22,6 +22,8 @@ import uk.gov.register.views.representations.turtle.RecordsTurtleWriter;
 import javax.inject.Provider;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -100,6 +102,12 @@ public class RecordsView implements CsvRepresentationView {
     @SuppressWarnings("unused, used by template")
     public boolean displayEntryKeyColumn() {
         return displayEntryKeyColumn;
+    }
+
+    @SuppressWarnings("unused, used by template")
+    public static String urlEncodeKey(String key) throws UnsupportedEncodingException {
+        return URLEncoder.encode(
+                key, StandardCharsets.UTF_8.name());
     }
 
     @SuppressWarnings("unused, used by template")

--- a/src/main/resources/templates/fragments/record-table.html
+++ b/src/main/resources/templates/fragments/record-table.html
@@ -15,9 +15,9 @@
     </thead>
     <tbody>
     <th:block th:each="record : ${records}">
-      <tr th:each="item : ${record}" th:with="firstItemColumnLink = ${view.displayEntryKeyColumn()} ? ${null} : ${'../records/' + record.key}">
+      <tr th:each="item : ${record}" th:with="firstItemColumnLink = ${view.displayEntryKeyColumn()} ? ${null} : @{'../records/' + ${view.urlEncodeKey(record.key)}}">
         <td th:if="${view.displayEntryKeyColumn()}">
-          <a th:href="${'./records/' + record.key}" th:text="${record.key}"></a>
+          <a th:href="@{'./records/' + ${view.urlEncodeKey(record.key)}" th:text="${record.key}"></a>
         </td>
         <div th:include="fragments/record-table-item-cells.html :: record-table-item-cells (item = ${item}, fieldNames = ${itemFieldNames}, resolveAllLinks = ${view.resolveAllItemLinks()}, firstColumnLink = ${firstItemColumnLink})"></div>
       </tr>

--- a/src/main/resources/templates/record.html
+++ b/src/main/resources/templates/record.html
@@ -29,7 +29,7 @@
           th:include="fragments/record-table.html :: record-table (view = ${content}, records = ${content.recordsSimple})"
           class="table-wrapper"></div>
       <p>
-        <a th:href="${'/records/' + content.entryKey +'/entries'}">View all versions of this record</a>
+        <a th:href="@{'/records/' + ${content.urlEncodeKey(content.entryKey)} +'/entries'}">View all versions of this record</a>
       </p>
 
     </main>

--- a/src/test/java/uk/gov/register/core/UriTemplateLinkResolverTest.java
+++ b/src/test/java/uk/gov/register/core/UriTemplateLinkResolverTest.java
@@ -39,6 +39,11 @@ public class UriTemplateLinkResolverTest {
 
     @Test
     public void separateRegisterAndValueReturnsCorrectLink() throws Exception {
-        assertThat(localResolver.resolve(new RegisterId("country"),"CZ"), is(URI.create("http://country.openregister.dev:8080/records/CZ")));
+        assertThat(localResolver.resolve(new RegisterId("country"), "CZ"), is(URI.create("http://country.openregister.dev:8080/records/CZ")));
+    }
+
+    @Test
+    public void keysAreURLEncoded() throws Exception {
+        assertThat(localResolver.resolve(new RegisterId("country"),"47.79/1"), is(URI.create("http://country.openregister.dev:8080/records/47.79%2F1")));
     }
 }


### PR DESCRIPTION
### Context
Previously the HTML view did not correctly handle linking where the key contains a literal backslash. e.g. https://industrial-classification-2007.cloudapps.digital/records/79.90%2F9
https://trello.com/c/B43trWa3/2025-forward-slashes-arent-url-encoded-in-api-explorer-record-id-links

### Changes proposed in this pull request
fix encoding of key link where key contains literal backslash. Although Thymeleaf does URL escape `/` is excluded as it is used to form URL paths, so instead we build the encoded key and pass it into the template.

### Guidance to review
Key containing literal slash e.g. `79.90/9` should link correctly in HTML view.
