### PR TITLE
Add additional hash column

### DIFF
--- a/src/main/java/uk/gov/migration/V__14_New_hashing_algorithm.java
+++ b/src/main/java/uk/gov/migration/V__14_New_hashing_algorithm.java
@@ -1,0 +1,33 @@
+package uk.gov.migration;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.flywaydb.core.api.migration.MigrationChecksumProvider;
+import org.flywaydb.core.api.migration.jdbc.BaseJdbcMigration;
+
+public class V__14_New_hashing_algorithm extends BaseJdbcMigration implements MigrationChecksumProvider {
+    @Override
+    public void migrate(Connection connection) throws Exception {
+        Statement stmt = connection.createStatement();
+        try {
+            stmt.execute("alter table entry add column blob_hash varchar");
+            stmt.execute("alter table entry_system add column blob_hash varchar");
+            stmt.execute("alter table item add column blob_hash varchar");
+
+            stmt.execute("update entry set blob_hash = sha256hex;");
+            stmt.execute("update entry_system set blob_hash = sha256hex;");
+            stmt.execute("update item set blob_hash = sha256hex;");
+
+            stmt.execute("alter table item alter column blob_hash set not null");
+        } finally {
+            stmt.close();
+        }
+    }
+
+    @Override
+    public Integer getChecksum() {
+        return 1;
+    }
+}

--- a/src/main/java/uk/gov/register/db/EntryDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryDAO.java
@@ -11,7 +11,7 @@ import uk.gov.register.store.postgres.BindEntry;
 
 @UseStringTemplate3StatementLocator
 public interface EntryDAO {
-    @SqlBatch("insert into \"<schema>\".<entry_table>(entry_number, timestamp, key, type, sha256hex) values(:entry_number, :timestampAsLong, :key, :entryType::\"<schema>\".ENTRY_TYPE, :itemHash)")
+    @SqlBatch("insert into \"<schema>\".<entry_table>(entry_number, timestamp, key, type, sha256hex, blob_hash) values(:entry_number, :timestampAsLong, :key, :entryType::\"<schema>\".ENTRY_TYPE, :itemHash, :itemHash)")
     @BatchChunkSize(1000)
     void insertInBatch(@BindEntry Iterable<Entry> entries, @Define("schema") String schema, @Define("entry_table") String entryTable);
 

--- a/src/main/java/uk/gov/register/db/ItemDAO.java
+++ b/src/main/java/uk/gov/register/db/ItemDAO.java
@@ -9,7 +9,7 @@ import uk.gov.register.store.postgres.BindItem;
 
 @UseStringTemplate3StatementLocator
 public interface ItemDAO {
-    @SqlBatch("insert into \"<schema>\".item(sha256hex, content) values(:sha256hex, :content) on conflict do nothing")
+    @SqlBatch("insert into \"<schema>\".item(sha256hex, blob_hash, content) values(:sha256hex, :sha256hex, :content) on conflict do nothing")
     @BatchChunkSize(1000)
     void insertInBatch(@BindItem Iterable<Item> items, @Define("schema") String schema );
 }

--- a/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
+++ b/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
@@ -34,8 +34,8 @@ public class EntryMapperTest {
         Instant expectedInstant = Instant.parse(expected);
 
         Collection<Entry> allEntriesNoPagination = dbi.withHandle(h -> {
-            h.execute("insert into address.item (sha256hex, content) values ('ghijkl', '{\"address\":\"K\"}')");
-            h.execute("insert into address.entry(entry_number, timestamp, key, type, sha256hex) values(5, :timestamp, 'K', 'user', 'ghijkl')", expectedInstant.getEpochSecond());
+            h.execute("insert into address.item (sha256hex, blob_hash, content) values ('ghijkl', 'ghijkl2', '{\"address\":\"K\"}')");
+            h.execute("insert into address.entry(entry_number, timestamp, key, type, sha256hex, blob_hash) values(5, :timestamp, 'K', 'user', 'ghijkl', 'ghijkl2')", expectedInstant.getEpochSecond());
             return h.attach(EntryQueryDAO.class).getAllEntriesNoPagination(schema);
         });
 
@@ -54,8 +54,8 @@ public class EntryMapperTest {
     @Test
     public void map_returnsSingleItemHashForEntry() {
         Collection<Entry> allEntriesNoPagination = dbi.withHandle(h -> {
-            h.execute("insert into address.item (sha256hex, content) values ('ghijkl', '{\"address\":\"K\"}')");
-            h.execute("insert into address.entry(entry_number, timestamp, key, type, sha256hex) values(5, :timestamp, 'K', 'user', 'ghijkl')", Instant.now().getEpochSecond());
+            h.execute("insert into address.item (sha256hex, blob_hash, content) values ('ghijkl', 'ghijkl2', '{\"address\":\"K\"}')");
+            h.execute("insert into address.entry(entry_number, timestamp, key, type, sha256hex, blob_hash) values(5, :timestamp, 'K', 'user', 'ghijkl', 'ghijkl2')", Instant.now().getEpochSecond());
             return h.attach(EntryQueryDAO.class).getAllEntriesNoPagination(schema);
         });
 

--- a/src/test/java/uk/gov/register/functional/db/TestEntryDAO.java
+++ b/src/test/java/uk/gov/register/functional/db/TestEntryDAO.java
@@ -24,9 +24,7 @@ import static uk.gov.register.core.HashingAlgorithm.*;
 @UseStringTemplate3StatementLocator
 public interface TestEntryDAO {
     @SqlUpdate("delete from \"<schema>\".entry;" +
-            "delete from \"<schema>\".entry_item;" +
             "delete from \"<schema>\".entry_system;" +
-            "delete from \"<schema>\".entry_item_system;" +
             "delete from \"<schema>\".current_entry_number;" +
             "insert into \"<schema>\".current_entry_number values(0);")
     void wipeData(@Define("schema") String schema);


### PR DESCRIPTION
### Context
This is the part of https://trello.com/c/JBenqGkg/3103-implement-rfc0010-item-hashing-algorithm-with-redactability which adds a new item hashing algorithm to ORJ.

Initially, we will store both old and new and hashes, and the new hashes will only be used by the version 2 API.

### Changes proposed in this pull request
The first step is to add a column to the schema to store the new hashes. For the moment it will just hold a copy of the old hashes. I will create a separate migration to update these once we've integrated the objecthash algorithm (https://github.com/openregister/objecthash-java)

### Guidance to review
- This should have no effect on any APIs at this stage
- /load-rsf should still work and should populate the new column