### PR TITLE
Warn about deprecated formats

### DIFF
--- a/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
+++ b/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
@@ -77,7 +77,7 @@ public class DeprecatedFormatFilter implements ContainerResponseFilter {
     }
 
     private String warningHeader(String deprecatedType) {
-        return "299 - \"Miscellaneous Persistent Warning\" \"" + deprecatedType + " is deprecated and will be removed. See \"Link\" header for a format to use instead.\"";
+        return "299 - \"" + deprecatedType + " is deprecated and will be removed. See 'Link' header for a format to use instead.\"";
     }
 
     private boolean recommendJson(MediaType mediaType) {

--- a/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
+++ b/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
@@ -42,10 +42,10 @@ public class DeprecatedFormatFilter implements ContainerResponseFilter {
 
         if (recommendJson(mediaType)) {
             alternateUri = alternateLink(requestedUri, ".json");
-            alternateType = MediaType.APPLICATION_JSON;
+            alternateType = "application/json";
         } else if (recommendCsv(mediaType)) {
             alternateUri = alternateLink(requestedUri, ".csv");
-            alternateType = ExtraMediaType.TEXT_CSV;
+            alternateType = "text/csv";
         } else {
             return;
         }

--- a/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
+++ b/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
@@ -21,7 +21,7 @@ import uk.gov.register.views.representations.ExtraMediaType;
 
 @Provider
 public class DeprecatedFormatFilter implements ContainerResponseFilter {
-    private HttpServletResponse httpServletResponse;
+    private final HttpServletResponse httpServletResponse;
 
     public DeprecatedFormatFilter(@Context HttpServletResponse httpServletResponse) {
         this.httpServletResponse = httpServletResponse;
@@ -33,10 +33,10 @@ public class DeprecatedFormatFilter implements ContainerResponseFilter {
         final URI requestedUri = uriInfo.getRequestUri();
         final MultivaluedMap<String, Object> headers = responseContext.getHeaders();
 
-        extractMediaType(headers).ifPresent(mediaType -> filterMediaType(mediaType, requestedUri, headers));
+        extractMediaType(headers).ifPresent(mediaType -> filterMediaType(mediaType, requestedUri));
     }
 
-    private void filterMediaType(MediaType mediaType, URI requestedUri, MultivaluedMap<String, Object> headers) {
+    private void filterMediaType(MediaType mediaType, URI requestedUri) {
         final String alternateUri;
         final String alternateType;
 

--- a/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
+++ b/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
@@ -55,7 +55,7 @@ public class DeprecatedFormatFilter implements ContainerResponseFilter {
         Map<String, String> extra = new HashMap<>();
         extra.put("rel", "alternate");
         extra.put("type", alternateType);
-        httpServletResponseAdapter.addLinkHeader(extra, alternateUri);
+        httpServletResponseAdapter.setLinkHeader(extra, alternateUri);
 
         httpServletResponseAdapter.setHeader(
                 HttpHeaders.WARNING,

--- a/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
+++ b/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
@@ -21,9 +21,11 @@ import uk.gov.register.views.representations.ExtraMediaType;
 
 @Provider
 public class DeprecatedFormatFilter implements ContainerResponseFilter {
+    private HttpServletResponse httpServletResponse;
 
-    @Context
-    HttpServletResponse httpServletResponse;
+    public DeprecatedFormatFilter(@Context HttpServletResponse httpServletResponse) {
+        this.httpServletResponse = httpServletResponse;
+    }
 
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
@@ -55,7 +57,7 @@ public class DeprecatedFormatFilter implements ContainerResponseFilter {
         extra.put("type", alternateType);
         httpServletResponseAdapter.addLinkHeader(extra, alternateUri);
 
-        headers.add(
+        httpServletResponseAdapter.setHeader(
                 HttpHeaders.WARNING,
                 warningHeader(mediaType.getSubtype())
         );

--- a/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
+++ b/src/main/java/uk/gov/register/filters/DeprecatedFormatFilter.java
@@ -1,0 +1,91 @@
+package uk.gov.register.filters;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+import java.net.URI;
+import java.util.Optional;
+
+import com.google.common.net.HttpHeaders;
+import uk.gov.register.views.representations.ExtraMediaType;
+
+@Provider
+public class DeprecatedFormatFilter implements ContainerResponseFilter {
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        final UriInfo uriInfo = requestContext.getUriInfo();
+        final URI requestedUri = uriInfo.getRequestUri();
+        final MultivaluedMap<String, Object> headers = responseContext.getHeaders();
+
+        extractMediaType(headers).ifPresent(mediaType -> filterMediaType(mediaType, requestedUri, headers));
+    }
+
+    private void filterMediaType(MediaType mediaType, URI requestedUri, MultivaluedMap<String, Object> headers) {
+        final String alternateUri;
+        final String alternateType;
+
+        if (recommendJson(mediaType)) {
+            alternateUri = alternateLink(requestedUri, ".json");
+            alternateType = MediaType.APPLICATION_JSON;
+        } else if (recommendCsv(mediaType)) {
+            alternateUri = alternateLink(requestedUri, ".csv");
+            alternateType = ExtraMediaType.TEXT_CSV;
+        } else {
+            return;
+        }
+
+        headers.add(
+                HttpHeaders.LINK,
+                linkHeader(alternateType, alternateUri)
+        );
+        headers.add(
+                HttpHeaders.WARNING,
+                warningHeader(mediaType.getSubtype())
+        );
+    }
+
+    private String alternateLink(URI requestedUri, String recommendedExtension) {
+        final String path = requestedUri.getPath();
+        final UriBuilder builder = UriBuilder.fromUri(requestedUri);
+
+        // Even if an extension was specified in the original URI, it has been stripped out
+        // at this point, so just add the new one (before any trailing slash).
+        final String newPath = path.replaceFirst("(/)?$", recommendedExtension + "$1");
+
+        builder.replacePath(newPath);
+
+        return builder.toTemplate();
+    }
+
+    private String linkHeader(String alternateType, String alternateUri) {
+        return alternateUri + "; rel=\"alternate\"" + "; type=\"" + alternateType + "\"";
+    }
+
+    private String warningHeader(String deprecatedType) {
+        return "299 - \"Miscellaneous Persistent Warning\" \"" + deprecatedType + " is deprecated and will be removed. See \"Link\" header for a format to use instead.\"";
+    }
+
+    private boolean recommendJson(MediaType mediaType) {
+        return mediaType.equals(ExtraMediaType.TEXT_TTL_TYPE) ||
+                mediaType.equals(ExtraMediaType.TEXT_YAML_TYPE);
+    }
+
+    private boolean recommendCsv(MediaType mediaType) {
+        return mediaType.equals(ExtraMediaType.TEXT_TSV_TYPE) ||
+                mediaType.equals(ExtraMediaType.APPLICATION_SPREADSHEET_TYPE);
+    }
+
+    private Optional<MediaType> extractMediaType(MultivaluedMap<String, Object> headers) {
+        try {
+            MediaType mediaType = (MediaType) headers.getFirst(HttpHeaders.CONTENT_TYPE);
+            return Optional.ofNullable(mediaType);
+        } catch (ClassCastException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/uk/gov/register/resources/DerivationRecordResource.java
+++ b/src/main/java/uk/gov/register/resources/DerivationRecordResource.java
@@ -94,18 +94,18 @@ public class DerivationRecordResource {
         IndexSizePagination pagination = new IndexSizePagination(pageIndex.map(IntParam::get), pageSize.map(IntParam::get), register.getTotalRecords(indexName));
 
         if (pagination.hasNextPage()) {
-            httpServletResponseAdapter.addLinkHeader("next", pagination.getNextPageLink());
+            httpServletResponseAdapter.setLinkHeader("next", pagination.getNextPageLink());
         }
 
         if (pagination.hasPreviousPage()) {
-            httpServletResponseAdapter.addLinkHeader("previous", pagination.getPreviousPageLink());
+            httpServletResponseAdapter.setLinkHeader("previous", pagination.getPreviousPageLink());
         }
         return pagination;
     }
 
     private void setContentDisposition() {
         requestContext.resourceExtension().ifPresent(
-                ext -> httpServletResponseAdapter.addInlineContentDispositionHeader(registerPrimaryKey + "-records." + ext)
+                ext -> httpServletResponseAdapter.setInlineContentDispositionHeader(registerPrimaryKey + "-records." + ext)
         );
     }
 

--- a/src/main/java/uk/gov/register/resources/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/EntryResource.java
@@ -102,15 +102,15 @@ public class EntryResource {
 
     private void setHeaders(StartLimitPagination startLimitPagination) {
         requestContext.resourceExtension().ifPresent(
-                ext -> httpServletResponseAdapter.addInlineContentDispositionHeader(registerPrimaryKey + "-entries." + ext)
+                ext -> httpServletResponseAdapter.setInlineContentDispositionHeader(registerPrimaryKey + "-entries." + ext)
         );
 
         if (startLimitPagination.hasNextPage()) {
-            httpServletResponseAdapter.addLinkHeader("next", startLimitPagination.getNextPageLink());
+            httpServletResponseAdapter.setLinkHeader("next", startLimitPagination.getNextPageLink());
         }
 
         if (startLimitPagination.hasPreviousPage()) {
-            httpServletResponseAdapter.addLinkHeader("previous", startLimitPagination.getPreviousPageLink());
+            httpServletResponseAdapter.setLinkHeader("previous", startLimitPagination.getPreviousPageLink());
         }
     }
 }

--- a/src/main/java/uk/gov/register/resources/HttpServletResponseAdapter.java
+++ b/src/main/java/uk/gov/register/resources/HttpServletResponseAdapter.java
@@ -39,6 +39,10 @@ public class HttpServletResponseAdapter {
 
         String headerValue = StringUtils.isEmpty(existingHeaderValue) ? newHeaderToAppend : String.join(",", existingHeaderValue, newHeaderToAppend);
 
-        httpServletResponse.setHeader("Link", headerValue);
+        setHeader("Link", headerValue);
+    }
+
+    public void setHeader(String name, String value) {
+        httpServletResponse.setHeader(name, value);
     }
 }

--- a/src/main/java/uk/gov/register/resources/HttpServletResponseAdapter.java
+++ b/src/main/java/uk/gov/register/resources/HttpServletResponseAdapter.java
@@ -5,22 +5,37 @@ import org.glassfish.jersey.media.multipart.ContentDisposition;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.HttpHeaders;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-class HttpServletResponseAdapter {
+public class HttpServletResponseAdapter {
     private final HttpServletResponse httpServletResponse;
 
-    HttpServletResponseAdapter(HttpServletResponse httpServletResponse) {
+    public HttpServletResponseAdapter(HttpServletResponse httpServletResponse) {
         this.httpServletResponse = httpServletResponse;
     }
 
-    void addInlineContentDispositionHeader(String fileName) {
+    public void addInlineContentDispositionHeader(String fileName) {
         ContentDisposition contentDisposition = ContentDisposition.type("inline").fileName(fileName).build();
         httpServletResponse.addHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString());
     }
 
-    void addLinkHeader(String rel, String value) {
+    public void addLinkHeader(String rel, String value) {
+        Map<String, String> extra = new HashMap<>();
+        extra.put("rel", rel);
+        addLinkHeader(extra, value);
+    }
+
+    public void addLinkHeader(Map<String, String> extra, String value) {
         String existingHeaderValue = httpServletResponse.getHeader("Link");
-        String newHeaderToAppend = String.format("<%s>; rel=\"%s\"", value, rel);
+
+        String extraString = extra.entrySet()
+                .stream()
+                .map(entry -> entry.getKey() + "=\"" + entry.getValue() + "\"")
+                .collect(Collectors.joining("; "));
+
+        String newHeaderToAppend = String.format("<%s>; %s", value, extraString);
 
         String headerValue = StringUtils.isEmpty(existingHeaderValue) ? newHeaderToAppend : String.join(",", existingHeaderValue, newHeaderToAppend);
 

--- a/src/main/java/uk/gov/register/resources/HttpServletResponseAdapter.java
+++ b/src/main/java/uk/gov/register/resources/HttpServletResponseAdapter.java
@@ -16,18 +16,18 @@ public class HttpServletResponseAdapter {
         this.httpServletResponse = httpServletResponse;
     }
 
-    public void addInlineContentDispositionHeader(String fileName) {
+    public void setInlineContentDispositionHeader(String fileName) {
         ContentDisposition contentDisposition = ContentDisposition.type("inline").fileName(fileName).build();
-        httpServletResponse.addHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString());
+        setHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString());
     }
 
-    public void addLinkHeader(String rel, String value) {
+    public void setLinkHeader(String rel, String value) {
         Map<String, String> extra = new HashMap<>();
         extra.put("rel", rel);
-        addLinkHeader(extra, value);
+        setLinkHeader(extra, value);
     }
 
-    public void addLinkHeader(Map<String, String> extra, String value) {
+    public void setLinkHeader(Map<String, String> extra, String value) {
         String existingHeaderValue = httpServletResponse.getHeader("Link");
 
         String extraString = extra.entrySet()

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -12,7 +12,6 @@ import uk.gov.register.views.*;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import java.util.Collection;
@@ -55,7 +54,7 @@ public class RecordResource {
     })
     @Timed
     public RecordView getRecordByKey(@PathParam("record-key") String key) throws FieldConversionException {
-        httpServletResponseAdapter.addLinkHeader("version-history", String.format("/record/%s/entries", key));
+        httpServletResponseAdapter.setLinkHeader("version-history", String.format("/record/%s/entries", key));
 
         return register.getRecord(key).map(viewFactory::getRecordMediaView)
                 .orElseThrow(NotFoundException::new);
@@ -155,11 +154,11 @@ public class RecordResource {
         IndexSizePagination pagination = new IndexSizePagination(pageIndex.map(IntParam::get), pageSize.map(IntParam::get), register.getTotalRecords());
 
         if (pagination.hasNextPage()) {
-            httpServletResponseAdapter.addLinkHeader("next", pagination.getNextPageLink());
+            httpServletResponseAdapter.setLinkHeader("next", pagination.getNextPageLink());
         }
 
         if (pagination.hasPreviousPage()) {
-            httpServletResponseAdapter.addLinkHeader("previous", pagination.getPreviousPageLink());
+            httpServletResponseAdapter.setLinkHeader("previous", pagination.getPreviousPageLink());
         }
         return pagination;
     }

--- a/src/test/java/uk/gov/register/filters/DeprecatedFormatFilterTest.java
+++ b/src/test/java/uk/gov/register/filters/DeprecatedFormatFilterTest.java
@@ -1,0 +1,77 @@
+package uk.gov.register.filters;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.register.views.representations.ExtraMediaType;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+public class DeprecatedFormatFilterTest {
+    @Rule
+    public ResourceTestRule rule = ResourceTestRule.builder().addResource(new DeprecatedFormatFilterTest.DummyResource()).addProvider(new DeprecatedFormatFilter()).build();
+
+    @Test
+    public void jsonResponseShouldNotWarn() {
+        Response response = rule.client().target("/json").request().get();
+
+        assertFalse(response.getStringHeaders().containsKey("Warning"));
+        assertFalse(response.getStringHeaders().containsKey("Link"));
+    }
+
+    @Test
+    public void yamlResponseShouldWarn() {
+        Response response = rule.client().target("/yaml").request().get();
+
+        String warning = response.getHeaderString("Warning");
+        String link = response.getHeaderString("Link");
+
+        assertThat(warning, equalTo("299 - \"Miscellaneous Persistent Warning\" \"yaml is deprecated and will be removed. See \"Link\" header for a format to use instead.\""));
+        assertThat(link, equalTo("/yaml.json; rel=\"alternate\"; type=\"application/json\""));
+    }
+
+    @Test
+    public void existingLinkHeadersShouldBePreserved() {
+        Response response = rule.client().target("/existing-header").request().get();
+
+        String link = response.getHeaderString("Link");
+
+        assertThat(link, equalTo("<?page-index=2&page-size=100>; rel=\"next\",/existing-header.json; rel=\"alternate\"; type=\"application/json\""));
+    }
+
+    @Path("/")
+    public class DummyResource {
+        @GET
+        @Path("json")
+        @Produces(MediaType.APPLICATION_JSON)
+        public String json() {
+            return "{}";
+        }
+
+        @GET
+        @Path("yaml")
+        @Produces(ExtraMediaType.TEXT_YAML)
+        public String yaml() {
+            return "{}";
+        }
+
+        @GET
+        @Path("existing-header")
+        public Response existingHeader() {
+            return Response
+                    .status(200)
+                    .header("Link", "<?page-index=2&page-size=100>; rel=\"next\"")
+                    .type(ExtraMediaType.TEXT_YAML)
+                    .entity("{}")
+                    .build();
+        }
+    }
+}

--- a/src/test/java/uk/gov/register/filters/DeprecatedFormatFilterTest.java
+++ b/src/test/java/uk/gov/register/filters/DeprecatedFormatFilterTest.java
@@ -17,7 +17,9 @@ import static org.junit.Assert.assertThat;
 
 public class DeprecatedFormatFilterTest {
     @Rule
-    public ResourceTestRule rule = ResourceTestRule.builder().addResource(new DeprecatedFormatFilterTest.DummyResource()).addProvider(new DeprecatedFormatFilter()).build();
+    public ResourceTestRule rule = ResourceTestRule.builder().addResource(new DeprecatedFormatFilterTest.DummyResource())
+            .addProvider(new DeprecatedFormatFilter())
+            .build();
 
     @Test
     public void jsonResponseShouldNotWarn() {

--- a/src/test/java/uk/gov/register/filters/DeprecatedFormatFilterTest.java
+++ b/src/test/java/uk/gov/register/filters/DeprecatedFormatFilterTest.java
@@ -45,7 +45,7 @@ public class DeprecatedFormatFilterTest {
         rule.client().target("/yaml").request().get();
 
         verify(mock).setHeader("Link", "</yaml.json>; rel=\"alternate\"; type=\"application/json\"");
-        verify(mock).setHeader("Warning", "299 - \"Miscellaneous Persistent Warning\" \"yaml is deprecated and will be removed. See \"Link\" header for a format to use instead.\"");
+        verify(mock).setHeader("Warning", "299 - \"yaml is deprecated and will be removed. See 'Link' header for a format to use instead.\"");
     }
 
     @Test

--- a/src/test/java/uk/gov/register/filters/DeprecatedFormatFilterTest.java
+++ b/src/test/java/uk/gov/register/filters/DeprecatedFormatFilterTest.java
@@ -5,48 +5,58 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.register.views.representations.ExtraMediaType;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 
 public class DeprecatedFormatFilterTest {
+    private final HttpServletResponse mock = mock(HttpServletResponse.class);
+
     @Rule
     public ResourceTestRule rule = ResourceTestRule.builder().addResource(new DeprecatedFormatFilterTest.DummyResource())
-            .addProvider(new DeprecatedFormatFilter())
+            .addProvider(new DeprecatedFormatFilter(mock))
             .build();
 
     @Test
     public void jsonResponseShouldNotWarn() {
         Response response = rule.client().target("/json").request().get();
 
+        verify(mock, never()).setHeader(eq("Link"), anyString());
+        verify(mock, never()).setHeader(eq("Warning"), anyString());
+
+        // It shouldn't set any headers via the ContainerResponseContext either.
         assertFalse(response.getStringHeaders().containsKey("Warning"));
         assertFalse(response.getStringHeaders().containsKey("Link"));
     }
 
     @Test
     public void yamlResponseShouldWarn() {
-        Response response = rule.client().target("/yaml").request().get();
+        rule.client().target("/yaml").request().get();
 
-        String warning = response.getHeaderString("Warning");
-        String link = response.getHeaderString("Link");
-
-        assertThat(warning, equalTo("299 - \"Miscellaneous Persistent Warning\" \"yaml is deprecated and will be removed. See \"Link\" header for a format to use instead.\""));
-        assertThat(link, equalTo("/yaml.json; rel=\"alternate\"; type=\"application/json\""));
+        verify(mock).setHeader("Link", "</yaml.json>; rel=\"alternate\"; type=\"application/json\"");
+        verify(mock).setHeader("Warning", "299 - \"Miscellaneous Persistent Warning\" \"yaml is deprecated and will be removed. See \"Link\" header for a format to use instead.\"");
     }
 
     @Test
     public void existingLinkHeadersShouldBePreserved() {
-        Response response = rule.client().target("/existing-header").request().get();
+        // Only headers set on the httpServletResponse are preserved, due to an implementation detail
+        // of Jersey's ContainerResponseContext.
+        when(mock.getHeader("Link")).thenReturn("<?page-index=2&page-size=100>; rel=\"next\"");
 
-        String link = response.getHeaderString("Link");
+        Response response = rule.client().target("/yaml").request().get();
 
-        assertThat(link, equalTo("<?page-index=2&page-size=100>; rel=\"next\",/existing-header.json; rel=\"alternate\"; type=\"application/json\""));
+        verify(mock).setHeader("Link", "<?page-index=2&page-size=100>; rel=\"next\",</yaml.json>; rel=\"alternate\"; type=\"application/json\"");
     }
 
     @Path("/")
@@ -63,17 +73,6 @@ public class DeprecatedFormatFilterTest {
         @Produces(ExtraMediaType.TEXT_YAML)
         public String yaml() {
             return "{}";
-        }
-
-        @GET
-        @Path("existing-header")
-        public Response existingHeader() {
-            return Response
-                    .status(200)
-                    .header("Link", "<?page-index=2&page-size=100>; rel=\"next\"")
-                    .type(ExtraMediaType.TEXT_YAML)
-                    .entity("{}")
-                    .build();
         }
     }
 }

--- a/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
@@ -11,13 +11,11 @@ import uk.gov.register.functional.app.RegisterRule;
 import uk.gov.register.functional.app.RsfRegisterDefinition;
 
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -94,6 +92,23 @@ public class RecordListResourceFunctionalTest {
         response = addressTarget.path("/records.json").queryParam("page-index",3).queryParam("page-size",1)
                 .request().get();
         assertThat(response.getHeaderString("Link"), equalTo("<?page-index=2&page-size=1>; rel=\"previous\""));
+    }
+
+    @Test
+    public void deprecatedFormatsCanReturnMultiValuedLinkHeaders() {
+        String expectedAlternate  = addressTarget.getUri().toString() + "/records.json";
+
+        Response response = addressTarget.path("/records.yaml").queryParam("page-index",1).queryParam("page-size",1)
+                .request().get();
+        assertThat(response.getHeaderString("Link"), equalTo("<?page-index=2&page-size=1>; rel=\"next\",<" + expectedAlternate + "?page-index=1&page-size=1>; rel=\"alternate\"; type=\"application/json\""));
+
+        response = addressTarget.path("/records.yaml").queryParam("page-index",2).queryParam("page-size",1)
+                .request().get();
+        assertThat(response.getHeaderString("Link"), equalTo("<?page-index=3&page-size=1>; rel=\"next\",<?page-index=1&page-size=1>; rel=\"previous\",<" + expectedAlternate + "?page-index=2&page-size=1>; rel=\"alternate\"; type=\"application/json\""));
+
+        response = addressTarget.path("/records.yaml").queryParam("page-index",3).queryParam("page-size",1)
+                .request().get();
+        assertThat(response.getHeaderString("Link"), equalTo("<?page-index=2&page-size=1>; rel=\"previous\",<" + expectedAlternate + "?page-index=3&page-size=1>; rel=\"alternate\"; type=\"application/json\""));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/resources/HttpServletResponseAdapterTest.java
+++ b/src/test/java/uk/gov/register/resources/HttpServletResponseAdapterTest.java
@@ -20,16 +20,16 @@ public class HttpServletResponseAdapterTest {
     public void addContentDispositionHeader_setsTheContentDispositionHeader() {
         HttpServletResponseAdapter httpServletResponseAdapter = new HttpServletResponseAdapter(httpServletResponse);
 
-        httpServletResponseAdapter.addInlineContentDispositionHeader("foo");
+        httpServletResponseAdapter.setInlineContentDispositionHeader("foo");
 
-        verify(httpServletResponse).addHeader(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"foo\"");
+        verify(httpServletResponse).setHeader(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"foo\"");
     }
 
     @Test
     public void addLinkHeaderHeader_setsTheLinkHeader_ifNoLinkHeaderExistsAlready() {
         HttpServletResponseAdapter httpServletResponseAdapter = new HttpServletResponseAdapter(httpServletResponse);
 
-        httpServletResponseAdapter.addLinkHeader("next", "bar");
+        httpServletResponseAdapter.setLinkHeader("next", "bar");
 
         verify(httpServletResponse).setHeader("Link", "<bar>; rel=\"next\"");
     }
@@ -40,7 +40,7 @@ public class HttpServletResponseAdapterTest {
 
         when(httpServletResponse.getHeader("Link")).thenReturn("<bar>; rel=\"next\"");
 
-        httpServletResponseAdapter.addLinkHeader("previous", "foo");
+        httpServletResponseAdapter.setLinkHeader("previous", "foo");
 
         verify(httpServletResponse).setHeader("Link", "<bar>; rel=\"next\",<foo>; rel=\"previous\"");
     }


### PR DESCRIPTION
### Context
We're deprecating representations that are used less frequently, leaving just JSON and CSV.

The API itself should inform users of the deprecations.

### Changes proposed in this pull request
Add the following headers:

- `Link: <https://....json>; rel="alternate"` for .yaml or .ttl
- `Link: <https://....csv>; rel="alternate"` for any .tsv or .xlsx
- `Warning: 299 - "Miscellaneous Persistent Warning" "yaml is deprecated
  and will be removed"` for all deprecated formats

Trello: https://trello.com/c/DyKxUdyA/2638-add-format-change-comms-to-api

See also:
- https://tools.ietf.org/html/rfc7234#section-5.5.7
- https://www.iana.org/assignments/link-relations/link-relations.xhtml

### Guidance to review
We have to use `httpServletResponse` instead of the usual `ContainerResponseContext`, because the pagination code is already adding `Link` headers this way, and when Jersey writes the response, it chooses to overwrite any headers that are already set on `httpServletResponse` with the same name as those added to the `ContainerResponseContext`.

Questions for reviewers:

- Do the warning messages make sense?
- Is the logic for generating an alternate URL correct?
- In particular, is the `type` the best parameter name to use for the media type?
- How can I make my java more idiomatic?