### PR TITLE
make JSON default representation if no format specified

### DIFF
--- a/src/main/java/uk/gov/register/resources/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/EntryResource.java
@@ -39,47 +39,6 @@ public class EntryResource {
 
     @GET
     @Path("/entries")
-    @Produces(ExtraMediaType.TEXT_HTML)
-    @Timed
-    public PaginatedView<EntryListView> entriesHtml(@QueryParam("start") Optional<IntegerParam> optionalStart, @QueryParam("limit") Optional<IntegerParam> optionalLimit) {
-        int totalEntries = register.getTotalEntries();
-        StartLimitPagination startLimitPagination = new StartLimitPagination(optionalStart.map(IntParam::get), optionalLimit.map(IntParam::get), totalEntries);
-
-        Collection<Entry> entries = register.getEntries(startLimitPagination.start, startLimitPagination.limit);
-
-        setHeaders(startLimitPagination);
-
-        return viewFactory.getEntriesView(entries, startLimitPagination);
-    }
-
-    @GET
-    @Path("/entries/{entry-number}")
-    @Produces(ExtraMediaType.TEXT_HTML)
-    @Timed
-    public AttributionView<Entry> findByEntryNumberHtml(@PathParam("entry-number") int entryNumber) {
-        Optional<Entry> entry = register.getEntry(entryNumber);
-        return entry.map(viewFactory::getEntryView).orElseThrow(NotFoundException::new);
-    }
-
-    @GET
-    @Path("/entries/{entry-number}")
-    @Produces({
-            MediaType.APPLICATION_JSON,
-            ExtraMediaType.TEXT_YAML,
-            ExtraMediaType.TEXT_CSV,
-            ExtraMediaType.TEXT_TSV,
-            ExtraMediaType.TEXT_TTL,
-            ExtraMediaType.APPLICATION_SPREADSHEET
-    })
-    @Timed
-    public Optional<EntryListView> findByEntryNumber(@PathParam("entry-number") int entryNumber) {
-        Optional<Entry> entry = register.getEntry(entryNumber);
-        return entry.map(function -> new EntryListView(Collections.singletonList(function)));
-    }
-
-
-    @GET
-    @Path("/entries")
     @Produces({
             MediaType.APPLICATION_JSON,
             ExtraMediaType.TEXT_YAML,
@@ -99,6 +58,49 @@ public class EntryResource {
 
         return new EntryListView(entries);
     }
+
+    @GET
+    @Path("/entries")
+    @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
+    public PaginatedView<EntryListView> entriesHtml(@QueryParam("start") Optional<IntegerParam> optionalStart, @QueryParam("limit") Optional<IntegerParam> optionalLimit) {
+        int totalEntries = register.getTotalEntries();
+        StartLimitPagination startLimitPagination = new StartLimitPagination(optionalStart.map(IntParam::get), optionalLimit.map(IntParam::get), totalEntries);
+
+        Collection<Entry> entries = register.getEntries(startLimitPagination.start, startLimitPagination.limit);
+
+        setHeaders(startLimitPagination);
+
+        return viewFactory.getEntriesView(entries, startLimitPagination);
+    }
+
+    @GET
+    @Path("/entries/{entry-number}")
+    @Produces({
+            MediaType.APPLICATION_JSON,
+            ExtraMediaType.TEXT_YAML,
+            ExtraMediaType.TEXT_CSV,
+            ExtraMediaType.TEXT_TSV,
+            ExtraMediaType.TEXT_TTL,
+            ExtraMediaType.APPLICATION_SPREADSHEET
+    })
+    @Timed
+    public Optional<EntryListView> findByEntryNumber(@PathParam("entry-number") int entryNumber) {
+        Optional<Entry> entry = register.getEntry(entryNumber);
+        return entry.map(function -> new EntryListView(Collections.singletonList(function)));
+    }
+
+    @GET
+    @Path("/entries/{entry-number}")
+    @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
+    public AttributionView<Entry> findByEntryNumberHtml(@PathParam("entry-number") int entryNumber) {
+        Optional<Entry> entry = register.getEntry(entryNumber);
+        return entry.map(viewFactory::getEntryView).orElseThrow(NotFoundException::new);
+    }
+
+
+
 
     private void setHeaders(StartLimitPagination startLimitPagination) {
         requestContext.resourceExtension().ifPresent(

--- a/src/main/java/uk/gov/register/resources/ItemResource.java
+++ b/src/main/java/uk/gov/register/resources/ItemResource.java
@@ -29,15 +29,6 @@ public class ItemResource {
 
     @GET
     @Path("/sha-256:{item-hash}")
-    @Produces(ExtraMediaType.TEXT_HTML)
-    @Timed
-    public AttributionView<ItemView> getItemWebViewByHex(@PathParam("item-hash") String itemHash) throws FieldConversionException {
-        return getItem(itemHash).map(viewFactory::getItemView)
-                .orElseThrow(() -> new NotFoundException("No item found with item hash: " + itemHash));
-    }
-
-    @GET
-    @Path("/sha-256:{item-hash}")
     @Produces({
             MediaType.APPLICATION_JSON,
             ExtraMediaType.TEXT_YAML,
@@ -56,4 +47,14 @@ public class ItemResource {
         HashValue hash = new HashValue(HashingAlgorithm.SHA256, itemHash);
         return register.getItem(hash);
     }
+
+    @GET
+    @Path("/sha-256:{item-hash}")
+    @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
+    public AttributionView<ItemView> getItemWebViewByHex(@PathParam("item-hash") String itemHash) throws FieldConversionException {
+        return getItem(itemHash).map(viewFactory::getItemView)
+                .orElseThrow(() -> new NotFoundException("No item found with item hash: " + itemHash));
+    }
+
 }

--- a/src/main/java/uk/gov/register/resources/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/RecordResource.java
@@ -34,16 +34,6 @@ public class RecordResource {
 
     @GET
     @Path("/records/{record-key}")
-    @Produces(ExtraMediaType.TEXT_HTML)
-    @Timed
-    public AttributionView<RecordView> getRecordByKeyHtml(@PathParam("record-key") String key) throws FieldConversionException {
-        return viewFactory.getRecordView(getRecordByKey(key));
-    }
-
-
-
-    @GET
-    @Path("/records/{record-key}")
     @Produces({
             MediaType.APPLICATION_JSON,
             ExtraMediaType.TEXT_YAML,
@@ -60,21 +50,12 @@ public class RecordResource {
                 .orElseThrow(NotFoundException::new);
     }
 
-
-
     @GET
-    @Path("/records/{record-key}/entries")
+    @Path("/records/{record-key}")
     @Produces(ExtraMediaType.TEXT_HTML)
     @Timed
-    public PaginatedView<EntryListView> getAllEntriesOfARecordHtml(@PathParam("record-key") String key) {
-        Collection<Entry> allEntries = register.allEntriesOfRecord(key);
-        if (allEntries.isEmpty()) {
-            throw new NotFoundException();
-        }
-        return viewFactory.getRecordEntriesView(
-                key, allEntries,
-                new IndexSizePagination(Optional.of(1), Optional.of(allEntries.size()), allEntries.size())
-        );
+    public AttributionView<RecordView> getRecordByKeyHtml(@PathParam("record-key") String key) throws FieldConversionException {
+        return viewFactory.getRecordView(getRecordByKey(key));
     }
 
     @GET
@@ -97,15 +78,20 @@ public class RecordResource {
     }
 
     @GET
-    @Path("/records/{key}/{value}")
+    @Path("/records/{record-key}/entries")
     @Produces(ExtraMediaType.TEXT_HTML)
     @Timed
-    public PaginatedView<RecordsView> facetedRecordsHtml(@PathParam("key") String key, @PathParam("value") String value) throws FieldConversionException, NoSuchFieldException {
-        List<Record> records = register.max100RecordsFacetedByKeyValue(key, value);
-        Pagination pagination
-                = new IndexSizePagination(Optional.empty(), Optional.empty(), records.size());
-        return viewFactory.getRecordsView(pagination, facetedRecords(key, value));
+    public PaginatedView<EntryListView> getAllEntriesOfARecordHtml(@PathParam("record-key") String key) {
+        Collection<Entry> allEntries = register.allEntriesOfRecord(key);
+        if (allEntries.isEmpty()) {
+            throw new NotFoundException();
+        }
+        return viewFactory.getRecordEntriesView(
+                key, allEntries,
+                new IndexSizePagination(Optional.of(1), Optional.of(allEntries.size()), allEntries.size())
+        );
     }
+
 
     @GET
     @Path("/records/{key}/{value}")
@@ -124,14 +110,16 @@ public class RecordResource {
     }
 
     @GET
-    @Path("/records")
+    @Path("/records/{key}/{value}")
     @Produces(ExtraMediaType.TEXT_HTML)
     @Timed
-    public PaginatedView<RecordsView> recordsHtml(@QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntegerParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntegerParam> pageSize) throws FieldConversionException {
-        IndexSizePagination pagination = setUpPagination(pageIndex, pageSize);
-        RecordsView recordsView = getRecordsView(pagination.pageSize(), pagination.offset());
-        return viewFactory.getRecordsView(pagination, recordsView);
+    public PaginatedView<RecordsView> facetedRecordsHtml(@PathParam("key") String key, @PathParam("value") String value) throws FieldConversionException, NoSuchFieldException {
+        List<Record> records = register.max100RecordsFacetedByKeyValue(key, value);
+        Pagination pagination
+                = new IndexSizePagination(Optional.empty(), Optional.empty(), records.size());
+        return viewFactory.getRecordsView(pagination, facetedRecords(key, value));
     }
+
 
     @GET
     @Path("/records")
@@ -149,6 +137,17 @@ public class RecordResource {
 
         return getRecordsView(pagination.pageSize(), pagination.offset());
     }
+
+    @GET
+    @Path("/records")
+    @Produces(ExtraMediaType.TEXT_HTML)
+    @Timed
+    public PaginatedView<RecordsView> recordsHtml(@QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntegerParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntegerParam> pageSize) throws FieldConversionException {
+        IndexSizePagination pagination = setUpPagination(pageIndex, pageSize);
+        RecordsView recordsView = getRecordsView(pagination.pageSize(), pagination.offset());
+        return viewFactory.getRecordsView(pagination, recordsView);
+    }
+
 
     private IndexSizePagination setUpPagination(@QueryParam(IndexSizePagination.INDEX_PARAM) Optional<IntegerParam> pageIndex, @QueryParam(IndexSizePagination.SIZE_PARAM) Optional<IntegerParam> pageSize) {
         IndexSizePagination pagination = new IndexSizePagination(pageIndex.map(IntParam::get), pageSize.map(IntParam::get), register.getTotalRecords());

--- a/src/test/java/uk/gov/register/functional/EntriesResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntriesResourceFunctionalTest.java
@@ -15,6 +15,7 @@ import uk.gov.register.functional.app.RsfRegisterDefinition;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.time.format.DateTimeFormatter;
 
@@ -82,7 +83,7 @@ public class EntriesResourceFunctionalTest {
         assertThat(entry1.get("entry-number").textValue(), equalTo("1"));
         assertThat(entry1.get("item-hash").getNodeType(), is(JsonNodeType.ARRAY));
         String hash1 = entry1.get("item-hash").get(0).asText();
-        assertThat( hash1, is("sha-256:" + DigestUtils.sha256Hex(item1)));
+        assertThat(hash1, is("sha-256:" + DigestUtils.sha256Hex(item1)));
         verifyStringIsADateSpecifiedInSpecification(entry1.get("entry-timestamp").textValue());
         assertThat(entry1.get("key").textValue(), equalTo("1234"));
 
@@ -90,7 +91,7 @@ public class EntriesResourceFunctionalTest {
         assertThat(Iterators.size(entry2.fields()), equalTo(5));
         assertThat(entry2.get("entry-number").textValue(), equalTo("2"));
         String hash2 = entry2.get("item-hash").get(0).asText();
-        assertThat( hash2, is("sha-256:" + DigestUtils.sha256Hex(item2)));
+        assertThat(hash2, is("sha-256:" + DigestUtils.sha256Hex(item2)));
         verifyStringIsADateSpecifiedInSpecification(entry2.get("entry-timestamp").textValue());
         assertThat(entry2.get("key").textValue(), equalTo("6789"));
 
@@ -98,7 +99,7 @@ public class EntriesResourceFunctionalTest {
 
     // TODO what does start = -1 mean?
     @Ignore
-    public void paginationSupport(){
+    public void paginationSupport() {
         String item1 = "{\"address\":\"1234\",\"street\":\"elvis\"}";
         String item2 = "{\"address\":\"6789\",\"street\":\"presley\"}";
         String item3 = "{\"address\":\"567\",\"street\":\"john\"}";
@@ -111,7 +112,7 @@ public class EntriesResourceFunctionalTest {
 
         register.loadRsf(address, rsf);
 
-        Response response = addressTarget.path("/entries.json").queryParam("start",1).queryParam("limit",2)
+        Response response = addressTarget.path("/entries.json").queryParam("start", 1).queryParam("limit", 2)
                 .request().get();
         ArrayNode jsonNodes = response.readEntity(ArrayNode.class);
         assertThat(jsonNodes.size(), equalTo(2));
@@ -119,7 +120,7 @@ public class EntriesResourceFunctionalTest {
         assertThat(jsonNodes.get(1).get("entry-number").textValue(), equalTo("2"));
         assertThat(response.getHeaderString("Link"), equalTo("<?start=3&limit=2>; rel=\"next\""));
 
-        response = addressTarget.path("/entries.json").queryParam("start",2).queryParam("limit",3)
+        response = addressTarget.path("/entries.json").queryParam("start", 2).queryParam("limit", 3)
                 .request().get();
         jsonNodes = response.readEntity(ArrayNode.class);
         assertThat(jsonNodes.size(), equalTo(3));
@@ -127,7 +128,7 @@ public class EntriesResourceFunctionalTest {
         assertThat(jsonNodes.get(1).get("entry-number").textValue(), equalTo("3"));
         assertThat(response.getHeaderString("Link"), equalTo("<?start=0&limit=3>; rel=\"previous\""));
 
-        response = addressTarget.path("/entries.json").queryParam("start",2).queryParam("limit",3)
+        response = addressTarget.path("/entries.json").queryParam("start", 2).queryParam("limit", 3)
                 .request().get();
         jsonNodes = response.readEntity(ArrayNode.class);
         assertThat(jsonNodes.size(), equalTo(2));
@@ -135,7 +136,7 @@ public class EntriesResourceFunctionalTest {
         assertThat(jsonNodes.get(1).get("entry-number").textValue(), equalTo("3"));
         assertThat(response.getHeaderString("Link"), equalTo("<?start=-1&limit=3>; rel=\"previous\""));
 
-        response = addressTarget.path("/entries.json").queryParam("start",2).queryParam("limit",1)
+        response = addressTarget.path("/entries.json").queryParam("start", 2).queryParam("limit", 1)
                 .request().get();
         jsonNodes = response.readEntity(ArrayNode.class);
         assertThat(jsonNodes.size(), equalTo(1));

--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -108,6 +108,14 @@ public class EntryResourceFunctionalTest {
     }
 
     @Test
+    public void entryView_returnsJsonWhenNoMediaTypeSpecified() {
+        Response response = register.getRequest(address, "/entries/1", MediaType.WILDCARD);
+
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.getHeaderString("Content-Type"), equalTo("application/json"));
+    }
+
+    @Test
     public void return200ResponseForTextHtmlMediaTypeWhenItemExists() {
         assertThat(register.getRequest(address, "/entry/1", MediaType.TEXT_HTML).getStatus(), equalTo(200));
     }

--- a/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
@@ -47,6 +47,16 @@ public class ItemResourceFunctionalTest {
     }
 
     @Test
+    public void itemReturnsJsonWhenNoMediaTypeSpecified() {
+        String sha256Hex = DigestUtils.sha256Hex(item1);
+
+        Response response = register.getRequest(address, String.format("/item/sha-256:%s", sha256Hex), MediaType.WILDCARD);
+
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.getHeaderString("Content-Type"), equalTo("application/json"));
+    }
+
+    @Test
     public void return200ResponseForTextHtmlMediaTypeWhenItemExists() {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -49,6 +49,13 @@ public class RecordResourceFunctionalTest {
         assertThat(itemMap.get("street").asText(), is("presley"));
         assertThat(itemMap.get("address").asText(), is("6789"));
     }
+
+    @Test
+    public void getRecordByKey_returnsJsonWhenNoMediaTypeSpecified() {
+        Response response = register.getRequest(address, "/record/6789");
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.getHeaderString("Content-Type"), equalTo("application/json"));
+    }
     
     @Test
     public void getRecords() throws IOException {
@@ -72,6 +79,13 @@ public class RecordResourceFunctionalTest {
     }
 
     @Test
+    public void getRecords_returnsJsonWhenNoMediaTypeSpecified() {
+        Response response = register.getRequest(address, "/records", MediaType.WILDCARD);
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.getHeaderString("Content-Type"), equalTo("application/json"));
+    }
+
+    @Test
     public void getFacetedRecords() throws IOException {
         Response response = register.getRequest(address, "/records/street/presley.json");
 
@@ -85,6 +99,13 @@ public class RecordResourceFunctionalTest {
         assertThat(facetedRecord.get("index-entry-number").textValue(), equalTo("2"));
         assertTrue(facetedRecord.get("entry-timestamp").textValue().matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"));
         assertThat(facetedRecord.get("item").size(), equalTo(1));
+    }
+
+    @Test
+    public void getFacetedRecords_returnsJsonWhenNoMediaTypeSpecified() {
+        Response response = register.getRequest(address, "/records/street/presley", MediaType.WILDCARD);
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.getHeaderString("Content-Type"), equalTo("application/json"));
     }
 
     @Test
@@ -160,6 +181,15 @@ public class RecordResourceFunctionalTest {
     public void historyResource_return404ResponseWhenRecordNotExist() {
         assertThat(register.getRequest(address, "/record/5001/entries.json").getStatus(), equalTo(404));
     }
+
+    @Test
+    public void historyResource_returnsJsonWhenNoMediaTypeSpecified() {
+        Response response = register.getRequest(address, "record/6789/entries", MediaType.WILDCARD);
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.getHeaderString("Content-Type"), equalTo("application/json"));
+    }
+
+
 
     @Test
     public void facetedRecordResource_return404ResponseWhenFieldNotExist() {


### PR DESCRIPTION
### Context
https://trello.com/c/m8sbtMLi/2956-make-json-the-default-format-when-accept-and-extension-are-missing

### Changes proposed in this pull request
Make JSON default format when no preference is expressed. The mechanism to do this is simply to declare JSON resources higher up than HTML ones which then makes them default (if no media type is specified.)


### Guidance to review
Tests should pass in Travis CI
`curl http://localhost:8080/records` should return JSON