### PR TITLE
Correct version history link header

### DIFF
--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -54,7 +54,7 @@ public class RecordResource {
     })
     @Timed
     public RecordView getRecordByKey(@PathParam("record-key") String key) throws FieldConversionException {
-        httpServletResponseAdapter.setLinkHeader("version-history", String.format("/record/%s/entries", key));
+        httpServletResponseAdapter.setLinkHeader("version-history", String.format("/records/%s/entries", key));
 
         return register.getRecord(key).map(viewFactory::getRecordMediaView)
                 .orElseThrow(NotFoundException::new);

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -36,7 +36,7 @@ public class RecordResourceFunctionalTest {
 
         assertThat(response.getStatus(), equalTo(200));
 
-        assertThat(response.getHeaderString("Link"), equalTo("</record/6789/entries>; rel=\"version-history\""));
+        assertThat(response.getHeaderString("Link"), equalTo("</records/6789/entries>; rel=\"version-history\""));
 
         JsonNode res = Jackson.newObjectMapper().readValue(response.readEntity(String.class), JsonNode.class).get("6789");
         assertThat(res.get("entry-number").textValue(), equalTo("2"));


### PR DESCRIPTION
### Context
The `Link` header for `/records/{key}` with relation
`rel="version-history"` uses the old url `/record/{key}/entries` instead
of the new one `/records/{key}/entries`.

Trello: https://trello.com/c/333bUFTY/2733-the-link-relation-version-history-shows-the-wrong-old-url

### Changes proposed in this pull request
Add an 's'

### Guidance to review
The link should point to the correct entries resource.