### PR TITLE
Versioning fixes

### DIFF
--- a/src/main/java/uk/gov/register/resources/RedirectResource.java
+++ b/src/main/java/uk/gov/register/resources/RedirectResource.java
@@ -28,39 +28,39 @@ public class RedirectResource {
      * add /v1/ to the URL.
      */
     @GET
-    @Path("/v1/{resource:.+}")
+    @Path("/v1{resource:(/.*)?}")
     public Response redirectV1GetRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
-        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+        return redirectByPath(request, "/v1" + resource, resource, Response.Status.TEMPORARY_REDIRECT);
     }
 
     @POST
-    @Path("/v1/{resource:.+}")
+    @Path("/v1{resource:(/.*)?}")
     public Response redirectV1PostRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
-        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+        return redirectByPath(request, "/v1" + resource, resource, Response.Status.TEMPORARY_REDIRECT);
     }
 
     @DELETE
-    @Path("/v1/{resource:.+}")
+    @Path("/v1{resource:(/.*)?}")
     public Response redirectV1DeleteRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
-        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+        return redirectByPath(request, "/v1" + resource, resource, Response.Status.TEMPORARY_REDIRECT);
     }
 
     @PUT
-    @Path("/v1/{resource:.+}")
+    @Path("/v1{resource:(/.*)?}")
     public Response redirectV1PutRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
-        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+        return redirectByPath(request, "/v1" + resource, resource, Response.Status.TEMPORARY_REDIRECT);
     }
 
     @HEAD
-    @Path("/v1/{resource:.+}")
+    @Path("/v1{resource:(/.*)?}")
     public Response redirectV1HeadRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
-        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+        return redirectByPath(request, "/v1" + resource, resource, Response.Status.TEMPORARY_REDIRECT);
     }
 
     @OPTIONS
-    @Path("/v1/{resource:.+}")
+    @Path("/v1{resource:(/.*)?}")
     public Response redirectV1OptionsRequests(@Context HttpServletRequest request, @PathParam("resource") String resource) {
-        return redirectByPath(request, "/v1/" + resource, "/" + resource, Response.Status.TEMPORARY_REDIRECT);
+        return redirectByPath(request, "/v1" + resource, resource, Response.Status.TEMPORARY_REDIRECT);
     }
 
     @GET
@@ -109,6 +109,9 @@ public class RedirectResource {
     }
 
     public static Response redirectByPath(@Context HttpServletRequest request, String oldPath, String newPath, Response.Status responseStatus) {
+        if (newPath.equals("")) {
+            newPath = "/";
+        }
         String requestUrl = request.getRequestURL().toString();
         String redirectUrl = requestUrl.replaceFirst(oldPath, newPath);
         URI uri = UriBuilder.fromUri(redirectUrl).build();

--- a/src/main/java/uk/gov/register/resources/v2/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/RecordResource.java
@@ -44,14 +44,6 @@ public class RecordResource {
 
     @GET
     @Path("/records/{record-key}")
-    @Produces(ExtraMediaType.TEXT_HTML)
-    @Timed
-    public AttributionView<RecordView> getRecordByKeyHtml(@PathParam("record-key") String key) throws FieldConversionException {
-        return viewFactory.getRecordView(getRecordByKey(key));
-    }
-
-    @GET
-    @Path("/records/{record-key}")
     @Produces({
             MediaType.APPLICATION_JSON,
             ExtraMediaType.TEXT_YAML,
@@ -66,24 +58,6 @@ public class RecordResource {
 
         return register.getRecord(EntryType.user, key).map(viewFactory::getRecordMediaView)
                 .orElseThrow(NotFoundException::new);
-    }
-
-
-
-    @GET
-    @Path("/records/{record-key}/entries")
-    @Produces(ExtraMediaType.TEXT_HTML)
-    @Timed
-    public PaginatedView<EntryListView> getAllEntriesOfARecordHtml(@PathParam("record-key") String key) {
-        Collection<Entry> allEntries = register.allEntriesOfRecord(key);
-        if (allEntries.isEmpty()) {
-            throw new NotFoundException();
-        }
-
-        EntryListView entryListView = new EntryListView(allEntries, key);
-        Pagination pagination = new IndexSizePagination(Optional.of(1), Optional.of(allEntries.size()), allEntries.size());
-
-        return viewFactory.getPaginatedView("v2-entries.html", entryListView, pagination);
     }
 
     @GET

--- a/src/main/java/uk/gov/register/resources/v2/RecordResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/RecordResource.java
@@ -54,7 +54,7 @@ public class RecordResource {
     })
     @Timed
     public RecordView getRecordByKey(@PathParam("record-key") String key) throws FieldConversionException {
-        httpServletResponseAdapter.setLinkHeader("version-history", String.format("/records/%s/entries", key));
+        httpServletResponseAdapter.setLinkHeader("version-history", String.format("/next/records/%s/entries", key));
 
         return register.getRecord(EntryType.user, key).map(viewFactory::getRecordMediaView)
                 .orElseThrow(NotFoundException::new);

--- a/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
@@ -40,6 +40,13 @@ public class RedirectResourceTest  {
     }
 
     @Test
+    public void getV1Redirect() throws Exception {
+        Response response = register.getRequest(TestRegister.register, "/v1", WILDCARD);
+        assertThat(response.getStatus(), equalTo(307));
+        assertThat(response.getLocation().getPath(), equalTo("/"));
+    }
+
+    @Test
     public void getV1ItemRedirect() throws Exception {
         Response response = register.getRequest(TestRegister.register, "/v1/items/sha-256:9432331d3343a7ceaaee46308069d01836460294c672223b236727a790acf786", WILDCARD);
         assertThat(response.getStatus(), equalTo(307));


### PR DESCRIPTION
### Context
This PR addresses a couple of things I overlooked when I introduced API versioning

- Link headers need to preserve the version
- The `/v1` URL should redirect to `/`, even without a trailing slash

Trello: https://trello.com/c/m2QMFk4c/3083-stuff-missing-from-v2-api

### Changes proposed in this pull request
- Extend the v1 redirect
- Fix the link between `/records/{record}` and `/records/{record}/entries`
- Remove some HTML support that was still left in the V2 resources (we made the decision not to implement HTML yet)

### Guidance to review
