### PR TITLE
ADR011: Propose a method to handle the root paths consistently

### DIFF
--- a/doc/arch/adr-011-root-path-handling.md
+++ b/doc/arch/adr-011-root-path-handling.md
@@ -11,19 +11,25 @@ This ADR proposes a behaviour for each one of them.
 
 ### Root (`/`)
 
-When HTML is requested, it should redirect (301) to `https://registers.service.gov.uk/registers/{register_id}`.
+When HTML is requested, it should return the exact same HTML as per now.
 
 Otherwise it should redirect (301) to the Register resource
-(`/{version}/register`) for the current version of the API in the requested
-format; JSON if unspecified.
+(`/{version}/register`) for the requested version in JSON regardless of the
+format specified.
 
-### Version root (`/v1`, `/v2`)
+### Version root `/v1`
 
-When HTML is requested, it should redirect (301) to `https://registers.service.gov.uk/registers/{register_id}`.
+When HTML is requested, it should redirect (301) to `/` (See above).
 
 Otherwise it should redirect (301) to the Register resource
-(`/{version}/register`) for the requested version in the requested format;
-JSON if unspecified.
+(`/{version}/register`) for the requested version in JSON regardless of the
+format specified.
+
+### Version root `/v2`
+
+It should redirect (301) to the Register resource
+(`/{version}/register`) for the requested version in JSON regardless of the
+format specified.
 
 ## Status
 

--- a/doc/arch/adr-011-root-path-handling.md
+++ b/doc/arch/adr-011-root-path-handling.md
@@ -33,4 +33,4 @@ format specified.
 
 ## Status
 
-Proposed.
+Accepted.

--- a/doc/arch/adr-011-root-path-handling.md
+++ b/doc/arch/adr-011-root-path-handling.md
@@ -1,0 +1,30 @@
+# Decision record: Root path handling
+
+## Context
+
+As part of the work to release the next major version, there are three routes
+that need special handling: `/`, `/v1` and `/v2`.
+
+This ADR proposes a behaviour for each one of them.
+
+## Decision
+
+### Root (`/`)
+
+When HTML is requested, it should redirect (301) to `https://registers.service.gov.uk/registers/{register_id}`.
+
+Otherwise it should redirect (301) to the Register resource
+(`/{version}/register`) for the current version of the API in the requested
+format; JSON if unspecified.
+
+### Version root (`/v1`, `/v2`)
+
+When HTML is requested, it should redirect (301) to `https://registers.service.gov.uk/registers/{register_id}`.
+
+Otherwise it should redirect (301) to the Register resource
+(`/{version}/register`) for the requested version in the requested format;
+JSON if unspecified.
+
+## Status
+
+Proposed.


### PR DESCRIPTION
### Context

As part of the work to release the next major version, there are three routes
that need special handling: `/`, `/v1` and `/v2`.

This ADR proposes a behaviour for each one of them.