### PR TITLE
Supress warning about Guava 21

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -99,4 +99,11 @@
         <gav regex="true">^stax:stax-api:.*$</gav>
         <cve>CVE-2017-16224</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: guava-21.0.jar
+   ]]></notes>
+        <gav regex="true">^com\.google\.guava:guava:.*$</gav>
+        <cpe>cpe:/a:google:guava</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION


### Context
We need to update to at least 24.1.1, but we are on an old version of
dropwizard and I can't find a version of dropwizard-lifecycle that
includes this update. 

### Changes proposed in this pull request
This suppresses the warning (so we can build the app) until we can find a solution.

### Guidance to review
