### PR TITLE
switch to LocalDate for date validation parser

### DIFF
--- a/src/main/java/uk/gov/register/util/DateFormatChecker.java
+++ b/src/main/java/uk/gov/register/util/DateFormatChecker.java
@@ -4,6 +4,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 
 import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.util.Date;
 
 import static uk.gov.register.util.DateFormat.ISO_8601.*;
@@ -15,12 +20,7 @@ public class DateFormatChecker {
             return false;
         }
 
-        try {
-            parseDateTime(dateToValidate);
-            return true;
-        } catch (ParseException ex) {
-            return false;
-        }
+       return isValidFormat(dateToValidate);
     }
 
     public static boolean isDateTimeFormatsOrdered(String startString, String endString) {
@@ -35,6 +35,43 @@ public class DateFormatChecker {
     }
 
     private static Date parseDateTime(String dateTimeString) throws ParseException {
-        return DateUtils.parseDate(dateTimeString, YEAR, YEAR_MONTH, YEAR_MONTH_DAY, YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS, YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS_UTC);
+        return DateUtils.parseDateStrictly(dateTimeString, YEAR, YEAR_MONTH, YEAR_MONTH_DAY, YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS, YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS_UTC);
+    }
+
+    private static boolean isValidFormat(String dateTimeString) {
+
+        DateTimeFormatter[] formatters = {
+                new DateTimeFormatterBuilder().appendPattern(YEAR)
+                        .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
+                        .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
+                        .parseStrict()
+                        .toFormatter(),
+                new DateTimeFormatterBuilder().appendPattern(YEAR_MONTH)
+                        .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
+                        .parseStrict()
+                        .toFormatter(),
+                new DateTimeFormatterBuilder().appendPattern(YEAR_MONTH_DAY)
+                        .parseStrict()
+                        .toFormatter(),
+                new DateTimeFormatterBuilder().appendPattern(YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS)
+                        .parseStrict()
+                        .toFormatter(),
+                new DateTimeFormatterBuilder().appendPattern(YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS_UTC)
+                        .parseStrict()
+                        .toFormatter()
+        };
+
+        for (final DateTimeFormatter formatter : formatters) {
+            try {
+                LocalDate.parse(dateTimeString, formatter);
+                return true;
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+        return false;
     }
 }
+
+
+
+

--- a/src/test/java/uk/gov/register/util/DateFormatCheckerTest.java
+++ b/src/test/java/uk/gov/register/util/DateFormatCheckerTest.java
@@ -15,7 +15,7 @@ public class DateFormatCheckerTest {
     }
 
     @Test
-    public void validateFormat_shouldValidateSuccessfully_whenInputDateTimeIsOfFormatYYYYDDMM() throws IOException {
+    public void validateFormat_shouldValidateSuccessfully_whenInputDateTimeIsOfFormatYYYYMM() throws IOException {
         assertTrue("Format should be valid", DateFormatChecker.isDateTimeFormatValid("2012-01"));
     }
 
@@ -42,6 +42,16 @@ public class DateFormatCheckerTest {
     @Test
     public void validateFormat_throwsValidationException_whenInputDateTimeIsEmpty() throws IOException {
         assertFalse("Format should not be valid", DateFormatChecker.isDateTimeFormatValid(""));
+    }
+
+    @Test
+    public void validateFormat_throwsValidationException_whenInputDateTimeIsFiveDigitNumber() throws IOException {
+        assertFalse("Format should not be valid", DateFormatChecker.isDateTimeFormatValid("41365"));
+    }
+
+    @Test
+    public void validateFormat_throwsValidationException_whenInputDateTimeIsUnPaddedMonth() throws IOException {
+        assertFalse("Format should not be valid", DateFormatChecker.isDateTimeFormatValid("2018-1"));
     }
 
     @Test


### PR DESCRIPTION
### Context
Previous date validator allowed values which should be illegal in the [spec](https://openregister.github.io/specification/#datetime-datatype) e.g. `41365` and `2018-1`

### Changes proposed in this pull request
Switch to Java 8 [LocalDate](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html) for date validation. 
Note, the reason this PR switches to use a list of formatters rather than parsing straight from the format string is that `LocalDate` always requires a year, month and date to be specified so we use the formatter to default them when they are not included in our permitted pattern.

### Guidance to review
Tests should pass in Travis CI