### PR TITLE
Switch off HTTP healthcheck

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: change-me
   memory: 512M
   buildpack: java_buildpack
-  health-check-http-endpoint: /healthcheck
+  health-check-type: process
   services:
     - change-me-db
   env:


### PR DESCRIPTION

### Context
As the app executes migrations on startup, the HTTP healthcheck
may fail after deploying a new version, causing the deploy to
be rolled back. This is currently blocking master from being deployed.

### Changes proposed in this pull request
As a workaround, switch to a simpler healthcheck that just ensures
the process is running.

See
https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html#types
for a full description of health check types in cloud foundry.

This should be reverted after master is deployable again.

### Guidance to review
