### PR TITLE
Add alpha phase into header

### DIFF
--- a/src/main/resources/assets/sass/_header.scss
+++ b/src/main/resources/assets/sass/_header.scss
@@ -44,7 +44,7 @@ $active-nav-color: #1d8feb;
   @extend %contain-floats;
 
   @include screen {
-    background: $black;
+    background-color: $govuk-blue;
     color: $white;
     border-bottom: 10px solid $white;
   }

--- a/src/main/resources/assets/sass/main.scss
+++ b/src/main/resources/assets/sass/main.scss
@@ -69,7 +69,6 @@ body {
 }
 
 .header {
-  background-color: $govuk-blue;
   border-bottom: 0;
   margin-bottom: 0;
 

--- a/src/main/resources/templates/fragments/global-header.html
+++ b/src/main/resources/templates/fragments/global-header.html
@@ -6,28 +6,16 @@
     <header class='header' role='banner'>
       <div class='header__container'>
         <div class='header__brand' data-click-events="" data-click-category="Header" data-click-action="Logo Clicked">
-          <a href="/" th:title="'Go to ' + ${friendlyRegisterId} + ' API home'">
+          <a href="https://www.registers.service.gov.uk" title="Go to GOV.UK Registers">
             <span class='govuk-logo'>
               <img src="/assets/images/gov.uk_logotype_crown_invert_trans.png" width="36" height="32" alt="GOV.UK Registers" class="govuk-logo__printable-crown" /> GOV.UK
             </span>
             <span class='header__title'>
-              <span th:text="${friendlyRegisterId}">Registers</span>
-              API
+              Registers
+              <span class='phase-banner'>Alpha</span>
             </span>
           </a>
         </div>
-        <input type="checkbox" name="show-menu" id="show-menu" class="header__navigation-toggle-checkbox" aria-controls="navigation" aria-expanded="false" />
-        <label class="header__navigation-toggle" for="show-menu">Menu</label>
-        <nav aria-hidden='true' aria-label='Top Level Navigation' class='header__navigation' id='navigation'>
-          <ul class="list-bullet" data-click-events="" data-click-category="Header" data-click-action="Navigation Link Clicked">
-            <li>
-              <a href="https://registers.cloudapps.digital/support" target="_blank">Support</a>
-            </li>
-            <li>
-              <a href="https://registers-docs.cloudapps.digital" target="_blank">Documentation</a>
-            </li>
-          </ul>
-        </nav>
       </div>
     </header>
   </th:block>

--- a/src/main/resources/templates/fragments/phase-banner.html
+++ b/src/main/resources/templates/fragments/phase-banner.html
@@ -3,14 +3,17 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <body>
   <th:block th:fragment="phase">
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        <div class="panel panel-border-wide phase">
-          <span class="phase-banner">In progress</span>
-          <p>This data is in progress and it's not ready for use.</p>
-          <th:block th:unless="${register.phase == 'discovery' || register.phase == 'test'}">
-            <p>You can <a th:href="@{'https://www.registers.service.gov.uk/registers/' + ${registerId}}" target="_blank">preview the data and give us feedback</a>.</p>
-          </th:block>
+    <div class="registers-intro">
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <h1 class="heading-medium"><th:block th:utext="${friendlyRegisterId}">Register name</th:block> API</h1>
+          <div class="panel panel-border-wide phase">
+            <span class="phase-banner">In progress</span>
+            <p>This data is in progress and it's not ready for use.</p>
+            <th:block th:unless="${register.phase == 'discovery' || register.phase == 'test'}">
+              <p>You can <a th:href="@{'https://www.registers.service.gov.uk/registers/' + ${registerId}}" target="_blank">preview the data and give us feedback</a>.</p>
+            </th:block>
+          </div>
         </div>
       </div>
     </div>

--- a/src/test/java/uk/gov/register/functional/AssetsBundleCustomErrorHandlerTest.java
+++ b/src/test/java/uk/gov/register/functional/AssetsBundleCustomErrorHandlerTest.java
@@ -27,7 +27,7 @@ public class AssetsBundleCustomErrorHandlerTest {
         assertThat(response.getMediaType().isCompatible(MediaType.TEXT_HTML_TYPE), equalTo(true));
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
-        Elements notFoundHeader = doc.select("main h1");
+        Elements notFoundHeader = doc.select(".heading-large");
         Assert.assertThat(notFoundHeader.first().text(), equalTo("Page not found"));
     }
 }


### PR DESCRIPTION
### Context
We need to tell our users that GOV.UK Registers as a service is in Aplha

### Changes proposed in this pull request
- Add `Alpha` phase tag to header
- Remove the register name
- Remove navigation

### Guidance to review
View any html page
