### PR TITLE
/download-rsf/0 should return system entries for an empty register

### DIFF
--- a/src/main/java/uk/gov/register/serialization/RSFCreator.java
+++ b/src/main/java/uk/gov/register/serialization/RSFCreator.java
@@ -35,7 +35,7 @@ public class RSFCreator {
     public RegisterSerialisationFormat create(Register register, int totalEntries1, int totalEntries2) {
         Iterator<?> iterators;
 
-        if (totalEntries1 == totalEntries2) {
+        if (totalEntries1 > 0 && totalEntries1 == totalEntries2) {
             iterators = Iterators.singletonIterator(register.getRegisterProof(totalEntries1).getRootHash());
         } else {
 


### PR DESCRIPTION
### Context
The /download-rsf/0 endpoint returns system data and user data when a register contains at least one user entry. However when a register does not contain any user entries, /download-rsf/0 does not return any system entries. 

### Changes proposed in this pull request
Fix above inconsistency. Also adds tests to ensure system data is included in RSF downloads where it's meant to.

### Guidance to review
Load a register that only has system entries and no user entries. /download-rsf/0 and /download-rsf/0/0 should return system entries.