### PR TITLE
use openjdk on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 sudo: required
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 services: 
   - postgresql
 addons:


### PR DESCRIPTION
### Context
Previously we ran the tests on Oracle JDK

### Changes proposed in this pull request
Switch to OpenJDK to be consistent with what we are running on production

### Guidance to review
Tests should pass on Travis CI