### PR TITLE
Implements ADR009: Trailing slash in HTTP resources 

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -26,6 +26,7 @@ import uk.gov.register.core.*;
 import uk.gov.register.db.Factories;
 import uk.gov.register.filters.CorsBundle;
 import uk.gov.register.filters.HttpToHttpsRedirectFilter;
+import uk.gov.register.filters.StripTrailingSlashRedirectFilter;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.resources.SchemeContext;
 import uk.gov.register.serialization.RSFCreator;
@@ -125,6 +126,10 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
 
         environment.servlets()
                 .addFilter("HttpToHttpsRedirectFilter", new HttpToHttpsRedirectFilter())
+                .addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");
+
+        environment.servlets()
+                .addFilter("StripTrailingSlashRedirectFilter", new StripTrailingSlashRedirectFilter())
                 .addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");
 
         jersey.register(new AbstractBinder() {

--- a/src/main/java/uk/gov/register/filters/StripTrailingSlashRedirectFilter.java
+++ b/src/main/java/uk/gov/register/filters/StripTrailingSlashRedirectFilter.java
@@ -1,0 +1,52 @@
+package uk.gov.register.filters;
+
+import com.google.common.net.HttpHeaders;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class StripTrailingSlashRedirectFilter implements javax.servlet.Filter {
+
+    private static String removeLastChar(String str) {
+        return str.substring(0, str.length() - 1);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) { }
+
+    @Override
+    public void destroy() { }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest)request;
+
+        String path = httpRequest.getRequestURI();
+        if (path.endsWith("/") && path.length() > 1) {
+        int serverPort = httpRequest.getServerPort();
+            StringBuilder location = new StringBuilder();
+            location.append(request.getScheme())
+                    .append("://")
+                    .append(httpRequest.getServerName());
+            if (!(serverPort == 80 || serverPort == 443)) {
+                location.append(":").append(httpRequest.getServerPort());
+            }
+            location.append(removeLastChar(httpRequest.getRequestURI()));
+
+            String queryString = httpRequest.getQueryString();
+            if (queryString != null) {
+                location.append('?');
+                location.append(queryString);
+            }
+
+            HttpServletResponse httpResponse = (HttpServletResponse)response;
+            httpResponse.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+            httpResponse.setHeader(HttpHeaders.LOCATION, location.toString());
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/uk/gov/register/filters/StripTrailingSlashRedirectFilter.java
+++ b/src/main/java/uk/gov/register/filters/StripTrailingSlashRedirectFilter.java
@@ -1,6 +1,7 @@
 package uk.gov.register.filters;
 
 import com.google.common.net.HttpHeaders;
+import org.apache.http.client.utils.URIBuilder;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
@@ -26,19 +27,16 @@ public class StripTrailingSlashRedirectFilter implements javax.servlet.Filter {
         String path = httpRequest.getRequestURI();
         if (path.endsWith("/") && path.length() > 1) {
         int serverPort = httpRequest.getServerPort();
-            StringBuilder location = new StringBuilder();
-            location.append(request.getScheme())
-                    .append("://")
-                    .append(httpRequest.getServerName());
+            URIBuilder location = new URIBuilder()
+            .setScheme(request.getScheme())
+            .setHost(httpRequest.getServerName())
+            .setPath(removeLastChar(httpRequest.getRequestURI()));
             if (!(serverPort == 80 || serverPort == 443)) {
-                location.append(":").append(httpRequest.getServerPort());
+                location.setPort(serverPort);
             }
-            location.append(removeLastChar(httpRequest.getRequestURI()));
-
             String queryString = httpRequest.getQueryString();
             if (queryString != null) {
-                location.append('?');
-                location.append(queryString);
+                location.setCustomQuery(queryString);
             }
 
             HttpServletResponse httpResponse = (HttpServletResponse)response;

--- a/src/test/java/uk/gov/register/filters/StripTrailingSlashRedirectFilterTest.java
+++ b/src/test/java/uk/gov/register/filters/StripTrailingSlashRedirectFilterTest.java
@@ -1,0 +1,70 @@
+package uk.gov.register.filters;
+
+import org.junit.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+public class StripTrailingSlashRedirectFilterTest {
+
+     private HttpServletResponse makeRequestToPath(String path) throws IOException, ServletException {
+      return makeRequestToPath(path, null, 443);
+    }
+
+    private HttpServletResponse makeRequestToPath(String path, String queryString) throws IOException, ServletException {
+      return makeRequestToPath(path, queryString, 443);
+    }
+
+    private HttpServletResponse makeRequestToPath(String path, String queryString, int port) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+        when(httpServletRequest.getRequestURI()).thenReturn(path);
+        when(httpServletRequest.getServerName()).thenReturn("country.register.gov.uk");
+        when(httpServletRequest.getScheme()).thenReturn("https");
+        when(httpServletRequest.getQueryString()).thenReturn(queryString);
+        when(httpServletRequest.getServerPort()).thenReturn(port);
+        StripTrailingSlashRedirectFilter stripTrailingSlashRedirectFilter = new StripTrailingSlashRedirectFilter();
+        stripTrailingSlashRedirectFilter.doFilter(httpServletRequest, httpServletResponse,
+                filterChain);
+        return httpServletResponse;
+    }
+
+    @Test
+    public void redirectsTrailingSlash() throws IOException, ServletException {
+        HttpServletResponse response = makeRequestToPath("/records/");
+        verify(response).setStatus(301);
+        verify(response).setHeader("Location", "https://country.register.gov.uk/records");
+    }
+
+    @Test
+    public void doesNotRedirectRootPath() throws IOException, ServletException {
+        HttpServletResponse response = makeRequestToPath("/");
+        verify(response, never()).setStatus(301);
+    }
+
+    @Test
+    public void doesNotRedirectPathWithoutTrailingSlash() throws IOException, ServletException {
+        HttpServletResponse response = makeRequestToPath("/records");
+        verify(response, never()).setStatus(301);
+    }
+
+    @Test
+    public void retainsQueryString() throws IOException, ServletException {
+        HttpServletResponse response = makeRequestToPath("/records/", "page-size=5000");
+        verify(response).setStatus(301);
+        verify(response).setHeader("Location", "https://country.register.gov.uk/records?page-size=5000");
+    }
+
+    @Test
+    public void retainsCustomPort() throws IOException, ServletException {
+        HttpServletResponse response = makeRequestToPath("/records/", "page-size=5000", 8080);
+        verify(response).setStatus(301);
+        verify(response).setHeader("Location", "https://country.register.gov.uk:8080/records?page-size=5000");
+    }
+}


### PR DESCRIPTION
### Context
https://github.com/openregister/openregister-java/blob/master/doc/arch/adr-009-trailing-slash.md

### Changes proposed in this pull request
Redirect trailing slash paths to non-trailing slash

### Guidance to review
Note this does not implement `rel=canonical` as suggested in the ADR, as while they were in the same ADR I would rather implement `rel=canonical` in a separate PR.