### PR TITLE
Add new v2 endpoints

### DIFF
--- a/src/main/java/uk/gov/register/resources/DeleteRegisterDataResource.java
+++ b/src/main/java/uk/gov/register/resources/DeleteRegisterDataResource.java
@@ -3,6 +3,7 @@ package uk.gov.register.resources;
 import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.RegisterContext;
 import uk.gov.register.exceptions.NoSuchConfigException;
+import uk.gov.register.resources.DataDeleteNotAllowed;
 
 import javax.annotation.security.PermitAll;
 import javax.inject.Inject;

--- a/src/main/java/uk/gov/register/resources/IndexSizePagination.java
+++ b/src/main/java/uk/gov/register/resources/IndexSizePagination.java
@@ -14,7 +14,7 @@ public class IndexSizePagination implements Pagination {
     private final int totalEntries;
     private final int pageSize;
 
-    IndexSizePagination(Optional<Integer> optionalPageIndex, Optional<Integer> optionalPageSize, int totalEntries) {
+    public IndexSizePagination(Optional<Integer> optionalPageIndex, Optional<Integer> optionalPageSize, int totalEntries) {
         this.totalEntries = totalEntries;
 
         this.pageIndex = optionalPageIndex.orElse(1);
@@ -37,7 +37,7 @@ public class IndexSizePagination implements Pagination {
         }
     }
 
-    int offset() {
+    public int offset() {
         return (pageIndex - 1) * pageSize;
     }
 

--- a/src/main/java/uk/gov/register/resources/v1/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/EntryResource.java
@@ -1,0 +1,16 @@
+package uk.gov.register.resources.v1;
+
+import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.resources.RequestContext;
+import uk.gov.register.views.ViewFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+
+@Path("/")
+public class EntryResource extends uk.gov.register.resources.v2.EntryResource {
+    @Inject
+    public EntryResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext) {
+        super(register, viewFactory, requestContext);
+    }
+}

--- a/src/main/java/uk/gov/register/resources/v1/ItemResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/ItemResource.java
@@ -1,0 +1,15 @@
+package uk.gov.register.resources.v1;
+
+import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.views.ViewFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+
+@Path("/items")
+public class ItemResource extends uk.gov.register.resources.v2.ItemResource {
+    @Inject
+    public ItemResource(RegisterReadOnly register, ViewFactory viewFactory) {
+        super(register, viewFactory);
+    }
+}

--- a/src/main/java/uk/gov/register/resources/v1/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/RecordResource.java
@@ -1,0 +1,16 @@
+package uk.gov.register.resources.v1;
+
+import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.resources.RequestContext;
+import uk.gov.register.views.ViewFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+
+@Path("/")
+public class RecordResource extends uk.gov.register.resources.v2.RecordResource {
+    @Inject
+    public RecordResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext) {
+        super(register, viewFactory, requestContext);
+    }
+}

--- a/src/main/java/uk/gov/register/resources/v1/RegisterResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/RegisterResource.java
@@ -1,0 +1,15 @@
+package uk.gov.register.resources.v1;
+
+import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.views.ViewFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+
+@Path("/")
+public class RegisterResource extends uk.gov.register.resources.v2.RegisterResource {
+    @Inject
+    public RegisterResource(RegisterReadOnly register, ViewFactory viewFactory) {
+        super(register, viewFactory);
+    }
+}

--- a/src/main/java/uk/gov/register/resources/v1/SearchResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/SearchResource.java
@@ -1,0 +1,15 @@
+package uk.gov.register.resources.v1;
+
+import uk.gov.register.core.RegisterId;
+import uk.gov.register.core.RegisterReadOnly;
+
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+
+@Path("/")
+public class SearchResource extends uk.gov.register.resources.v2.SearchResource {
+    @Inject
+    public SearchResource(RegisterId registerId, RegisterReadOnly register) {
+        super(registerId, register);
+    }
+}

--- a/src/main/java/uk/gov/register/resources/v1/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/VerifiableLogResource.java
@@ -1,0 +1,14 @@
+package uk.gov.register.resources.v1;
+
+import uk.gov.register.core.RegisterReadOnly;
+
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+
+@Path("/proof")
+public class VerifiableLogResource extends uk.gov.register.resources.v2.VerifiableLogResource {
+    @Inject
+    public VerifiableLogResource(RegisterReadOnly register) {
+        super(register);
+    }
+}

--- a/src/main/java/uk/gov/register/resources/v2/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/EntryResource.java
@@ -1,4 +1,4 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v2;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.jersey.params.IntParam;
@@ -7,6 +7,9 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.core.RegisterId;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.providers.params.IntegerParam;
+import uk.gov.register.resources.HttpServletResponseAdapter;
+import uk.gov.register.resources.RequestContext;
+import uk.gov.register.resources.StartLimitPagination;
 import uk.gov.register.views.AttributionView;
 import uk.gov.register.views.EntryListView;
 import uk.gov.register.views.EntryView;
@@ -21,7 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
-@Path("/")
+@Path("/dev/")
 public class EntryResource {
 
     private final RegisterReadOnly register;
@@ -35,7 +38,7 @@ public class EntryResource {
         this.register = register;
         this.viewFactory = viewFactory;
         this.requestContext = requestContext;
-        this.httpServletResponseAdapter = new HttpServletResponseAdapter(requestContext.httpServletResponse);
+        this.httpServletResponseAdapter = new HttpServletResponseAdapter(requestContext.getHttpServletResponse());
         this.registerPrimaryKey = register.getRegisterId();
     }
 

--- a/src/main/java/uk/gov/register/resources/v2/ItemResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/ItemResource.java
@@ -1,4 +1,4 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v2;
 
 import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.HashingAlgorithm;
@@ -16,7 +16,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.Optional;
 
-@Path("/items")
+@Path("/dev/items")
 public class ItemResource {
     private final RegisterReadOnly register;
     private final ViewFactory viewFactory;

--- a/src/main/java/uk/gov/register/resources/v2/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/RecordResource.java
@@ -1,4 +1,4 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v2;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.jersey.params.IntParam;
@@ -9,6 +9,10 @@ import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.exceptions.FieldConversionException;
 import uk.gov.register.exceptions.NoSuchFieldException;
 import uk.gov.register.providers.params.IntegerParam;
+import uk.gov.register.resources.HttpServletResponseAdapter;
+import uk.gov.register.resources.IndexSizePagination;
+import uk.gov.register.resources.Pagination;
+import uk.gov.register.resources.RequestContext;
 import uk.gov.register.views.*;
 import uk.gov.register.views.representations.ExtraMediaType;
 
@@ -20,7 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 
-@Path("/")
+@Path("/dev/")
 public class RecordResource {
     private final HttpServletResponseAdapter httpServletResponseAdapter;
     private final RegisterReadOnly register;
@@ -30,7 +34,7 @@ public class RecordResource {
     public RecordResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext) {
         this.register = register;
         this.viewFactory = viewFactory;
-        this.httpServletResponseAdapter = new HttpServletResponseAdapter(requestContext.httpServletResponse);
+        this.httpServletResponseAdapter = new HttpServletResponseAdapter(requestContext.getHttpServletResponse());
     }
 
     @GET

--- a/src/main/java/uk/gov/register/resources/v2/RegisterResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/RegisterResource.java
@@ -1,4 +1,4 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v2;
 
 import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.EntryType;
@@ -13,7 +13,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-@Path("/")
+@Path("/dev/")
 public class RegisterResource {
     private final RegisterReadOnly register;
     protected final ViewFactory viewFactory;

--- a/src/main/java/uk/gov/register/resources/v2/SearchResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/SearchResource.java
@@ -1,4 +1,4 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v2;
 
 import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.RegisterId;
@@ -14,7 +14,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
-@Path("/")
+@Path("/dev/")
 public class SearchResource {
 
     private final RegisterId registerPrimaryKey;

--- a/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
@@ -1,4 +1,4 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v2;
 
 import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.EntryType;
@@ -16,7 +16,7 @@ import javax.ws.rs.core.Response;
 
 import static uk.gov.register.resources.RedirectResource.redirectByPath;
 
-@Path("/proof")
+@Path("/dev/proof")
 public class VerifiableLogResource {
     private final RegisterReadOnly register;
 

--- a/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import uk.gov.register.core.EntryType;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.resources.v2.VerifiableLogResource;
 import uk.gov.register.util.HashValue;
 import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;

--- a/src/test/java/uk/gov/register/resources/v1/EntryResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/v1/EntryResourceTest.java
@@ -1,8 +1,9 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v1;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.register.resources.v2.EntryResource;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.ws.rs.Produces;

--- a/src/test/java/uk/gov/register/resources/v1/RegisterResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/v1/RegisterResourceTest.java
@@ -1,6 +1,7 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v1;
 
 import org.junit.Test;
+import uk.gov.register.resources.v2.RegisterResource;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;

--- a/src/test/java/uk/gov/register/resources/v1/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/v1/SearchResourceTest.java
@@ -1,10 +1,11 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.register.configuration.RegisterFieldsConfiguration;
 import uk.gov.register.core.*;
+import uk.gov.register.resources.v2.SearchResource;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.ws.rs.NotFoundException;

--- a/src/test/java/uk/gov/register/resources/v2/EntryResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/v2/EntryResourceTest.java
@@ -1,0 +1,29 @@
+package uk.gov.register.resources.v2;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.register.views.representations.ExtraMediaType;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EntryResourceTest {
+    @Test
+    public void findByEntryNumberAvailableInV2() throws Exception {
+        Method findBySerialMethod = EntryResource.class.getDeclaredMethod("findByEntryNumber", int.class);
+        List<String> declaredMediaTypes = asList(findBySerialMethod.getDeclaredAnnotation(Produces.class).value());
+
+        assertThat(declaredMediaTypes,
+                hasItems(MediaType.APPLICATION_JSON,
+                        ExtraMediaType.TEXT_CSV));
+    }
+}


### PR DESCRIPTION
### Context
This builds on top of https://github.com/openregister/openregister-java/pull/515 so I'll need to rebase this once that's merged.

### Changes proposed in this pull request
Introduce a /dev/ prefix so we can serve multiple versions of the API at the same time.

Anyone using these endpoints should expect functionality to be
added/removed/changed. Once this version is stable, we will rename
it to /v2/.

As part of this change I've moved the main resource classes (i.e. stuff
that's part of the specified API) to subpackages by version.

I've made IndexSizePagination public so it can be used in both of these
packages (previously it was package private).

As a follow up to this work, we will need to do something with the
conformance tests so that we have the ability to test multiple
versions of the API against their corresponding specification.

### Guidance to review
- The unversioned (v1) endpoints should still work
- You should be able to put /dev/ in front of any API URL
- I decided to make v1 inherit from v2 rather than the other way round because I think v2 is the more interesting implementation from the perspective of someone auditing the code (as it will be the most up to date) so I want this to be easy to read without having to look at legacy code as well.