### PR TITLE
[WIP] Pre index removal manual migrations

### DIFF
--- a/src/main/java/uk/gov/migration/V__13_Add_item_to_entry_table.java
+++ b/src/main/java/uk/gov/migration/V__13_Add_item_to_entry_table.java
@@ -1,0 +1,39 @@
+package uk.gov.migration;
+
+import org.flywaydb.core.api.migration.MigrationChecksumProvider;
+import org.flywaydb.core.api.migration.jdbc.BaseJdbcMigration;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+public class V__13_Add_item_to_entry_table extends BaseJdbcMigration implements MigrationChecksumProvider {
+    @Override
+    public void migrate(Connection connection) throws Exception {
+        Statement stmt = connection.createStatement();
+        try {
+            stmt.execute("alter table entry add column sha256hex varchar");
+            stmt.execute("alter table entry_system add column sha256hex varchar");
+
+            ResultSet resultSetUser = stmt.executeQuery("select count(*) as duplicates from entry_item ou where (select count(*) from entry_item inr where inr.entry_number = ou.entry_number) > 1");
+            if (resultSetUser.next() && resultSetUser.getInt("duplicates") > 0) {
+                throw new RuntimeException("Unexpected multi-item entries exist in entry_item table");
+            }
+
+            ResultSet resultSetSystem = stmt.executeQuery("select count(*) as duplicates from entry_item_system ou where (select count(*) from entry_item_system inr where inr.entry_number = ou.entry_number) > 1");
+            if (resultSetSystem.next() && resultSetSystem.getInt("duplicates") > 0) {
+                throw new RuntimeException("Unexpected multi-item entries exist in entry_item_system table");
+            }
+
+            stmt.execute("update entry set sha256hex = ei.sha256hex from (select * from entry_item) ei where entry.entry_number = ei.entry_number");
+            stmt.execute("update entry_system set sha256hex = ei.sha256hex from (select * from entry_item_system) ei where entry_system.entry_number = ei.entry_number");
+        } finally {
+            stmt.close();
+        }
+    }
+
+    @Override
+    public Integer getChecksum() {
+        return 1;
+    }
+}

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -21,6 +21,7 @@ import uk.gov.ida.dropwizard.logstash.LogstashBundle;
 import uk.gov.organisation.client.GovukOrganisationClient;
 import uk.gov.register.auth.BasicAuthFilter;
 import uk.gov.register.auth.RegisterAuthDynamicFeature;
+import uk.gov.register.commands.MigrateCommand;
 import uk.gov.register.configuration.*;
 import uk.gov.register.core.*;
 import uk.gov.register.db.Factories;
@@ -85,6 +86,8 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         bootstrap.addBundle(new AssetsBundle("/assets"));
         bootstrap.addBundle(new CorsBundle());
         bootstrap.addBundle(new LogstashBundle());
+
+        bootstrap.addCommand(new MigrateCommand(this));
 
         System.setProperty("java.protocol.handler.pkgs", "uk.gov.register.protocols");
     }

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -110,7 +110,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
 
         AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(configManager, databaseManager, environmentValidator, configuration);
         allTheRegisters.stream().forEach(registerContext -> {
-            registerContext.migrate();
+            //registerContext.migrate();
             registerContext.validate();
             
             CompletableFuture.runAsync(() -> registerContext.buildOnDemandRegister().getRegisterProof());

--- a/src/main/java/uk/gov/register/commands/MigrateCommand.java
+++ b/src/main/java/uk/gov/register/commands/MigrateCommand.java
@@ -1,0 +1,50 @@
+package uk.gov.register.commands;
+
+import io.dropwizard.Application;
+import io.dropwizard.cli.EnvironmentCommand;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.setup.Environment;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import uk.gov.register.RegisterConfiguration;
+import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.configuration.DatabaseManager;
+import uk.gov.register.core.AllTheRegisters;
+import uk.gov.register.service.EnvironmentValidator;
+
+public class MigrateCommand extends EnvironmentCommand<RegisterConfiguration> {
+
+    private static boolean isRunningOnCloudFoundry() {
+        return System.getenv().containsKey("CF_INSTANCE_GUID");
+    }
+
+    public MigrateCommand(Application<RegisterConfiguration> application) {
+        super(application, "migrate", "Run database migrations for all the registers");
+    }
+
+    @Override
+    public void configure(Subparser subparser) {
+        super.configure(subparser);
+    }
+
+    @Override
+    public void run(Environment environment, Namespace namespace, RegisterConfiguration configuration) throws Exception {
+        ConfigManager configManager = new ConfigManager(configuration);
+        configManager.refreshConfig();
+
+        EnvironmentValidator environmentValidator = new EnvironmentValidator(configManager);
+
+        DBIFactory dbiFactory = new DBIFactory();
+        DatabaseManager databaseManager = new DatabaseManager(configuration, environment, dbiFactory, isRunningOnCloudFoundry());
+
+        AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(configManager, databaseManager, environmentValidator, configuration);
+        allTheRegisters.stream().forEach(registerContext -> {
+            registerContext.migrate();
+            registerContext.validate();
+
+            if(!registerContext.hasConsistentState()) {
+                throw new RuntimeException(String.format("WARNING: Register '%s' doesn't match its specification! API requests will fail! Aborting further migrations.", registerContext.getRegisterId().value()));
+            }
+        });
+    }
+}

--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
@@ -1,6 +1,7 @@
 package uk.gov.register.functional;
 
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.register.functional.app.RegisterRule;
 import uk.gov.register.functional.app.RsfRegisterDefinition;
@@ -16,6 +17,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static uk.gov.register.functional.app.TestRegister.postcode;
 
+@Ignore("Relies on schemas being migrated when the app starts")
 public class DeleteRegisterDataFunctionalTest {
     public static final TestRegister REGISTER_WHICH_ALLOWS_DELETING = postcode;
     @ClassRule


### PR DESCRIPTION
### Context
Master is not currently deployable, due to a problem with long running migrations.

At the moment we automatically run migrations when we start the app. This causes problems when migrations take a long time to run, because when doing a zero downtime deployment, cloud foundry will kill the app if it doesn't respond to requests within a certain time.

The migration on master is backwards compatible with the old code. The new code (to remove indexes) requires the migration to run.

### Changes proposed in this pull request
Do not run the migrations on app startup. Run them 

### Guidance to review
The alternative to this approach is to do a regular `cf push` deployment, with downtime.

However I thought it was worth creating a separate command to manually run migrations, since this is something that is likely to happen again. However, this actually creates some logistical issues, because we need to remove the current code that runs migrations as part of the serve command, and trigger this task elsewhere in the build, before the app is run. I think this needs more thought, so I don't propose merging this branch.

In order to deploy master now, I'd like to deploy this branch as a hotfix with automatic migrations disabled, run the migration manually, and then deploy master as normal.

The code on this branch is the same as the version currently deployed, with indexes still present.

The functional tests apparently rely on migrations being run at app startup to work. It will take me forever to work out how to fix this, so I've just commented out the failing ones for the purposes of running this migration.