### PR TITLE
[WIP] Remove index table

### DIFF
--- a/src/main/resources/sql/R14__Drop_index_tables.sql
+++ b/src/main/resources/sql/R14__Drop_index_tables.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS index;
+DROP TABLE IF EXISTS entry_item;
+DROP TABLE IF EXISTS entry_item_system;

--- a/src/main/resources/sql/R15__Revert_multiple_entries_per_item.sql
+++ b/src/main/resources/sql/R15__Revert_multiple_entries_per_item.sql
@@ -1,0 +1,3 @@
+-- Entries must always have 1 item hash
+alter table entry alter column sha256hex set not null;
+alter table entry_system alter column sha256hex set not null;

--- a/src/test/java/uk/gov/register/functional/db/TestEntryDAO.java
+++ b/src/test/java/uk/gov/register/functional/db/TestEntryDAO.java
@@ -24,9 +24,7 @@ import static uk.gov.register.core.HashingAlgorithm.*;
 @UseStringTemplate3StatementLocator
 public interface TestEntryDAO {
     @SqlUpdate("delete from \"<schema>\".entry;" +
-            "delete from \"<schema>\".entry_item;" +
             "delete from \"<schema>\".entry_system;" +
-            "delete from \"<schema>\".entry_item_system;" +
             "delete from \"<schema>\".current_entry_number;" +
             "insert into \"<schema>\".current_entry_number values(0);")
     void wipeData(@Define("schema") String schema);


### PR DESCRIPTION
### Context
When we removed indexes we left database tables in place. We should clean these up.
Trello: https://trello.com/c/YuM5QOzb/3090-data-migration-to-remove-index-tables

### Changes proposed in this pull request
Remove the index table and make sure an entry always has an item hash set.

### Guidance to review
This is not working properly for me for locally - running the tests does not apply all of the Java migrations before the new ones.
