### PR TITLE
ADR009: Trailing slash in HTTP resources

### DIFF
--- a/doc/arch/adr-009-trailing-slash.md
+++ b/doc/arch/adr-009-trailing-slash.md
@@ -20,6 +20,9 @@ This ADR proposes a canonical URL and a way to consolidate around it.
 The canonical path for a resource MUST NOT have a trailing slash. Aliases MUST
 redirect (301) to the canonical path.
 
+Also, the `Link` header for aliases should add the canonical URL using the
+`rel="canonical"` ([RFC6596](https://tools.ietf.org/html/rfc6596)).
+
 For example, the `GB` record has the canonical path:
 
 ```

--- a/doc/arch/adr-009-trailing-slash.md
+++ b/doc/arch/adr-009-trailing-slash.md
@@ -1,0 +1,73 @@
+# Decision record: Trailing slash in HTTP resources
+
+## Context
+
+Currently, HTTP resources have many URLs representing the same thing. This is
+not an ideal scenario for search engine indexing or caching. For example, the
+record `GB` resource can be accessed via:
+
+* `GET /records/GB`
+* `GET /records/GB/`
+* `GET /records/GB.json`
+* `GET /records/GB.json/`
+* `GET /records/GB.csv`
+* `GET /records/GB.csv/`
+
+This ADR proposes a canonical URL and a way to consolidate around it.
+
+## Decision
+
+The canonical path for a resource MUST NOT have a trailing slash. Aliases MUST
+redirect (301) to the canonical path.
+
+For example, the `GB` record has the canonical path:
+
+```
+/records/GB
+```
+
+And the canonical JSON resource:
+
+```
+/records/GB.json
+```
+
+Aliases like `/records/GB/` and `/records/GB.json/` MUST redirect to their
+respective canonical resources.
+
+### Paginated resources
+
+The first page for the records list has the canonical path:
+
+```
+/records?page-index=1&page-size=100
+```
+
+Possible aliases of the above are:
+
+* `/records`
+* `/records/`
+* `/records/?page-index=1&page-size=100`
+
+Similarly, the canonical JSON resource:
+
+```
+/records.json?page-index=1&page-size=100
+```
+
+Has these possible aliases:
+
+* `/records.json`
+* `/records.json/`
+* `/records.json/?page-index=1&page-size=100`
+
+
+## Status
+
+Proposed.
+
+## Consequences
+
+This change is expected to make caching and caching invalidation easier
+without disrupting any user.
+

--- a/doc/arch/adr-009-trailing-slash.md
+++ b/doc/arch/adr-009-trailing-slash.md
@@ -51,7 +51,7 @@ the first page. This means that `/records` is canonical with the alias
 
 ## Status
 
-Proposed.
+Approved.
 
 ## Consequences
 

--- a/doc/arch/adr-009-trailing-slash.md
+++ b/doc/arch/adr-009-trailing-slash.md
@@ -40,29 +40,13 @@ respective canonical resources.
 
 ### Paginated resources
 
-The first page for the records list has the canonical path:
+Paginated resources behave in a similar way, trailing slashes are aliases to
+the equivalent without trailing slashes.
 
-```
-/records?page-index=1&page-size=100
-```
-
-Possible aliases of the above are:
-
-* `/records`
-* `/records/`
-* `/records/?page-index=1&page-size=100`
-
-Similarly, the canonical JSON resource:
-
-```
-/records.json?page-index=1&page-size=100
-```
-
-Has these possible aliases:
-
-* `/records.json`
-* `/records.json/`
-* `/records.json/?page-index=1&page-size=100`
+Notice that this ADR postpones the decision of what is the canonical path for
+the first page. This means that `/records` is canonical with the alias
+`/records/` and `/records?page-index=1` is canonical with the alias
+`/records/?page-index=1`
 
 
 ## Status


### PR DESCRIPTION
### Context

Currently, HTTP resources have many URLs representing the same thing. This is
not an ideal scenario for search engine indexing or caching.

### Changes proposed in this pull request

It proposes a canonical URL per resource.

### Guidance to review

It should cover all cases.