### PR TITLE
Remove load endpoint

### DIFF
--- a/src/main/java/uk/gov/register/serialization/RegisterResult.java
+++ b/src/main/java/uk/gov/register/serialization/RegisterResult.java
@@ -12,11 +12,17 @@ public class RegisterResult {
     private Boolean isSuccessful;
     private String message;
     private Optional<Exception> exception;
+    private String details;
+
+    public RegisterResult() {
+        exception = Optional.empty();
+    }
 
     private RegisterResult(Boolean isSuccessful, String message, Optional<Exception> exception) {
         this.isSuccessful = isSuccessful;
         this.message = message;
         this.exception = exception;
+        this.details = exception.map(this::getCauseMessage).orElse(null);
     }
 
     public static RegisterResult createSuccessResult() {
@@ -39,7 +45,7 @@ public class RegisterResult {
 
     @JsonProperty("details")
     public String getDetails() {
-        return exception.map(this::getCauseMessage).orElse(null);
+        return details;
     }
 
     @JsonIgnore

--- a/src/test/java/uk/gov/register/functional/AuthenticationTest.java
+++ b/src/test/java/uk/gov/register/functional/AuthenticationTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.register.functional.app.TestRegister.address;
 import static uk.gov.register.functional.app.TestRegister.postcode;
+import static uk.gov.register.views.representations.ExtraMediaType.APPLICATION_RSF_TYPE;
 
 public class AuthenticationTest {
     @ClassRule
@@ -26,28 +27,40 @@ public class AuthenticationTest {
     }
     
     @Test
-    public void correctCredentials_shouldBeAllowed() throws Exception {
+    public void correctCredentials_shouldBeAllowed() {
+        String addressRsf = "add-item\t{\"address\":\"1234\"}\n" +
+                "append-entry\tuser\t1234\t2018-07-26T16:13:37Z\tsha-256:fdae0299e49857bb0165d5406ee1eb8f3a4465891d01a3100964ced1b80fc63f";
+
+        String postcodeRsf = "add-item\t{\"postcode\":\"1234\"}\n" +
+                "append-entry\tuser\t1234\t2018-07-26T16:13:37Z\tsha-256:a2efed1ddf15c08f491b5e8f5ea2550081074018f87530924fcee03eee0a644f";
+
         Response addressResponse = register.target(address).register(address.httpAuthFeature())
-                .path("/load").request()
-                .post(Entity.json("{\"address\":\"1234\"}"));
-        assertThat(addressResponse.getStatus(), is(204));
+                .path("/load-rsf").request()
+                .post(Entity.entity(addressRsf, APPLICATION_RSF_TYPE));
+        assertThat(addressResponse.getStatus(), is(200));
 
         Response postcodeResponse = register.target(postcode).register(postcode.httpAuthFeature())
-                .path("/load").request()
-                .post(Entity.json("{\"postcode\":\"12345\"}"));
-        assertThat(postcodeResponse.getStatus(), is(204));
+                .path("/load-rsf").request()
+                .post(Entity.entity(postcodeRsf, APPLICATION_RSF_TYPE));
+        assertThat(postcodeResponse.getStatus(), is(200));
     }
 
     @Test
-    public void incorrectCredentials_shouldBeRejected() throws Exception {
+    public void incorrectCredentials_shouldBeRejected() {
+        String addressRsf = "add-item\t{\"address\":\"1234\"}\n" +
+                "append-entry\tuser\t1234\t2018-07-26T16:13:37Z\tsha-256:fdae0299e49857bb0165d5406ee1eb8f3a4465891d01a3100964ced1b80fc63f";
+
+        String postcodeRsf = "add-item\t{\"postcode\":\"1234\"}\n" +
+                "append-entry\tuser\t1234\t2018-07-26T16:13:37Z\tsha-256:a2efed1ddf15c08f491b5e8f5ea2550081074018f87530924fcee03eee0a644f";
+
         Response addressWithPostcodeCredsResponse = register.target(address).register(postcode.httpAuthFeature())
-                .path("/load").request()
-                .post(Entity.json("{\"address\":\"1234\"}"));
+                .path("/load-rsf").request()
+                .post(Entity.entity(addressRsf, APPLICATION_RSF_TYPE));
         assertThat(addressWithPostcodeCredsResponse.getStatus(), is(401));
 
         Response postcodeWithAddressCredsResponse = register.target(postcode).register(address.httpAuthFeature())
-                .path("/load").request()
-                .post(Entity.json("{\"postcode\":\"1234\"}"));
+                .path("/load-rsf").request()
+                .post(Entity.entity(postcodeRsf, APPLICATION_RSF_TYPE));
         assertThat(postcodeWithAddressCredsResponse.getStatus(), is(401));
     }
 }

--- a/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
@@ -20,6 +20,7 @@ import uk.gov.register.functional.app.TestRegister;
 import uk.gov.register.functional.db.TestDBItem;
 import uk.gov.register.functional.db.TestEntryDAO;
 import uk.gov.register.functional.db.TestItemCommandDAO;
+import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.util.CanonicalJsonMapper;
 
 import javax.ws.rs.core.Response;
@@ -29,11 +30,12 @@ import java.util.List;
 import java.util.Map;
 
 import static javax.ws.rs.client.Entity.entity;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import static uk.gov.register.views.representations.ExtraMediaType.APPLICATION_RSF_TYPE;
 
 public class DataUploadFunctionalTest {
     @ClassRule
@@ -61,10 +63,13 @@ public class DataUploadFunctionalTest {
     }
 
     @Test
-    public void checkMessageIsConsumedAndStoredInDatabase() throws Exception {
+    public void checkMessageIsConsumedAndStoredInDatabase() {
         JsonNode inputItem = canonicalJsonMapper.readFromBytes("{\"register\":\"ft_openregister_test\",\"text\":\"SomeText\"}".getBytes());
-        Response r = register.mintLines(TestRegister.register, inputItem.toString());
-        assertThat(r.getStatus(), equalTo(204));
+        String rsf = "add-item\t{\"register\":\"ft_openregister_test\",\"text\":\"SomeText\"}\n" +
+                "append-entry\tuser\tft_openregister_test\t2018-07-26T15:05:16Z\tsha-256:3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254";
+
+        Response r = register.loadRsf(TestRegister.register, rsf);
+        assertThat(r.getStatus(), equalTo(200));
 
         TestDBItem storedItem = testItemDAO.getItems(schema).get(7);
         assertThat(storedItem.contents, equalTo(inputItem));
@@ -92,15 +97,17 @@ public class DataUploadFunctionalTest {
 
     @Test
     public void loadTwoDistinctItems_addsTwoRowsInEntryAndItemTable() {
-        String item1 = "{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}";
-        String item2 = "{\"register\":\"register2\",\"text\":\"Register2 Text\", \"phase\":\"alpha\"}";
+        String rsf = "add-item\t{\"phase\":\"alpha\",\"register\":\"register1\",\"text\":\"Register1 Text\"}\n" +
+                "add-item\t{\"phase\":\"alpha\",\"register\":\"register2\",\"text\":\"Register2 Text\"}\n" +
+                "append-entry\tuser\tregister1\t2018-07-26T15:30:06Z\tsha-256:98d89fd39d305a7ffb409b24714e921e56b3365565860598133e77cd46b48996\n" +
+                "append-entry\tuser\tregister2\t2018-07-26T15:30:06Z\tsha-256:fbc0134b8945ac09551ad7afded161a71c5ab01f2687bfc93b55bd27d985a2b1";
 
-        Response r = register.mintLines(TestRegister.register, item1, item2);
+        Response r = register.loadRsf(TestRegister.register, rsf);
 
-        assertThat(r.getStatus(), equalTo(204));
+        assertThat(r.getStatus(), equalTo(200));
 
-        JsonNode canonicalItem1 = canonicalJsonMapper.readFromBytes(item1.getBytes());
-        JsonNode canonicalItem2 = canonicalJsonMapper.readFromBytes(item2.getBytes());
+        JsonNode canonicalItem1 = canonicalJsonMapper.readFromBytes("{\"register\":\"register1\",\"text\":\"Register1 Text\", \"phase\":\"alpha\"}".getBytes());
+        JsonNode canonicalItem2 = canonicalJsonMapper.readFromBytes("{\"register\":\"register2\",\"text\":\"Register2 Text\", \"phase\":\"alpha\"}".getBytes());
 
         List<Entry> entries = testEntryDAO.getAllEntries(schema);
         Instant timestamp = entries.get(0).getTimestamp();
@@ -205,37 +212,64 @@ public class DataUploadFunctionalTest {
     }
 
     @Test
-    public void validation_FailsToLoadEntryWhenNonEmptyPrimaryKeyFieldIsNotExist() {
-        Response response = register.mintLines(TestRegister.register, "{}");
-        assertThat(response.getStatus(), equalTo(400));
-        assertThat(response.readEntity(String.class), equalTo("Item did not contain key field"));
+    public void validation_FailsToLoadEntryWhenMissingKeyField() {
+        String rsf = "add-item\t{}\n" +
+                "append-entry\tuser\tfoo\t2018-07-26T13:53:34Z\tsha-256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a";
 
-        response = register.mintLines(TestRegister.register, "{\"register\":\"  \"}");
+        Response response = register.loadRsf(TestRegister.register, rsf);
         assertThat(response.getStatus(), equalTo(400));
-        assertThat(response.readEntity(String.class), equalTo("Failed to append entry with entry-number 1 and key '  '"));
+
+        RegisterResult result = response.readEntity(RegisterResult.class);
+        assertThat(result.getMessage(), equalTo("Failed to load RSF"));
+        assertThat(result.getDetails(), containsString("Entry does not contain primary key field 'register'"));
+    }
+
+    @Test
+    public void validation_FailsToLoadEntryWhenBlankKeyField() {
+        String rsf = "add-item\t{\"register\":\"  \"}\n" +
+                "append-entry\tuser\t  \t2018-07-26T13:58:25Z\tsha-256:adeec959e9f6a1481f1bd77d541f19c8e430b668c174e96bfe8ad5a224e3e6ee";
+
+        Response response = register.loadRsf(TestRegister.register, rsf);
+        assertThat(response.getStatus(), equalTo(400));
+
+        RegisterResult result = response.readEntity(RegisterResult.class);
+
+        assertThat(result.getMessage(), equalTo("Failed to load RSF"));
+        assertThat(result.getDetails(), containsString("Primary key field 'register' must have a valid value"));
     }
 
     @Test
     public void validation_FailsToLoadEntryWhenEntryContainsInvalidFields() {
-        Response response = register.mintLines(TestRegister.register, "{\"foo\":\"bar\",\"foo1\":\"bar1\"}");
+        String rsf = "add-item\t{\"foo\":\"bar\",\"register\":\"invalid-items\"}\n" +
+                "append-entry\tuser\tinvalid-items\t2018-07-27T12:37:31Z\tsha-256:baeecd3c54f412d77089f25d6ba1637b1861b545a9b6b2eaceb757d328007e7c";
+
+        Response response = register.loadRsf(TestRegister.register, rsf);
         assertThat(response.getStatus(), equalTo(400));
-        assertThat(response.readEntity(String.class), equalTo("Item did not contain key field"));
+
+        RegisterResult result = response.readEntity(RegisterResult.class);
+        assertThat(result.getMessage(), equalTo("Failed to load RSF"));
+        assertThat(result.getDetails(), containsString("Entry contains invalid fields: [foo]"));
     }
 
     @Test
     public void validation_FailsToLoadEntryWhenFieldWithCardinalityManyIsNotAJsonArray() {
-        String entry = "{\"register\":\"someregister\",\"fields\":\"value\"}";
-        Response response = register.mintLines(TestRegister.register, entry);
+        String rsf = "add-item\t{\"fields\":\"single-field\",\"register\":\"some-register\"}\n" +
+                "append-entry\tuser\tsome-register\t2018-07-27T12:39:04Z\tsha-256:8a4545d97667542075a7d245c4274f6cc73dac3083c55a6aee81fe1b911b7d91";
+
+        Response response = register.loadRsf(TestRegister.register, rsf);
         assertThat(response.getStatus(), equalTo(400));
-        assertThat(response.readEntity(String.class), equalTo("Failed to append entry with entry-number 1 and key 'someregister'"));
+
+        RegisterResult result = response.readEntity(RegisterResult.class);
+        assertThat(result.getMessage(), equalTo("Failed to load RSF"));
+        assertThat(result.getDetails(), containsString("Field 'fields' has cardinality 'n'"));
     }
 
     @Test
     public void requestWithoutCredentials_isRejectedAsUnauthorized() throws Exception {
         // register.target() is unauthenticated
-        Response response = register.target(TestRegister.register).path("/load")
+        Response response = register.target(TestRegister.register).path("/load-rsf")
                 .request()
-                .post(entity("{}", APPLICATION_JSON_TYPE));
+                .post(entity("add-item\t{}", APPLICATION_RSF_TYPE));
         assertThat(response.getStatus(), equalTo(401));
     }
 }

--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
@@ -25,11 +25,13 @@ public class DeleteRegisterDataFunctionalTest {
     public void deleteRegisterData_deletesAllDataFromDb() throws Exception {
         register.loadRsf(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
 
-        String item1 = "{\"postcode\":\"P1\"}";
-        String item2 = "{\"postcode\":\"P2\"}";
+        String rsf = "add-item\t{\"postcode\":\"P1\"}\n" +
+                "add-item\t{\"postcode\":\"P2\"}\n" +
+                "append-entry\tuser\tP1\t2018-07-26T15:55:27Z\tsha-256:50a5de96d4cb6341a2f18c0b34bc401b2c92e3ac46641c0d1014dc82ed498326\n" +
+                "append-entry\tuser\tP2\t2018-07-26T15:55:27Z\tsha-256:af0cf1489bfb0f3da8130a50e6b4fa49de7c480a416dfa710418c0e42dc72949\n";
 
-        Response mintResponse = register.mintLines(REGISTER_WHICH_ALLOWS_DELETING, item1, item2);
-        assertThat(mintResponse.getStatus(), equalTo(204));
+        Response mintResponse = register.loadRsf(REGISTER_WHICH_ALLOWS_DELETING, rsf);
+        assertThat(mintResponse.getStatus(), equalTo(200));
 
         Response entriesResponse1 = register.getRequest(REGISTER_WHICH_ALLOWS_DELETING, "/entries.json");
         List<?> entriesList = entriesResponse1.readEntity(List.class);
@@ -48,11 +50,13 @@ public class DeleteRegisterDataFunctionalTest {
     public void deleteRegisterData_deletesProofCache() throws Exception {
         register.loadRsf(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
 
-        String item1 = "{\"postcode\":\"P1\"}";
-        String item2 = "{\"postcode\":\"P2\"}";
+        String rsf = "add-item\t{\"postcode\":\"P1\"}\n" +
+                "add-item\t{\"postcode\":\"P2\"}\n" +
+                "append-entry\tuser\tP1\t2018-07-26T15:55:27Z\tsha-256:50a5de96d4cb6341a2f18c0b34bc401b2c92e3ac46641c0d1014dc82ed498326\n" +
+                "append-entry\tuser\tP2\t2018-07-26T15:55:27Z\tsha-256:af0cf1489bfb0f3da8130a50e6b4fa49de7c480a416dfa710418c0e42dc72949\n";
 
         register.deleteRegisterData(REGISTER_WHICH_ALLOWS_DELETING);
-        register.mintLines(REGISTER_WHICH_ALLOWS_DELETING, item1, item2);
+        register.loadRsf(REGISTER_WHICH_ALLOWS_DELETING, rsf);
 
         Response proof1Response = register.getRequest(REGISTER_WHICH_ALLOWS_DELETING, "/proof/register/merkle:sha-256");
         assertThat(proof1Response.getStatus(), equalTo(200));
@@ -60,7 +64,7 @@ public class DeleteRegisterDataFunctionalTest {
 
         register.deleteRegisterData(REGISTER_WHICH_ALLOWS_DELETING);
         register.loadRsf(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
-        register.mintLines(REGISTER_WHICH_ALLOWS_DELETING, item2, item1);
+        register.loadRsf(REGISTER_WHICH_ALLOWS_DELETING, rsf);
 
         Response proof2Response = register.getRequest(REGISTER_WHICH_ALLOWS_DELETING, "/proof/register/merkle:sha-256");
         assertThat(proof2Response.getStatus(), equalTo(200));

--- a/src/test/java/uk/gov/register/functional/EntriesResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntriesResourceFunctionalTest.java
@@ -65,8 +65,12 @@ public class EntriesResourceFunctionalTest {
     public void entries_returnsListViewOfAllAvailableEntries() {
         String item1 = "{\"address\":\"1234\",\"street\":\"elvis\"}";
         String item2 = "{\"address\":\"6789\",\"street\":\"presley\"}";
+        String rsf = "add-item\t{\"address\":\"1234\",\"street\":\"elvis\"}\n" +
+                "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}\n" +
+                "append-entry\tuser\t1234\t2018-07-26T15:51:26Z\tsha-256:cb0f5233e9acf1a41f30803dcf902208e7d4918a41a9738091b179ce8c62010c\n" +
+                "append-entry\tuser\t6789\t2018-07-26T15:51:26Z\tsha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\n";
 
-        register.mintLines(address, item1, item2);
+        register.loadRsf(address, rsf);
 
         Response response = register.getRequest(address, "/entries.json");
         assertThat(response.getStatus(), equalTo(200));
@@ -98,8 +102,14 @@ public class EntriesResourceFunctionalTest {
         String item1 = "{\"address\":\"1234\",\"street\":\"elvis\"}";
         String item2 = "{\"address\":\"6789\",\"street\":\"presley\"}";
         String item3 = "{\"address\":\"567\",\"street\":\"john\"}";
+        String rsf = "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}\n" +
+                "add-item\t{\"address\":\"145678\",\"street\":\"ellis\"}\n" +
+                "add-item\t{\"address\":\"567\",\"street\":\"john\"}\n" +
+                "append-entry\tuser\tregister1\t2018-07-26T15:48:03Z\tsha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\n" +
+                "append-entry\tuser\tregister1\t2018-07-26T15:48:03Z\tsha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983\n" +
+                "append-entry\tuser\tregister1\t2018-07-26T15:48:03Z\tsha-256:6352a25fe8c9222676b29ba6f5e675b5dfa2b886010a844dd596b0d0cd615849\n";
 
-        register.mintLines(address, item1, item2, item3);
+        register.loadRsf(address, rsf);
 
         Response response = addressTarget.path("/entries.json").queryParam("start",1).queryParam("limit",2)
                 .request().get();

--- a/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
@@ -26,7 +26,13 @@ public class ItemResourceFunctionalTest {
     public void publishTestMessages() throws Throwable {
         register.wipe();
         register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
-        register.mintLines(address, item1, item2);
+
+        String rsf = "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}\n" +
+                "add-item\t{\"address\":\"145678\",\"street\":\"ellis\"}\n" +
+                "append-entry\tuser\tregister1\t2018-07-26T15:43:12Z\tsha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\n" +
+                "append-entry\tuser\tregister1\t2018-07-26T15:43:12Z\tsha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983\n";
+
+        register.loadRsf(address, rsf);
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
@@ -30,7 +30,7 @@ public class ItemResourceFunctionalTest {
     }
 
     @Test
-    public void jsonRepreHemelsentationOfAnItem() throws JSONException {
+    public void jsonRepresentationOfAnItem() throws JSONException {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 
         Response response = register.getRequest(address, String.format("/item/sha-256:%s.json", sha256Hex));

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -76,12 +76,6 @@ public class RegisterRule implements TestRule {
                 .post(entity(rsf, APPLICATION_RSF_TYPE));
     }
 
-    public Response mintLines(TestRegister register, String... payload) {
-        return authenticatedTarget(register).path("/load")
-                .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.json(String.join("\n", payload)));
-    }
-
     public Response getRequest(TestRegister register, String path) {
         return target(register).path(path).request().get();
     }


### PR DESCRIPTION
### Context
We used to use the `/load` endpoint to load data into ORJ. We now use `/load-rsf`. 

We are updating the spec so that it doesn't prescribe how entries are minted; see https://github.com/openregister/specification/pull/83

### Changes proposed in this pull request
- Remove the load endpoint
- Change tests to use load-rsf instead

I don't plan on deploying this until the corresponding spec change has been merged.

Trello: https://trello.com/c/s2bEdih7/2661-remove-load-endpoint

### Guidance to review
This'll be easier to review one commit at a time because there's a lot of test changes.

The test code probably needs cleaning up a bit more, but it would be helpful if you could initially give it a quick look over to see if the general approach is OK.

In particular, I had to add a public constructor to RegisterResult so that I could deserialise error responses in the tests, because changing from `/load` to `/load-rsf` changed all the responses that were being tested. I don't know much about Jackson, so I followed the example from http://www.baeldung.com/jackson-exception to fix the problem I ran into. Let me know if there's a better way to do it!