### PR TITLE
Revert "Switch off HTTP healthcheck"

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: change-me
   memory: 512M
   buildpack: java_buildpack
-  health-check-type: process
+  health-check-http-endpoint: /healthcheck
   services:
     - change-me-db
   env:


### PR DESCRIPTION
Reverts openregister/openregister-java#512

Now that master has been deployed, we can switch the normal healthcheck back on.

We should change something to avoid master becoming undeployable again, but I don't think this is the right solution long term. https://github.com/openregister/openregister-java/pull/511 was my first attempt at solving this problem, but it turned out to be more complicated than I first thought so I've parked it for now. cc @gidsg 