### PR TITLE
Drop total_records and current_keys tables

### DIFF
--- a/src/main/java/uk/gov/migration/V__12_Drop_unused_tables.java
+++ b/src/main/java/uk/gov/migration/V__12_Drop_unused_tables.java
@@ -1,0 +1,25 @@
+package uk.gov.migration;
+
+import org.flywaydb.core.api.migration.MigrationChecksumProvider;
+import org.flywaydb.core.api.migration.jdbc.BaseJdbcMigration;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+public class V__12_Drop_unused_tables extends BaseJdbcMigration implements MigrationChecksumProvider {
+    @Override
+    public void migrate(Connection connection) throws Exception {
+        Statement stmt = connection.createStatement();
+        try {
+            stmt.execute("drop table total_records");
+            stmt.execute("drop table current_keys");
+        } finally {
+            stmt.close();
+        }
+    }
+
+    @Override
+    public Integer getChecksum() {
+        return 1;
+    }
+}


### PR DESCRIPTION
### Context
These tables were used before we moved to store records as indexes, and
are therefore no longer required.

Trello: https://trello.com/c/dh4sLAJ1/2732-drop-totalrecords-and-currentkeys-tables

### Changes proposed in this pull request
This migration drops these tables from a register's schema.

ORJ runs migrations for each schema on startup: https://github.com/openregister/openregister-java/blob/master/src/main/java/uk/gov/register/RegisterApplication.java#L109

### Guidance to review
- Do I actually need to implement `MigrationChecksumProvider` here? Or is this just for re-runnable migrations?