### PR TITLE
Remove indexes from the v2 API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 csvvalidator==1.2
 jsonschema==2.5.1
--e git+https://github.com/openregister/conformance-test.git@10e699784d3e1f20dcfa882a5e0b2ebb8add341d#egg=openregister_conformance-master
+-e git+https://github.com/openregister/conformance-test.git@b04c3ae5a97385d5b22b706b2f055c1f74a57e39#egg=openregister_conformance-master
 py==1.7.0
 pytest==3.10.0
 PyYAML==3.11

--- a/src/main/java/uk/gov/register/core/Record.java
+++ b/src/main/java/uk/gov/register/core/Record.java
@@ -1,10 +1,5 @@
 package uk.gov.register.core;
 
-import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import uk.gov.register.views.EntryView;
-
-import java.util.*;
-
 public class Record {
     private final Entry entry;
     private final Item item;
@@ -20,16 +15,6 @@ public class Record {
 
     public Item getItem() {
         return item;
-    }
-
-    public static CsvSchema csvSchema(Iterable<String> fields) {
-        CsvSchema entrySchema = EntryView.csvSchemaWithOmittedFields(Arrays.asList("item-hash"));
-        CsvSchema.Builder schemaBuilder = entrySchema.rebuild();
-
-        for (Iterator<CsvSchema.Column> iterator = Item.csvSchema(fields).rebuild().getColumns(); iterator.hasNext();) {
-            schemaBuilder.addColumn(iterator.next().getName(), CsvSchema.ColumnType.STRING);
-        }
-        return schemaBuilder.build();
     }
 
     @Override

--- a/src/main/java/uk/gov/register/resources/v1/ItemResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/ItemResource.java
@@ -75,8 +75,6 @@ public class ItemResource {
     }
 
     protected ItemView buildItemView(Item item) {
-        Map<String, Field> fieldsByName = getFieldsByName();
-        Map<String, FieldValue> itemKeyValuePairs = itemConverter.convertItem(item, fieldsByName);
-        return new ItemView(item.getSha256hex(), itemKeyValuePairs, fieldsByName.values());
+        return new ItemView(item, register.getFieldsByName());
     }
 }

--- a/src/main/java/uk/gov/register/resources/v2/BlobResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/BlobResource.java
@@ -77,9 +77,7 @@ public class BlobResource {
     }
 
     protected ItemView buildItemView(Item item) {
-        Map<String, Field> fieldsByName = getFieldsByName();
-        Map<String, FieldValue> itemKeyValuePairs = itemConverter.convertItem(item, fieldsByName);
-        return new ItemView(item.getSha256hex(), itemKeyValuePairs, fieldsByName.values());
+        return new ItemView(item, register.getFieldsByName(), this.itemConverter);
     }
 
     protected ItemListView buildItemListView(Collection<Item> items) {

--- a/src/main/java/uk/gov/register/resources/v2/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/EntryResource.java
@@ -49,9 +49,9 @@ public class EntryResource {
             ExtraMediaType.TEXT_CSV
     })
     @Timed
-    public Optional<EntryListView> findByEntryNumber(@PathParam("entry-number") int entryNumber) {
-        Optional<Entry> entry = register.getEntry(entryNumber);
-        return entry.map(function -> new EntryListView(Collections.singletonList(function)));
+    public EntryView findByEntryNumber(@PathParam("entry-number") int entryNumber) {
+        Optional<Entry> maybeEntry = register.getEntry(entryNumber);
+        return maybeEntry.map(entry -> new EntryView(entry)).orElseThrow(NotFoundException::new);
     }
 
 

--- a/src/main/java/uk/gov/register/resources/v2/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/RecordResource.java
@@ -4,28 +4,32 @@ import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.jersey.params.IntParam;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.EntryType;
+import uk.gov.register.core.FieldValue;
 import uk.gov.register.core.Record;
 import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.exceptions.FieldConversionException;
-import uk.gov.register.exceptions.NoSuchFieldException;
 import uk.gov.register.providers.params.IntegerParam;
 import uk.gov.register.resources.HttpServletResponseAdapter;
 import uk.gov.register.resources.IndexSizePagination;
-import uk.gov.register.resources.Pagination;
 import uk.gov.register.resources.RequestContext;
-import uk.gov.register.views.AttributionView;
-import uk.gov.register.views.PaginatedView;
-import uk.gov.register.views.RecordView;
+import uk.gov.register.service.ItemConverter;
 import uk.gov.register.views.RecordsView;
 import uk.gov.register.views.ViewFactory;
-import uk.gov.register.views.v2.EntryListView;
 import uk.gov.register.views.representations.ExtraMediaType;
+import uk.gov.register.views.v2.EntryListView;
+import uk.gov.register.views.v2.RecordView;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 
@@ -34,20 +38,14 @@ public class RecordResource {
     protected final HttpServletResponseAdapter httpServletResponseAdapter;
     protected final RegisterReadOnly register;
     protected final ViewFactory viewFactory;
+    protected final ItemConverter itemConverter;
 
     @Inject
-    public RecordResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext) {
+    public RecordResource(RegisterReadOnly register, ViewFactory viewFactory, RequestContext requestContext, ItemConverter itemConverter) {
         this.register = register;
         this.viewFactory = viewFactory;
+        this.itemConverter = itemConverter;
         this.httpServletResponseAdapter = new HttpServletResponseAdapter(requestContext.getHttpServletResponse());
-    }
-
-    @GET
-    @Path("/records/{record-key}")
-    @Produces(ExtraMediaType.TEXT_HTML)
-    @Timed
-    public AttributionView<RecordView> getRecordByKeyHtml(@PathParam("record-key") String key) throws FieldConversionException {
-        return viewFactory.getRecordView(getRecordByKey(key));
     }
 
     @GET
@@ -64,26 +62,8 @@ public class RecordResource {
     public RecordView getRecordByKey(@PathParam("record-key") String key) throws FieldConversionException {
         httpServletResponseAdapter.setLinkHeader("version-history", String.format("/records/%s/entries", key));
 
-        return register.getRecord(EntryType.user, key).map(viewFactory::getRecordMediaView)
+        return register.getRecord(EntryType.user, key).map(this::getRecordView)
                 .orElseThrow(NotFoundException::new);
-    }
-
-
-
-    @GET
-    @Path("/records/{record-key}/entries")
-    @Produces(ExtraMediaType.TEXT_HTML)
-    @Timed
-    public PaginatedView<EntryListView> getAllEntriesOfARecordHtml(@PathParam("record-key") String key) {
-        Collection<Entry> allEntries = register.allEntriesOfRecord(key);
-        if (allEntries.isEmpty()) {
-            throw new NotFoundException();
-        }
-
-        EntryListView entryListView = new EntryListView(allEntries, key);
-        Pagination pagination = new IndexSizePagination(Optional.of(1), Optional.of(allEntries.size()), allEntries.size());
-
-        return viewFactory.getPaginatedView("v2-entries.html", entryListView, pagination);
     }
 
     @GET
@@ -154,5 +134,10 @@ public class RecordResource {
     private RecordsView getRecordsView(int limit, int offset) throws FieldConversionException {
         List<Record> records = register.getRecords(EntryType.user, limit, offset);
         return viewFactory.getRecordsMediaView(records);
+    }
+
+    private RecordView getRecordView(final Record record) throws FieldConversionException {
+        Map<String, FieldValue> itemKeyValuePairs = itemConverter.convertItem(record.getItem(), register.getFieldsByName());
+        return new RecordView(record, itemKeyValuePairs, register.getFieldsByName().values());
     }
 }

--- a/src/main/java/uk/gov/register/resources/v2/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/RecordResource.java
@@ -141,7 +141,6 @@ public class RecordResource {
     }
 
     private RecordView buildRecordView(final Record record) throws FieldConversionException {
-        Map<String, FieldValue> itemKeyValuePairs = itemConverter.convertItem(record.getItem(), register.getFieldsByName());
-        return new RecordView(record, itemKeyValuePairs, register.getFieldsByName().values());
+        return new RecordView(record, register.getFieldsByName());
     }
 }

--- a/src/main/java/uk/gov/register/views/ItemListView.java
+++ b/src/main/java/uk/gov/register/views/ItemListView.java
@@ -33,8 +33,7 @@ public class ItemListView implements CsvRepresentationView {
     public Map<HashValue, ItemView> getItems() {
         return this.items
                 .stream()
-                .map(item -> new ItemView(item, fieldsByName, this.itemConverter))
-                .collect(Collectors.toMap(item -> item.getItemHash(), Function.identity()));
+                .collect(Collectors.toMap(item -> item.getSha256hex(), item -> new ItemView(item, fieldsByName, this.itemConverter)));
     }
 
     public static CsvSchema csvSchema(Iterable<String> fields) {

--- a/src/main/java/uk/gov/register/views/ItemListView.java
+++ b/src/main/java/uk/gov/register/views/ItemListView.java
@@ -31,11 +31,10 @@ public class ItemListView implements CsvRepresentationView {
 
     @JsonValue
     public Map<HashValue, ItemView> getItems() {
-        return this.items.stream().map(item -> new ItemView(
-                item.getSha256hex(),
-                itemConverter.convertItem(item, fieldsByName),
-                fieldsByName.values()
-        )).collect(Collectors.toMap(item -> item.getItemHash(), Function.identity()));
+        return this.items
+                .stream()
+                .map(item -> new ItemView(item, fieldsByName, this.itemConverter))
+                .collect(Collectors.toMap(item -> item.getItemHash(), Function.identity()));
     }
 
     public static CsvSchema csvSchema(Iterable<String> fields) {

--- a/src/main/java/uk/gov/register/views/ItemView.java
+++ b/src/main/java/uk/gov/register/views/ItemView.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.register.core.*;
+import uk.gov.register.service.ItemConverter;
 import uk.gov.register.util.HashValue;
 import uk.gov.register.views.representations.CsvRepresentation;
 import uk.gov.register.views.representations.ExtraMediaType;
@@ -34,6 +35,16 @@ public class ItemView implements CsvRepresentationView<Map<String, FieldValue>> 
 
     private final ObjectMapper jsonObjectMapper = Jackson.newObjectMapper();
     private final ObjectMapper yamlObjectMapper = Jackson.newObjectMapper(new YAMLFactory());
+
+    public ItemView(Item item, final Map<String, Field> fieldsByName) {
+        this(item, fieldsByName, new ItemConverter());
+    }
+
+    public ItemView(Item item, final Map<String, Field> fieldsByName, final ItemConverter itemConverter) {
+        this.fields = fieldsByName.values();
+        this.fieldValueMap = itemConverter.convertItem(item, fieldsByName);
+        this.sha256hex = item.getSha256hex();
+    }
 
     public ItemView(final HashValue sha256hex, final Map<String, FieldValue> fieldValueMap, final Iterable<Field> fields) {
         this.fields = fields;

--- a/src/main/java/uk/gov/register/views/RecordsView.java
+++ b/src/main/java/uk/gov/register/views/RecordsView.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.Iterables;
 import io.dropwizard.jackson.Jackson;
@@ -85,7 +86,7 @@ public class RecordsView implements CsvRepresentationView {
     @Override
     public CsvRepresentation<ArrayNode> csvRepresentation() {
         final Iterable<String> fieldNames = Iterables.transform(getFields(), f -> f.fieldName);
-        return new CsvRepresentation<>(Record.csvSchema(fieldNames), getFlatRecordsJson());
+        return new CsvRepresentation<>(RecordsView.csvSchema(fieldNames), getFlatRecordsJson());
     }
 
     protected ArrayNode getFlatRecordsJson() {
@@ -134,5 +135,15 @@ public class RecordsView implements CsvRepresentationView {
 
     private ObjectNode getItemJson(final ItemView itemView) {
         return jsonObjectMapper.convertValue(itemView, ObjectNode.class);
+    }
+
+    public static CsvSchema csvSchema(Iterable<String> fields) {
+        CsvSchema entrySchema = EntryView.csvSchemaWithOmittedFields(Arrays.asList("item-hash"));
+        CsvSchema.Builder schemaBuilder = entrySchema.rebuild();
+
+        for (Iterator<CsvSchema.Column> iterator = Item.csvSchema(fields).rebuild().getColumns(); iterator.hasNext();) {
+            schemaBuilder.addColumn(iterator.next().getName(), CsvSchema.ColumnType.STRING);
+        }
+        return schemaBuilder.build();
     }
 }

--- a/src/main/java/uk/gov/register/views/RecordsView.java
+++ b/src/main/java/uk/gov/register/views/RecordsView.java
@@ -57,7 +57,7 @@ public class RecordsView implements CsvRepresentationView {
     }
 
     @SuppressWarnings("unused, used by the template")
-    public List<ItemView> getRecordsSimple() {
+    public List<ItemSimpleView> getRecordsSimple() {
         return recordMap.entrySet()
                 .stream()
                 .map(e -> new ItemSimpleView(e.getKey().getKey(), e.getValue()))
@@ -121,7 +121,7 @@ public class RecordsView implements CsvRepresentationView {
         final Map<Entry, ItemView> map = new LinkedHashMap<>();
 
         records.forEach(record -> {
-            map.put(record.getEntry(), new ItemView(record.getItem().getSha256hex(), itemConverter.convertItem(record.getItem(), fieldsByName), getFields()));
+            map.put(record.getEntry(), new ItemView(record.getItem(), fieldsByName, itemConverter));
         });
         return map;
     }

--- a/src/main/java/uk/gov/register/views/v2/EntryListView.java
+++ b/src/main/java/uk/gov/register/views/v2/EntryListView.java
@@ -1,64 +1,27 @@
 package uk.gov.register.views.v2;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.dropwizard.jackson.Jackson;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.register.core.Entry;
 import uk.gov.register.views.CsvRepresentationView;
-import uk.gov.register.views.v2.EntryView;
 import uk.gov.register.views.representations.CsvRepresentation;
 
 import java.util.Collection;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class EntryListView implements CsvRepresentationView {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(EntryListView.class);
-
-    private static final String END_OF_LINE = "\n";
-
     private final Collection<Entry> entries;
-    private final Optional<String> recordKey;
-
-    private final ObjectMapper jsonObjectMapper = Jackson.newObjectMapper();
 
     public EntryListView(final Collection<Entry> entries) {
         this.entries = entries;
-        recordKey = Optional.empty();
     }
-
-    public EntryListView(final Collection<Entry> entries, final String recordKey) {
-        this.entries = entries;
-        this.recordKey = Optional.of(recordKey);
-    }
-
 
     @JsonValue
     public Collection<EntryView> getEntries() {
         return entries.stream().map(entry -> new EntryView(entry)).collect(Collectors.toList());
     }
 
-    @SuppressWarnings("unused, used from templates")
-    public Optional<String> getRecordKey() {
-        return recordKey;
-    }
-
-    @SuppressWarnings("unused, used from templates")
-    public String getDownloadLink() {
-        Optional<String> recordKey = getRecordKey();
-        return recordKey.isPresent() ? String.format("record/%s/entries", recordKey.get()) : "entries";
-    }
-
     @Override
     public CsvRepresentation<Collection<EntryView>> csvRepresentation() {
         return new CsvRepresentation<>(EntryView.csvSchema(), getEntries());
-    }
-
-    private ObjectNode getEntryJson(final Entry entry) {
-        return jsonObjectMapper.convertValue(entry, ObjectNode.class);
     }
 }

--- a/src/main/java/uk/gov/register/views/v2/EntryView.java
+++ b/src/main/java/uk/gov/register/views/v2/EntryView.java
@@ -5,21 +5,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import com.google.common.collect.Lists;
 import uk.gov.register.core.Entry;
 import uk.gov.register.util.HashValue;
 import uk.gov.register.util.ISODateFormatter;
-import uk.gov.register.util.ToArrayConverter;
 import uk.gov.register.views.CsvRepresentationView;
 import uk.gov.register.views.representations.CsvRepresentation;
 
 import java.time.Instant;
-import java.util.Iterator;
-import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"index-entry-number", "entry-number", "entry-timestamp", "key", "blob-hash"})
@@ -47,7 +41,6 @@ public class EntryView implements CsvRepresentationView<EntryView> {
     }
 
     @JsonProperty("entry-number")
-    @JsonSerialize(using = ToStringSerializer.class)
     public Integer getEntryNumber() {
         return entryNumber;
     }

--- a/src/main/java/uk/gov/register/views/v2/EntryView.java
+++ b/src/main/java/uk/gov/register/views/v2/EntryView.java
@@ -42,7 +42,6 @@ public class EntryView implements CsvRepresentationView<EntryView> {
     }
 
     @JsonProperty("blob-hash")
-    @JsonSerialize(using = ToArrayConverter.class)
     public HashValue getBlobHash() {
         return hashValue;
     }
@@ -50,12 +49,6 @@ public class EntryView implements CsvRepresentationView<EntryView> {
     @JsonProperty("entry-number")
     @JsonSerialize(using = ToStringSerializer.class)
     public Integer getEntryNumber() {
-        return entryNumber;
-    }
-
-    @JsonProperty("index-entry-number")
-    @JsonSerialize(using = ToStringSerializer.class)
-    public Integer getIndexEntryNumber() {
         return entryNumber;
     }
 
@@ -73,16 +66,6 @@ public class EntryView implements CsvRepresentationView<EntryView> {
         CsvMapper csvMapper = new CsvMapper();
         csvMapper.disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
         return csvMapper.schemaFor(EntryView.class);
-    }
-
-    public static CsvSchema csvSchemaWithOmittedFields(List<String> fieldsToRemove) {
-        CsvSchema originalSchema = csvSchema();
-        Iterator<CsvSchema.Column> columns = originalSchema.rebuild().getColumns();
-
-        List<CsvSchema.Column> updatedColumns = Lists.newArrayList(columns);
-        updatedColumns.removeIf(c -> fieldsToRemove.contains(c.getName()));
-
-        return CsvSchema.builder().addColumns(updatedColumns).build();
     }
 
     @Override

--- a/src/main/java/uk/gov/register/views/v2/RecordListView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordListView.java
@@ -37,9 +37,8 @@ public class RecordListView implements CsvRepresentationView<ArrayNode> {
                         record -> record.getEntry().getKey(),
                         record -> new RecordView(
                                 record,
-                                itemConverter.convertItem(record.getItem(), fieldsByName),
-                                fieldsByName.values()
-
+                                fieldsByName,
+                                this.itemConverter
                         )
                 )
         );

--- a/src/main/java/uk/gov/register/views/v2/RecordListView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordListView.java
@@ -1,0 +1,71 @@
+package uk.gov.register.views.v2;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import io.dropwizard.jackson.Jackson;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.Record;
+import uk.gov.register.service.ItemConverter;
+import uk.gov.register.views.CsvRepresentationView;
+import uk.gov.register.views.representations.CsvRepresentation;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RecordListView implements CsvRepresentationView<ArrayNode> {
+    private final Collection<Record> records;
+    private final ItemConverter itemConverter;
+    private final Map<String, Field> fieldsByName;
+    private final List<String> fieldNames;
+    private final ObjectMapper jsonObjectMapper = Jackson.newObjectMapper();
+
+    public RecordListView(Collection<Record> records, final Map<String, Field> fieldsByName) {
+        this.records = records;
+        this.itemConverter = new ItemConverter();
+        this.fieldsByName = fieldsByName;
+        this.fieldNames = fieldsByName.values().stream().map(field -> field.fieldName).collect(Collectors.toList());
+    }
+
+    @JsonValue
+    public Map<String, RecordView> getRecords() {
+        return this.records.stream().collect(
+                Collectors.toMap(
+                        record -> record.getEntry().getKey(),
+                        record -> new RecordView(
+                                record,
+                                itemConverter.convertItem(record.getItem(), fieldsByName),
+                                fieldsByName.values()
+
+                        )
+                )
+        );
+    }
+
+    public CsvSchema csvSchema() {
+        CsvSchema.Builder schemaBuilder = new CsvSchema.Builder();
+        schemaBuilder.addColumn("entry-number", CsvSchema.ColumnType.NUMBER);
+        schemaBuilder.addColumn("entry-timestamp", CsvSchema.ColumnType.STRING);
+        schemaBuilder.addColumn("key", CsvSchema.ColumnType.STRING);
+
+        for (String value : this.fieldNames) {
+            schemaBuilder.addColumn(value, CsvSchema.ColumnType.STRING);
+        }
+
+        return schemaBuilder.build();
+    }
+
+    protected ArrayNode getFlatRecordJson() {
+        ArrayNode arrayNode = jsonObjectMapper.createArrayNode();
+        getRecords().values().stream().forEach(view -> arrayNode.add(view.getFlatRecordJson()));
+        return arrayNode;
+    }
+
+    @Override
+    public CsvRepresentation<ArrayNode> csvRepresentation() {
+        return new CsvRepresentation<>(csvSchema(), getFlatRecordJson());
+    }
+}

--- a/src/main/java/uk/gov/register/views/v2/RecordView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordView.java
@@ -8,9 +8,9 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import io.dropwizard.jackson.Jackson;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.Field;
-import uk.gov.register.core.FieldValue;
 import uk.gov.register.core.Record;
 import uk.gov.register.exceptions.FieldConversionException;
+import uk.gov.register.service.ItemConverter;
 import uk.gov.register.views.CsvRepresentationView;
 import uk.gov.register.views.ItemView;
 import uk.gov.register.views.representations.CsvRepresentation;
@@ -26,10 +26,14 @@ public class RecordView implements CsvRepresentationView<ObjectNode> {
     private final ItemView itemView;
     private final ObjectMapper jsonObjectMapper = Jackson.newObjectMapper();
 
-    public RecordView(final Record record, final Map<String, FieldValue> fieldValueMap, final Iterable<Field> fields) throws FieldConversionException {
-        this.fields = fields;
+    public RecordView(final Record record, final Map<String, Field> fieldsByName) {
+        this(record, fieldsByName, new ItemConverter());
+    }
+
+    public RecordView(final Record record, final Map<String, Field> fieldsByName, ItemConverter itemConverter) throws FieldConversionException {
+        this.fields = fields = fieldsByName.values();
         this.record = record;
-        this.itemView = new ItemView(record.getItem().getSha256hex(), fieldValueMap, fields);
+        this.itemView = new ItemView(record.getItem(), fieldsByName, itemConverter);
     }
 
     private Record getRecord() {

--- a/src/main/java/uk/gov/register/views/v2/RecordView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordView.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public class RecordView implements CsvRepresentationView<ObjectNode> {
-        private Iterable<Field> fields;
+    private Iterable<Field> fields;
     private Record record;
     private final ItemView itemView;
     private final ObjectMapper jsonObjectMapper = Jackson.newObjectMapper();
@@ -52,7 +52,7 @@ public class RecordView implements CsvRepresentationView<ObjectNode> {
     public JsonNode getContent() {
         final ObjectNode result = jsonObjectMapper.createObjectNode();
         result.putPOJO("blob", itemView);
-        result.put("entry-number", this.getEntry().getEntryNumber().toString());
+        result.put("entry-number", this.getEntry().getEntryNumber());
         result.put("entry-timestamp", this.getEntry().getTimestampAsISOFormat());
         result.put("key", this.getEntry().getKey());
         return result;
@@ -60,7 +60,7 @@ public class RecordView implements CsvRepresentationView<ObjectNode> {
 
     protected ObjectNode getFlatRecordJson() {
         ObjectNode result = jsonObjectMapper.convertValue(itemView, ObjectNode.class);
-        result.put("entry-number", this.getEntry().getEntryNumber().toString());
+        result.put("entry-number", this.getEntry().getEntryNumber());
         result.put("entry-timestamp", this.getEntry().getTimestampAsISOFormat());
         result.put("key", this.getEntry().getKey());
         return result;
@@ -68,7 +68,7 @@ public class RecordView implements CsvRepresentationView<ObjectNode> {
 
     public CsvSchema csvSchema() {
         CsvSchema.Builder schemaBuilder = new CsvSchema.Builder();
-        schemaBuilder.addColumn("entry-number", CsvSchema.ColumnType.STRING);
+        schemaBuilder.addColumn("entry-number", CsvSchema.ColumnType.NUMBER);
         schemaBuilder.addColumn("entry-timestamp", CsvSchema.ColumnType.STRING);
         schemaBuilder.addColumn("key", CsvSchema.ColumnType.STRING);
 

--- a/src/main/java/uk/gov/register/views/v2/RecordView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordView.java
@@ -1,0 +1,77 @@
+package uk.gov.register.views.v2;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.dropwizard.jackson.Jackson;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.FieldValue;
+import uk.gov.register.core.Record;
+import uk.gov.register.exceptions.FieldConversionException;
+import uk.gov.register.views.CsvRepresentationView;
+import uk.gov.register.views.ItemView;
+import uk.gov.register.views.representations.CsvRepresentation;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class RecordView implements CsvRepresentationView<ObjectNode> {
+    private final Map<String, FieldValue> fieldValueMap;
+    private Iterable<Field> fields;
+    private Record record;
+    private final ItemView itemView;
+    private final ObjectMapper jsonObjectMapper = Jackson.newObjectMapper();
+
+    public RecordView(final Record record, final Map<String, FieldValue> fieldValueMap, final Iterable<Field> fields) throws FieldConversionException {
+        this.fields = fields;
+        this.record = record;
+        this.fieldValueMap = fieldValueMap;
+        this.itemView = new ItemView(record.getItem().getSha256hex(), fieldValueMap, fields);
+    }
+
+    private Record getRecord() {
+        return record;
+    }
+
+    private Entry getEntry() {
+        return getRecord().getEntry();
+    }
+
+    private Iterable<Field> getFields() {
+        return this.fields;
+    }
+
+    private List<String> getFieldNames() {
+        return StreamSupport.stream(getFields().spliterator(), false).map(field -> field.fieldName).collect(Collectors.toList());
+    }
+
+    @JsonValue
+    public JsonNode getContent() {
+        final ObjectNode result = jsonObjectMapper.createObjectNode();
+        result.putPOJO("blob", itemView);
+        result.put("entry-number", this.getEntry().getEntryNumber());
+        result.put("entry-timestamp", this.getEntry().getTimestampAsISOFormat());
+        result.put("key", this.getEntry().getKey());
+        return result;
+    }
+
+    protected ObjectNode getFlatRecordJson() {
+        ObjectNode result = jsonObjectMapper.convertValue(itemView, ObjectNode.class);
+        result.put("entry-number", this.getEntry().getEntryNumber());
+        result.put("entry-timestamp", this.getEntry().getTimestampAsISOFormat());
+        result.put("key", this.getEntry().getKey());
+        return result;
+    }
+
+    @Override
+    public CsvRepresentation<ObjectNode> csvRepresentation() {
+        final List<String> fieldNames = Arrays.asList("key", "entry-number", "entry-timestamp");
+        fieldNames.addAll(getFieldNames());
+        return new CsvRepresentation<>(Record.csvSchema(fieldNames), getFlatRecordJson());
+    }
+}

--- a/src/test/java/uk/gov/register/views/v2/EntryListViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/EntryListViewTest.java
@@ -43,18 +43,16 @@ public class EntryListViewTest {
 
         assertThat(result, equalTo("[" +
                 "{" +
-                "\"index-entry-number\":\"1\"," +
                 "\"entry-number\":\"1\"," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:00Z\"," +
                 "\"key\":\"b\"," +
-                "\"blob-hash\":[\"sha-256:ab\"]" +
+                "\"blob-hash\":\"sha-256:ab\"" +
                 "}," +
                 "{" +
-                "\"index-entry-number\":\"2\"," +
                 "\"entry-number\":\"2\"," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:01Z\"," +
                 "\"key\":\"c\"," +
-                "\"blob-hash\":[\"sha-256:cd\"]" +
+                "\"blob-hash\":\"sha-256:cd\"" +
                 "}" +
                 "]"));
     }
@@ -74,9 +72,9 @@ public class EntryListViewTest {
         String result = new String(bytes, StandardCharsets.UTF_8);
 
         assertThat(result, equalTo(
-                "index-entry-number,entry-number,entry-timestamp,key,blob-hash\r\n" +
-                        "1,1,2016-08-05T13:24:00Z,b,sha-256:ab\r\n" +
-                        "2,2,2016-08-05T13:24:01Z,c,sha-256:cd\r\n"
+                "entry-number,entry-timestamp,key,blob-hash\r\n" +
+                        "1,2016-08-05T13:24:00Z,b,sha-256:ab\r\n" +
+                        "2,2016-08-05T13:24:01Z,c,sha-256:cd\r\n"
         ));
     }
 }

--- a/src/test/java/uk/gov/register/views/v2/EntryListViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/EntryListViewTest.java
@@ -43,13 +43,13 @@ public class EntryListViewTest {
 
         assertThat(result, equalTo("[" +
                 "{" +
-                "\"entry-number\":\"1\"," +
+                "\"entry-number\":1," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:00Z\"," +
                 "\"key\":\"b\"," +
                 "\"blob-hash\":\"sha-256:ab\"" +
                 "}," +
                 "{" +
-                "\"entry-number\":\"2\"," +
+                "\"entry-number\":2," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:01Z\"," +
                 "\"key\":\"c\"," +
                 "\"blob-hash\":\"sha-256:cd\"" +

--- a/src/test/java/uk/gov/register/views/v2/EntryViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/EntryViewTest.java
@@ -35,7 +35,7 @@ public class EntryViewTest {
         String result = objectMapper.writeValueAsString(view);
 
         assertThat(result, equalTo("{" +
-                "\"entry-number\":\"1\"," +
+                "\"entry-number\":1," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:00Z\"," +
                 "\"key\":\"b\"," +
                 "\"blob-hash\":\"sha-256:ab\"" +

--- a/src/test/java/uk/gov/register/views/v2/EntryViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/EntryViewTest.java
@@ -35,11 +35,10 @@ public class EntryViewTest {
         String result = objectMapper.writeValueAsString(view);
 
         assertThat(result, equalTo("{" +
-                "\"index-entry-number\":\"1\"," +
                 "\"entry-number\":\"1\"," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:00Z\"," +
                 "\"key\":\"b\"," +
-                "\"blob-hash\":[\"sha-256:ab\"]" +
+                "\"blob-hash\":\"sha-256:ab\"" +
                 "}"));
     }
 
@@ -58,8 +57,8 @@ public class EntryViewTest {
         String result = new String(bytes, StandardCharsets.UTF_8);
 
         assertThat(result, equalTo(
-                "index-entry-number,entry-number,entry-timestamp,key,blob-hash\r\n" +
-                "1,1,2016-08-05T13:24:00Z,b,sha-256:ab\r\n"
+                "entry-number,entry-timestamp,key,blob-hash\r\n" +
+                "1,2016-08-05T13:24:00Z,b,sha-256:ab\r\n"
         ));
     }
 }

--- a/src/test/java/uk/gov/register/views/v2/RecordListViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/RecordListViewTest.java
@@ -1,0 +1,122 @@
+package uk.gov.register.views.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.register.core.Cardinality;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.EntryType;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.core.Item;
+import uk.gov.register.core.Record;
+import uk.gov.register.core.RegisterId;
+import uk.gov.register.util.HashValue;
+import uk.gov.register.views.representations.CsvWriter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
+
+public class RecordListViewTest {
+    private Entry entry1;
+    private Entry entry2;
+    private Item item1;
+    private Item item2;
+    private Record record1;
+    private Record record2;
+    private Map<String, Field> fieldsByName;
+    private JsonNode itemNode1;
+    private JsonNode itemNode2;
+    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+
+    @Before
+    public void setup() throws IOException {
+        Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
+        Instant t2 = Instant.parse("2016-03-28T09:49:26Z");
+
+        this.entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123", EntryType.user);
+        this.entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cd"), t2, "456", EntryType.user);
+
+        itemNode1 = objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}");
+        itemNode2 = objectMapper.readTree("{\"address\":\"456\",\"street\":\"bar\"}");
+
+        this.item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "ab"), itemNode1);
+        this.item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "cd"), itemNode2);
+
+        this.record1 = new Record(entry1, item1);
+        this.record2 = new Record(entry2, item2);
+
+        this.fieldsByName = ImmutableMap.of(
+                "street", new Field("street", "string", new RegisterId("foo"), Cardinality.ONE, "bla"),
+                "address", new Field("address", "string", new RegisterId("foo"), Cardinality.ONE, "bla")
+        );
+    }
+
+    @Test
+    public void jsonRepresentation() throws IOException {
+        RecordListView view = new RecordListView(Arrays.asList(this.record1, this.record2), fieldsByName);
+        String result = objectMapper.writeValueAsString(view);
+        JsonNode jsonNode = objectMapper.readTree(result);
+
+        assertTrue(jsonNode.has("123"));
+        assertTrue(jsonNode.has("456"));
+
+        JsonNode record1Node = jsonNode.get("123");
+        JsonNode record2Node = jsonNode.get("456");
+        assertHasRecordFields(record1Node);
+        assertHasRecordFields(record2Node);
+
+        assertThat(record1Node.get("entry-number").intValue(), equalTo(1));
+        assertThat(record2Node.get("entry-number").intValue(), equalTo(2));
+
+        assertThat(record1Node.get("entry-timestamp").textValue(), equalTo("2016-03-29T08:59:25Z"));
+        assertThat(record2Node.get("entry-timestamp").textValue(), equalTo("2016-03-28T09:49:26Z"));
+
+        assertThat(record1Node.get("key").textValue(), equalTo("123"));
+        assertThat(record2Node.get("key").textValue(), equalTo("456"));
+
+        assertThat(record1Node.get("blob"), equalTo(itemNode1));
+        assertThat(record2Node.get("blob"), equalTo(itemNode2));
+    }
+
+    @Test
+    public void csvRepresentation() throws IOException {
+        RecordListView view = new RecordListView(Arrays.asList(this.record1, this.record2), fieldsByName);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        CsvWriter csvWriter = new CsvWriter();
+        csvWriter.writeTo(view,
+                RecordListView.class,
+                null,
+                null,
+                null,
+                null,
+                outputStream);
+        byte[] bytes = outputStream.toByteArray();
+        String result = new String(bytes, StandardCharsets.UTF_8);
+
+        assertThat(result, equalTo(
+                "entry-number,entry-timestamp,key,street,address\r\n" +
+                        "1,2016-03-29T08:59:25Z,123,foo,123\r\n" +
+                        "2,2016-03-28T09:49:26Z,456,bar,456\r\n"
+        ));
+    }
+
+    private void assertHasRecordFields(JsonNode node) {
+        Set<String> fields = new HashSet<>();
+        node.fieldNames().forEachRemaining(fields::add);
+        assertThat(fields, equalTo(new HashSet<>(Arrays.asList("entry-number", "key", "entry-timestamp", "blob"))));
+    }
+}

--- a/src/test/java/uk/gov/register/views/v2/RecordViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/RecordViewTest.java
@@ -1,0 +1,75 @@
+package uk.gov.register.views.v2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.register.core.Cardinality;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.EntryType;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.FieldValue;
+import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.core.Item;
+import uk.gov.register.core.Record;
+import uk.gov.register.core.RegisterId;
+import uk.gov.register.service.ItemConverter;
+import uk.gov.register.util.HashValue;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class RecordViewTest {
+    private Entry entry1;
+    private Item item1;
+    private Record record1;
+    private Map<String, Field> fieldsByName;
+    private Map<String, FieldValue> itemValues;
+    private Collection<Field> fields;
+    private JsonNode itemNode1;
+    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+
+    @Before
+    public void setup() throws IOException {
+        Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
+        itemNode1 = objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}");
+
+        this.entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123", EntryType.user);
+        this.item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "ab"), itemNode1);
+        this.record1 = new Record(entry1, item1);
+
+        this.fieldsByName = ImmutableMap.of(
+                "street", new Field("street", "string", new RegisterId("foo"), Cardinality.ONE, "bla"),
+                "address", new Field("address", "string", new RegisterId("foo"), Cardinality.ONE, "bla")
+        );
+
+        this.fields = ImmutableList.of(
+                new Field("street", "string", new RegisterId("foo"), Cardinality.ONE, "bla"),
+                new Field("address", "string", new RegisterId("foo"), Cardinality.ONE, "bla")
+        );
+
+        ItemConverter itemConverter = new ItemConverter();
+
+        this.itemValues = itemConverter.convertItem(this.item1, fieldsByName);
+    }
+
+    @Test
+    public void jsonResponse() throws IOException {
+        RecordView view = new RecordView(record1, itemValues, fields);
+        String result = objectMapper.writeValueAsString(view);
+        JsonNode jsonNode = objectMapper.readTree(result);
+
+        assertThat(jsonNode.get("entry-number").intValue(), equalTo(1));
+        assertThat(jsonNode.get("entry-timestamp").textValue(), equalTo("2016-03-29T08:59:25Z"));
+        assertThat(jsonNode.get("key").textValue(), equalTo("123"));
+        assertThat(jsonNode.get("blob"), equalTo(this.itemNode1));
+    }
+}

--- a/src/test/java/uk/gov/register/views/v2/RecordViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/RecordViewTest.java
@@ -51,11 +51,6 @@ public class RecordViewTest {
                 "address", new Field("address", "string", new RegisterId("foo"), Cardinality.ONE, "bla")
         );
 
-        this.fields = ImmutableList.of(
-                new Field("street", "string", new RegisterId("foo"), Cardinality.ONE, "bla"),
-                new Field("address", "string", new RegisterId("foo"), Cardinality.ONE, "bla")
-        );
-
         ItemConverter itemConverter = new ItemConverter();
 
         this.itemValues = itemConverter.convertItem(this.item1, fieldsByName);
@@ -63,7 +58,7 @@ public class RecordViewTest {
 
     @Test
     public void jsonResponse() throws IOException {
-        RecordView view = new RecordView(record1, itemValues, fields);
+        RecordView view = new RecordView(record1, fieldsByName);
         String result = objectMapper.writeValueAsString(view);
         JsonNode jsonNode = objectMapper.readTree(result);
 


### PR DESCRIPTION
### Context
See corresponding PR for the conformance tests: https://github.com/openregister/conformance-test/pull/32

### Changes proposed in this pull request
- Update tests for V2 entry, blob, and record resources to reflect the data model changes.
- Remove some more V2 view code that was only required for HTML views
- Refactored `ItemView` to simplify the resource layer and record view classes a bit

Trello: https://trello.com/c/VUhFKnKy/3033-implement-rfc0024-indexes-removal-breaking-changes

### Guidance to review
- Nothing should be broken