### PR TITLE
Redirect /v1/ to the unversioned URLs

### DIFF
--- a/src/main/java/uk/gov/register/resources/RedirectResource.java
+++ b/src/main/java/uk/gov/register/resources/RedirectResource.java
@@ -1,8 +1,15 @@
 package uk.gov.register.resources;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
@@ -14,6 +21,48 @@ import static javax.ws.rs.core.Response.status;
 
 @Path("/")
 public class RedirectResource {
+
+    /*
+     * From v2 onwards every URL will have a version in it, but v1 actually used unversioned
+     * URLs. While v1 is still available, we should return a helpful response if people try to
+     * add /v1/ to the URL.
+     */
+    @GET
+    @Path("/v1/{resource:.+}")
+    public Response redirectV1GetRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
+        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+    }
+
+    @POST
+    @Path("/v1/{resource:.+}")
+    public Response redirectV1PostRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
+        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+    }
+
+    @DELETE
+    @Path("/v1/{resource:.+}")
+    public Response redirectV1DeleteRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
+        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+    }
+
+    @PUT
+    @Path("/v1/{resource:.+}")
+    public Response redirectV1PutRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
+        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+    }
+
+    @HEAD
+    @Path("/v1/{resource:.+}")
+    public Response redirectV1HeadRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
+        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+    }
+
+    @OPTIONS
+    @Path("/v1/{resource:.+}")
+    public Response redirectV1OptionsRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
+        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+    }
+
     @GET
     @Path("/proof/entry/{entry-number}/{total-entries}/merkle:sha-256")
     public Response getProofRedirect(
@@ -59,16 +108,14 @@ public class RedirectResource {
         return redirectByPath(request, "/record/", "/records/");
     }
 
-
-
-    private static ResponseBuilder movedPermanently(URI location) {
-        return status(Response.Status.MOVED_PERMANENTLY).location(location);
-    }
-
-    public static Response redirectByPath(@Context HttpServletRequest request, String oldPath, String newPath) {
+    public static Response redirectByPath(@Context HttpServletRequest request, String oldPath, String newPath, Response.Status responseStatus) {
         String requestUrl = request.getRequestURL().toString();
         String redirectUrl = requestUrl.replaceFirst(oldPath, newPath);
         URI uri = UriBuilder.fromUri(redirectUrl).build();
-        return movedPermanently(uri).build();
+        return status(responseStatus).location(uri).build();
+    }
+
+    public static Response redirectByPath(@Context HttpServletRequest request, String oldPath, String newPath) {
+        return redirectByPath(request, oldPath, newPath, Response.Status.MOVED_PERMANENTLY);
     }
 }

--- a/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
@@ -40,6 +40,28 @@ public class RedirectResourceTest  {
     }
 
     @Test
+    public void getV1ItemRedirect() throws Exception {
+        Response response = register.getRequest(TestRegister.register, "/v1/items/sha-256:9432331d3343a7ceaaee46308069d01836460294c672223b236727a790acf786", WILDCARD);
+        assertThat(response.getStatus(), equalTo(307));
+        assertThat(response.getLocation().getPath(), equalTo("/items/sha-256:9432331d3343a7ceaaee46308069d01836460294c672223b236727a790acf786"));
+    }
+
+    @Test
+    public void getV1RecordsRedirect() throws Exception {
+        Response response = register.getRequest(TestRegister.register, "/v1/records", WILDCARD);
+        assertThat(response.getStatus(), equalTo(307));
+        assertThat(response.getLocation().getPath(), equalTo("/records"));
+    }
+
+    @Test
+    public void getV1TrailingSlashRedirect() throws Exception {
+        // Trailing slashes are handled by a filter so the immediate request doesn't strip the v1
+        Response response = register.getRequest(TestRegister.register, "/v1/records/", WILDCARD);
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getLocation().getPath(), equalTo("/v1/records"));
+    }
+
+    @Test
     public void getProofRedirect() throws Exception {
         Response response = register.getRequest(TestRegister.register, "/proof/entry/1/2/merkle:sha-256", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));


### PR DESCRIPTION
### Context
We are going to start versioning URLs in line with the [GDS API standards](https://www.gov.uk/guidance/gds-api-technical-and-data-standards#when-you-need-to-make-a-backwards-incompatible-change).

### Changes proposed in this pull request
Since we didn't have `/v1/` in the URLs from the beginning, I think it makes sense to keep all the existing resources as they are, but redirect `/v1/` URLs. That way any users who try to construct the v1 URLs based on newer documentation will still get sent to the unversioned resources.

I used a temporary redirect rather than a permanent one because we're redirecting to something with a fixed life expectancy.

### Guidance to review
- Does this make sense?
- Is there a cleaner way to do this?
- I'm working on the assumption that there will be a v2 of every resource, even if nothing has changed from v1.
- After this my plan is to move the resource classes into a package per version (and probably the same with the views)