### PR TITLE
set cache-control headers on DataDownload routes

### DIFF
--- a/src/main/java/uk/gov/register/resources/DataDownload.java
+++ b/src/main/java/uk/gov/register/resources/DataDownload.java
@@ -11,11 +11,9 @@ import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
+import javax.ws.rs.core.*;
 import java.util.Collection;
+import io.dropwizard.jersey.caching.CacheControl;
 
 @Path("/")
 public class DataDownload {
@@ -26,7 +24,6 @@ public class DataDownload {
     private final ResourceConfiguration resourceConfiguration;
     private final RegisterSerialisationFormatService rsfService;
     private final RSFFormatter rsfFormatter;
-
 
     @Inject
     public DataDownload(RegisterReadOnly register,
@@ -43,6 +40,7 @@ public class DataDownload {
 
     @GET
     @Path("/download-register")
+    @CacheControl(maxAge = 60, isPrivate = true)
     @Produces({MediaType.APPLICATION_OCTET_STREAM, ExtraMediaType.TEXT_HTML})
     @DownloadNotAvailable
     @Timed
@@ -66,6 +64,7 @@ public class DataDownload {
 
     @GET
     @Path("/download-rsf")
+    @CacheControl(maxAge = 60, isPrivate = true)
     @Produces({ExtraMediaType.APPLICATION_RSF, ExtraMediaType.TEXT_HTML})
     @DownloadNotAvailable
     @Timed
@@ -78,6 +77,7 @@ public class DataDownload {
 
     @GET
     @Path("/index/{index-name}/download-rsf")
+    @CacheControl(maxAge = 60, isPrivate = true)
     @Produces({ExtraMediaType.APPLICATION_RSF, ExtraMediaType.TEXT_HTML})
     @DownloadNotAvailable
     @Timed
@@ -90,6 +90,7 @@ public class DataDownload {
 
     @GET
     @Path("/index/{index-name}/download-rsf/{total-entries-1}/{total-entries-2}")
+    @CacheControl(maxAge = 60, isPrivate = true)
     @Produces({ExtraMediaType.APPLICATION_RSF, ExtraMediaType.TEXT_HTML})
     @DownloadNotAvailable
     @Timed
@@ -102,6 +103,7 @@ public class DataDownload {
 
     @GET
     @Path("/download-rsf/{start-entry-number}")
+    @CacheControl(maxAge = 60, isPrivate = true)
     @Produces({ExtraMediaType.APPLICATION_RSF, ExtraMediaType.TEXT_HTML})
     @DownloadNotAvailable
     @Timed
@@ -124,6 +126,7 @@ public class DataDownload {
 
     @GET
     @Path("/download-rsf/{total-entries-1}/{total-entries-2}")
+    @CacheControl(maxAge = 60, isPrivate = true)
     @Produces({ExtraMediaType.APPLICATION_RSF, ExtraMediaType.TEXT_HTML})
     @DownloadNotAvailable
     @Timed


### PR DESCRIPTION
### Context
Previously these routes were subject to default TTL

### Changes proposed in this pull request
set 60 second cache headers on these routes to decrease frontend latency

### Guidance to review
Cache-Control headers should be set on: `curl -I localhost:8080/download-rsf`

DO NOT MERGE until we discuss preferred values/need for performance testing.