### PR TITLE
Test both versions of the API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,18 +169,24 @@ task installConformanceTestDeps(type: Exec) {
     commandLine '.venv/bin/pip', 'install', '-r', 'requirements.txt'
 }
 
-task runConformanceTests(type: Exec) {
+task runConformanceTestsV1(type: Exec) {
     dependsOn << assemble
     dependsOn << startAppForConformance
     dependsOn << loadSchoolDataForConformance
     dependsOn << installConformanceTestDeps
-    finalizedBy stopAppForConformance
     mustRunAfter test
-    commandLine '.venv/bin/openregister-conformance', '--no-https', '--register', 'school', 'http://localhost:9090', '--register-domain', 'test.register.gov.uk'
+    commandLine '.venv/bin/openregister-conformance', '--api-version', '1', '--no-https', '--register', 'school', 'http://localhost:9090/v1/', '--register-domain', 'test.register.gov.uk'
+}
+
+task runConformanceTestsV2(type: Exec) {
+    dependsOn << runConformanceTestsV1
+    finalizedBy stopAppForConformance
+    commandLine '.venv/bin/openregister-conformance', '--api-version', '2', '--no-https', '--register', 'school', 'http://localhost:9090/next/', '--register-domain', 'test.register.gov.uk'
 }
 
 check {
-    dependsOn << runConformanceTests
+    dependsOn << runConformanceTestsV1
+    dependsOn << runConformanceTestsV2
     dependsOn << 'dependencyCheckAnalyze'
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 csvvalidator==1.2
 jsonschema==2.5.1
--e git+https://github.com/openregister/conformance-test.git@5e9adaf6481970bcdc7f644fc631bd190355a29b#egg=openregister_conformance-master
-py==1.4.31
-pytest==2.9.0
+-e git+https://github.com/openregister/conformance-test.git@10e699784d3e1f20dcfa882a5e0b2ebb8add341d#egg=openregister_conformance-master
+py==1.7.0
+pytest==3.10.0
 PyYAML==3.11
-requests==2.9.1
+requests==2.20.0
 Werkzeug==0.11.5
 rdflib==4.2.1


### PR DESCRIPTION
### Context
This is a follow up to https://github.com/openregister/conformance-test/pull/31 to make sure the build runs tests for both API versions.

### Changes proposed in this pull request
- Use the latest conformance tests
- Run tests for both api versions

### Guidance to review
`./gradlew check` should run the conformance tests for both versions of the API.

I'm not familiar with gradle so let me know if there's a better way of specifying the relationship between the dependencies here.
