### PR TITLE
Create open-standards registers in beta

### DIFF
--- a/deploy/manifests/beta/multi.yml
+++ b/deploy/manifests/beta/multi.yml
@@ -12,6 +12,8 @@ applications:
     - register.gov.uk
   hosts:
     - allergen
+    - approved-open-standard
+    - approved-open-standard-guidance
     - country
     - government-domain
     - government-organisation


### PR DESCRIPTION
### Context
Custodian has approved these registers moving to "ready to use". I'll remove the alpha versions of these registers once we have moved the data to beta.

### Changes proposed in this pull request
Add two registers to beta:
- approved-open-standard
- approved-open-standard-guidance

### Guidance to review
https://trello.com/c/f3cxIHBg/2573-move-approved-open-standards-registers-to-ready-to-use