### PR TITLE
The V2 api should read from the blob-hash columns of item/entry

### DIFF
--- a/src/main/java/uk/gov/register/core/Entry.java
+++ b/src/main/java/uk/gov/register/core/Entry.java
@@ -8,13 +8,26 @@ import java.time.Instant;
 public class Entry {
     private final int entryNumber;
     private final HashValue v1ItemHash;
+    private final HashValue blobHash;
     private final Instant timestamp;
     private final EntryType entryType;
     private String key;
 
+    public Entry(int entryNumber, HashValue v1ItemHash, HashValue blobHash, Instant timestamp, String key, EntryType entryType) {
+        this.entryNumber = entryNumber;
+        this.blobHash = blobHash;
+        this.v1ItemHash = v1ItemHash;
+        this.timestamp = timestamp;
+        this.key = key;
+        this.entryType = entryType;
+    }
+
+    // TODO: Move all usages to the other constructor
+    @Deprecated
     public Entry(int entryNumber, HashValue v1ItemHash, Instant timestamp, String key, EntryType entryType) {
         this.entryNumber = entryNumber;
         this.v1ItemHash = v1ItemHash;
+        this.blobHash = v1ItemHash;
         this.timestamp = timestamp;
         this.key = key;
         this.entryType = entryType;
@@ -26,6 +39,10 @@ public class Entry {
 
     public HashValue getV1ItemHash() {
         return v1ItemHash;
+    }
+
+    public HashValue getBlobHash() {
+        return blobHash;
     }
 
     public long getTimestampAsLong() {

--- a/src/main/java/uk/gov/register/core/Entry.java
+++ b/src/main/java/uk/gov/register/core/Entry.java
@@ -80,7 +80,7 @@ public class Entry {
         if (key != null ? !key.equals(entry.key) : entry.key != null) return false;
         if (timestamp != null ? !timestamp.equals(entry.timestamp) : entry.timestamp != null) return false;
         if (entryType != null ? !entryType.equals(entry.entryType) : entry.entryType != null) return false;
-        return v1ItemHash != null ? v1ItemHash.equals(entry.v1ItemHash) : entry.v1ItemHash == null;
+        return blobHash != null ? blobHash.equals(entry.blobHash) : entry.blobHash == null;
     }
 
     @Override
@@ -90,7 +90,7 @@ public class Entry {
         result = 31 * result + (timestamp != null ? timestamp.hashCode() : 0);
         result = 31 * result + (key != null ? key.hashCode() : 0);
         result = 31 * result + (entryType != null ? entryType.hashCode() : 0);
-        result = 31 * result + (v1ItemHash != null ? v1ItemHash.hashCode() : 0);
+        result = 31 * result + (blobHash != null ? blobHash.hashCode() : 0);
 
         return result;
     }

--- a/src/main/java/uk/gov/register/core/Entry.java
+++ b/src/main/java/uk/gov/register/core/Entry.java
@@ -7,14 +7,14 @@ import java.time.Instant;
 
 public class Entry {
     private final int entryNumber;
-    private final HashValue hashValue;
+    private final HashValue v1ItemHash;
     private final Instant timestamp;
     private final EntryType entryType;
     private String key;
 
-    public Entry(int entryNumber, HashValue hashValue, Instant timestamp, String key, EntryType entryType) {
+    public Entry(int entryNumber, HashValue v1ItemHash, Instant timestamp, String key, EntryType entryType) {
         this.entryNumber = entryNumber;
-        this.hashValue = hashValue;
+        this.v1ItemHash = v1ItemHash;
         this.timestamp = timestamp;
         this.key = key;
         this.entryType = entryType;
@@ -24,8 +24,8 @@ public class Entry {
         return timestamp;
     }
 
-    public HashValue getItemHash() {
-        return hashValue;
+    public HashValue getV1ItemHash() {
+        return v1ItemHash;
     }
 
     public long getTimestampAsLong() {
@@ -63,7 +63,7 @@ public class Entry {
         if (key != null ? !key.equals(entry.key) : entry.key != null) return false;
         if (timestamp != null ? !timestamp.equals(entry.timestamp) : entry.timestamp != null) return false;
         if (entryType != null ? !entryType.equals(entry.entryType) : entry.entryType != null) return false;
-        return hashValue != null ? hashValue.equals(entry.hashValue) : entry.hashValue == null;
+        return v1ItemHash != null ? v1ItemHash.equals(entry.v1ItemHash) : entry.v1ItemHash == null;
     }
 
     @Override
@@ -73,7 +73,7 @@ public class Entry {
         result = 31 * result + (timestamp != null ? timestamp.hashCode() : 0);
         result = 31 * result + (key != null ? key.hashCode() : 0);
         result = 31 * result + (entryType != null ? entryType.hashCode() : 0);
-        result = 31 * result + (hashValue != null ? hashValue.hashCode() : 0);
+        result = 31 * result + (v1ItemHash != null ? v1ItemHash.hashCode() : 0);
 
         return result;
     }

--- a/src/main/java/uk/gov/register/core/EntryLogImpl.java
+++ b/src/main/java/uk/gov/register/core/EntryLogImpl.java
@@ -33,7 +33,7 @@ public class EntryLogImpl implements EntryLog {
     public void appendEntry(Entry entry) throws IndexingException {
         Optional<Record> record = dataAccessLayer.getRecord(entry.getEntryType(), entry.getKey());
 
-        if (record.isPresent() && record.get().getEntry().getItemHash().equals(entry.getItemHash())) {
+        if (record.isPresent() && record.get().getEntry().getV1ItemHash().equals(entry.getV1ItemHash())) {
             throw new IndexingException(entry, "Cannot contain identical items to previous entry");
         }
 

--- a/src/main/java/uk/gov/register/core/Item.java
+++ b/src/main/java/uk/gov/register/core/Item.java
@@ -91,16 +91,14 @@ public class Item {
 
         Item item = (Item) o;
 
-        if (v1HashValue != null ? !v1HashValue.equals(item.v1HashValue) : item.v1HashValue != null) return false;
+        if (blobHash != null ? !blobHash.equals(item.blobHash) : item.blobHash != null) return false;
         return content != null ? content.equals(item.content) : item.content == null;
 
     }
 
     @Override
     public int hashCode() {
-        int result = v1HashValue != null ? v1HashValue.hashCode() : 0;
-        result = 31 * result + (content != null ? content.hashCode() : 0);
-        return result;
+        return blobHash != null ? blobHash.hashCode() : 0;
     }
 
     @Override

--- a/src/main/java/uk/gov/register/core/RegisterImpl.java
+++ b/src/main/java/uk/gov/register/core/RegisterImpl.java
@@ -273,6 +273,6 @@ public class RegisterImpl implements Register {
     }
 
     private Item getReferencedItem(Entry entry) throws NoSuchItemException {
-        return itemStore.getItemByV1Hash(entry.getItemHash()).orElseThrow(() -> new NoSuchItemException(entry.getItemHash()));
+        return itemStore.getItemByV1Hash(entry.getV1ItemHash()).orElseThrow(() -> new NoSuchItemException(entry.getV1ItemHash()));
     }
 }

--- a/src/main/java/uk/gov/register/db/mappers/EntryMapper.java
+++ b/src/main/java/uk/gov/register/db/mappers/EntryMapper.java
@@ -21,6 +21,7 @@ public class EntryMapper implements ResultSetMapper<Entry> {
     public Entry map(int index, ResultSet r, StatementContext ctx) throws SQLException {
         return new Entry(r.getInt("entry_number"),
                 new HashValue(HashingAlgorithm.SHA256, r.getString("sha256hex")),
+                new HashValue(HashingAlgorithm.SHA256, r.getString("blob_hash")),
                 longTimestampToInstantMapper.map(index, r, ctx),
                 r.getString("key"),
                 EntryType.valueOf(r.getString("type")));

--- a/src/main/java/uk/gov/register/resources/v2/BlobResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/BlobResource.java
@@ -9,7 +9,7 @@ import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.exceptions.FieldConversionException;
 import uk.gov.register.service.ItemConverter;
 import uk.gov.register.util.HashValue;
-import uk.gov.register.views.ItemListView;
+import uk.gov.register.views.v2.BlobListView;
 import uk.gov.register.views.ItemView;
 import uk.gov.register.views.ViewFactory;
 import uk.gov.register.views.representations.ExtraMediaType;
@@ -62,11 +62,11 @@ public class BlobResource {
             ExtraMediaType.TEXT_CSV,
     })
     @Timed
-    public ItemListView listBlobs() throws FieldConversionException {
+    public BlobListView listBlobs() throws FieldConversionException {
         Collection<Item> items = register.getAllItems(EntryType.user);
 
         // TODO: allow this resource to be paginated
-        return buildItemListView(items.stream().limit(100).collect(Collectors.toList()));
+        return buildBlobListView(items.stream().limit(100).collect(Collectors.toList()));
     }
 
     protected Optional<Item> getBlob(String blobHash) {
@@ -82,7 +82,7 @@ public class BlobResource {
         return new ItemView(item, register.getFieldsByName(), this.itemConverter);
     }
 
-    protected ItemListView buildItemListView(Collection<Item> items) {
-        return new ItemListView(items, getFieldsByName());
+    protected BlobListView buildBlobListView(Collection<Item> items) {
+        return new BlobListView(items, getFieldsByName());
     }
 }

--- a/src/main/java/uk/gov/register/serialization/mappers/EntryToCommandMapper.java
+++ b/src/main/java/uk/gov/register/serialization/mappers/EntryToCommandMapper.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 public class EntryToCommandMapper extends RegisterCommandMapper<Entry, RegisterCommand> {
     @Override
     public RegisterCommand apply(Entry entry) {
-        return new RegisterCommand("append-entry", Arrays.asList(entry.getEntryType().name(), entry.getKey(), entry.getTimestampAsISOFormat(), entry.getItemHash().encode()));
+        return new RegisterCommand("append-entry", Arrays.asList(entry.getEntryType().name(), entry.getKey(), entry.getTimestampAsISOFormat(), entry.getV1ItemHash().encode()));
     }
 }
 

--- a/src/main/java/uk/gov/register/store/postgres/BatchedPostgresDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/BatchedPostgresDataAccessLayer.java
@@ -205,7 +205,7 @@ public class BatchedPostgresDataAccessLayer implements DataAccessLayer {
         // It's possible for an entry to be loaded where the item already exists in the database and is therefore not batched (as per RSF rules).
         // Therefore this statement only entered if entire register is batched.
         if (isEntireRegisterBatched && batchedEntries.containsKey(entryType)) {
-            List<HashValue> itemHashes = batchedEntries.get(entryType).values().stream().map(Entry::getItemHash).collect(Collectors.toList());
+            List<HashValue> itemHashes = batchedEntries.get(entryType).values().stream().map(Entry::getV1ItemHash).collect(Collectors.toList());
             return batchedItems.entrySet().stream().filter(item -> itemHashes.contains(item.getKey())).map(Map.Entry::getValue).iterator();
         }
 
@@ -221,7 +221,7 @@ public class BatchedPostgresDataAccessLayer implements DataAccessLayer {
             TreeMap<Integer, Entry> entries = batchedEntries.get(EntryType.user);
 
             if (entries.containsKey(startEntryNumber + 1) && entries.containsKey(endEntryNumber)) {
-                List<HashValue> itemHashes = entries.values().stream().filter(entry -> entry.getEntryNumber() > startEntryNumber && entry.getEntryNumber() <= endEntryNumber).map(Entry::getItemHash).collect(Collectors.toList());
+                List<HashValue> itemHashes = entries.values().stream().filter(entry -> entry.getEntryNumber() > startEntryNumber && entry.getEntryNumber() <= endEntryNumber).map(Entry::getV1ItemHash).collect(Collectors.toList());
                 return batchedItems.entrySet().stream().filter(item -> itemHashes.contains(item.getKey())).map(Map.Entry::getValue).iterator();
             }
         }
@@ -243,7 +243,7 @@ public class BatchedPostgresDataAccessLayer implements DataAccessLayer {
 
                     // It's possible for an entry to be loaded where the item already exists in the database and is therefore not batched (as per RSF rules).
                     // Therefore use existing getItemByV1Hash(HashValue hash) logic which goes to the database if necessary.
-                    Item item = getItemByV1Hash(entry.getItemHash()).get();
+                    Item item = getItemByV1Hash(entry.getV1ItemHash()).get();
 
                     return Optional.of(new Record(entry, item));
                 } catch (NullPointerException | NoSuchElementException ex) {
@@ -268,7 +268,7 @@ public class BatchedPostgresDataAccessLayer implements DataAccessLayer {
 
                             // It's possible for an entry to be loaded where the item already exists in the database and is therefore not batched (as per RSF rules).
                             // Therefore use existing getItemByV1Hash(HashValue hash) logic which goes to the database if necessary.
-                            Item item = getItemByV1Hash(entry.getItemHash()).get();
+                            Item item = getItemByV1Hash(entry.getV1ItemHash()).get();
 
                             return new Record(entry, item);
                         } catch (NullPointerException | NoSuchElementException ex) {
@@ -298,7 +298,7 @@ public class BatchedPostgresDataAccessLayer implements DataAccessLayer {
 
                         // It's possible for an entry to be loaded where the item already exists in the database and is therefore not batched (as per RSF rules).
                         // Therefore use existing getItemByV1Hash(HashValue hash) logic which goes to the database if necessary.
-                        Item item = getItemByV1Hash(entry.getItemHash()).get();
+                        Item item = getItemByV1Hash(entry.getV1ItemHash()).get();
 
                         return new Record(entry, item);
                     } catch (NullPointerException | NoSuchElementException ex) {

--- a/src/main/java/uk/gov/register/store/postgres/BindEntry.java
+++ b/src/main/java/uk/gov/register/store/postgres/BindEntry.java
@@ -18,7 +18,7 @@ public @interface BindEntry {
                 q.bind("timestampAsLong", arg.getTimestampAsLong());
                 q.bind("key", arg.getKey());
                 q.bind("entryType", arg.getEntryType());
-                q.bind("itemHash", arg.getItemHash().getValue());
+                q.bind("itemHash", arg.getV1ItemHash().getValue());
             };
         }
     }

--- a/src/main/java/uk/gov/register/views/EntryView.java
+++ b/src/main/java/uk/gov/register/views/EntryView.java
@@ -5,7 +5,6 @@ import uk.gov.register.core.Entry;
 import uk.gov.register.util.HashValue;
 import uk.gov.register.util.ISODateFormatter;
 import uk.gov.register.util.ToArrayConverter;
-import uk.gov.register.views.CsvRepresentationView;
 import uk.gov.register.views.representations.CsvRepresentation;
 
 import java.time.Instant;
@@ -29,7 +28,7 @@ public class EntryView implements CsvRepresentationView<EntryView> {
 
     public EntryView(Entry entry) {
         this.entryNumber = entry.getEntryNumber();
-        this.hashValue = entry.getItemHash();
+        this.hashValue = entry.getV1ItemHash();
         this.timestamp = entry.getTimestamp();
         this.key = entry.getKey();
     }

--- a/src/main/java/uk/gov/register/views/v2/BlobListView.java
+++ b/src/main/java/uk/gov/register/views/v2/BlobListView.java
@@ -1,4 +1,4 @@
-package uk.gov.register.views;
+package uk.gov.register.views.v2;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,6 +10,8 @@ import uk.gov.register.core.Field;
 import uk.gov.register.core.Item;
 import uk.gov.register.service.ItemConverter;
 import uk.gov.register.util.HashValue;
+import uk.gov.register.views.CsvRepresentationView;
+import uk.gov.register.views.ItemView;
 import uk.gov.register.views.representations.CsvRepresentation;
 
 import java.util.Collection;
@@ -17,13 +19,13 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class ItemListView implements CsvRepresentationView {
+public class BlobListView implements CsvRepresentationView {
     private final Collection<Item> items;
     private final Map<String, Field> fieldsByName;
     private final ItemConverter itemConverter;
     private final ObjectMapper jsonObjectMapper = Jackson.newObjectMapper();
 
-    public ItemListView(Collection<Item> items, final Map<String, Field> fieldsByName) {
+    public BlobListView(Collection<Item> items, final Map<String, Field> fieldsByName) {
         this.items = items;
         this.fieldsByName = fieldsByName;
         this.itemConverter = new ItemConverter();

--- a/src/main/java/uk/gov/register/views/v2/BlobListView.java
+++ b/src/main/java/uk/gov/register/views/v2/BlobListView.java
@@ -16,7 +16,6 @@ import uk.gov.register.views.representations.CsvRepresentation;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class BlobListView implements CsvRepresentationView {
@@ -32,10 +31,10 @@ public class BlobListView implements CsvRepresentationView {
     }
 
     @JsonValue
-    public Map<HashValue, ItemView> getItems() {
+    public Map<HashValue, ItemView> getBlobs() {
         return this.items
                 .stream()
-                .collect(Collectors.toMap(item -> item.getSha256hex(), item -> new ItemView(item, fieldsByName, this.itemConverter)));
+                .collect(Collectors.toMap(item -> item.getBlobHash(), item -> new ItemView(item, fieldsByName, this.itemConverter)));
     }
 
     public static CsvSchema csvSchema(Iterable<String> fields) {
@@ -47,9 +46,9 @@ public class BlobListView implements CsvRepresentationView {
         return schemaBuilder.build();
     }
 
-    public ArrayNode flatItemsJson() {
+    public ArrayNode flatBlobsJson() {
         final ArrayNode blobsArray = jsonObjectMapper.createArrayNode();
-        getItems().forEach((key, value) -> {
+        getBlobs().forEach((key, value) -> {
             final ObjectNode valueNode = jsonObjectMapper.convertValue(value, ObjectNode.class);
             blobsArray.add(valueNode.put("blob-hash", jsonObjectMapper.convertValue(key, String.class)));
         });
@@ -58,6 +57,6 @@ public class BlobListView implements CsvRepresentationView {
 
     @Override
     public CsvRepresentation<ArrayNode> csvRepresentation() {
-        return new CsvRepresentation<>(csvSchema(fieldsByName.keySet()), flatItemsJson());
+        return new CsvRepresentation<>(csvSchema(fieldsByName.keySet()), flatBlobsJson());
     }
 }

--- a/src/main/java/uk/gov/register/views/v2/EntryView.java
+++ b/src/main/java/uk/gov/register/views/v2/EntryView.java
@@ -25,7 +25,7 @@ public class EntryView implements CsvRepresentationView<EntryView> {
 
     public EntryView(Entry entry) {
         this.entryNumber = entry.getEntryNumber();
-        this.hashValue = entry.getItemHash();
+        this.hashValue = entry.getV1ItemHash();
         this.timestamp = entry.getTimestamp();
         this.key = entry.getKey();
     }

--- a/src/main/java/uk/gov/register/views/v2/EntryView.java
+++ b/src/main/java/uk/gov/register/views/v2/EntryView.java
@@ -19,13 +19,13 @@ import java.time.Instant;
 @JsonPropertyOrder({"index-entry-number", "entry-number", "entry-timestamp", "key", "blob-hash"})
 public class EntryView implements CsvRepresentationView<EntryView> {
     private final int entryNumber;
-    private final HashValue hashValue;
+    private final HashValue blobHash;
     private final Instant timestamp;
     private String key;
 
     public EntryView(Entry entry) {
         this.entryNumber = entry.getEntryNumber();
-        this.hashValue = entry.getV1ItemHash();
+        this.blobHash = entry.getBlobHash();
         this.timestamp = entry.getTimestamp();
         this.key = entry.getKey();
     }
@@ -37,7 +37,7 @@ public class EntryView implements CsvRepresentationView<EntryView> {
 
     @JsonProperty("blob-hash")
     public HashValue getBlobHash() {
-        return hashValue;
+        return blobHash;
     }
 
     @JsonProperty("entry-number")

--- a/src/test/java/uk/gov/register/core/EntryTest.java
+++ b/src/test/java/uk/gov/register/core/EntryTest.java
@@ -22,13 +22,13 @@ public class EntryTest {
     @Test
     public void getSha256hex_returnsTheSha256HexOfItem() {
         Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), Instant.ofEpochSecond(1470403440), "sample-key", EntryType.user);
-        assertThat(entry.getItemHash().getValue(), equalTo("abc"));
+        assertThat(entry.getV1ItemHash().getValue(), equalTo("abc"));
     }
 
     @Test
     public void getItemHash_returnsSha256AsItemHash() {
         Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), Instant.ofEpochSecond(1470403440), "sample-key", EntryType.user);
-        assertThat(entry.getItemHash().toString(), equalTo("sha-256:abc"));
+        assertThat(entry.getV1ItemHash().toString(), equalTo("sha-256:abc"));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/core/RegisterImplTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterImplTest.java
@@ -81,7 +81,7 @@ public class RegisterImplTest {
         Entry entry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "abc"), Instant.now(),
                 "key", EntryType.user);
 
-        when(itemStore.getItemByV1Hash(entry.getItemHash())).thenReturn(Optional.empty());
+        when(itemStore.getItemByV1Hash(entry.getV1ItemHash())).thenReturn(Optional.empty());
         register.appendEntry(entry);
     }
 
@@ -92,7 +92,7 @@ public class RegisterImplTest {
         Item item = new Item(hashValue, content);
         Entry entry = new Entry(1, hashValue, Instant.now(),"key", EntryType.user);
 
-        when(itemStore.getItemByV1Hash(entry.getItemHash())).thenReturn(Optional.of(item));
+        when(itemStore.getItemByV1Hash(entry.getV1ItemHash())).thenReturn(Optional.of(item));
 
         register.appendEntry(entry);
     }
@@ -104,7 +104,7 @@ public class RegisterImplTest {
         Item item = new Item(hashValue, content);
         Entry entry = new Entry(1, hashValue, Instant.now(),"key", EntryType.user);
 
-        when(itemStore.getItemByV1Hash(entry.getItemHash())).thenReturn(Optional.of(item));
+        when(itemStore.getItemByV1Hash(entry.getV1ItemHash())).thenReturn(Optional.of(item));
 
         doThrow(new ItemValidationException("", content)).when(itemValidator).validateItem(any(), any(), any());
 

--- a/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
+++ b/src/test/java/uk/gov/register/db/mappers/EntryMapperTest.java
@@ -43,7 +43,7 @@ public class EntryMapperTest {
 
         Entry entry = allEntriesNoPagination.iterator().next();
 
-        assertThat(entry.getItemHash(), is(new HashValue(HashingAlgorithm.SHA256, "ghijkl")));
+        assertThat(entry.getV1ItemHash(), is(new HashValue(HashingAlgorithm.SHA256, "ghijkl")));
         assertThat(entry.getEntryNumber(), is(5));
         assertThat(entry.getIndexEntryNumber(), is(5));
         assertThat(allEntriesNoPagination.iterator().next().getTimestamp(), equalTo(expectedInstant));
@@ -62,6 +62,6 @@ public class EntryMapperTest {
         Entry entry = allEntriesNoPagination.iterator().next();
 
         assertThat(allEntriesNoPagination.size(), equalTo(1));
-        assertThat(entry.getItemHash(), is(new HashValue(HashingAlgorithm.SHA256, "ghijkl")));
+        assertThat(entry.getV1ItemHash(), is(new HashValue(HashingAlgorithm.SHA256, "ghijkl")));
     }
 }

--- a/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
@@ -90,26 +90,26 @@ public class LoadSerializedFunctionalTest {
 
         List<Entry> systemEntries = testEntryDAO.getAllSystemEntries(schema);
         assertThat(systemEntries.get(0).getEntryNumber(), is(1));
-        assertThat(systemEntries.get(0).getItemHash().getValue(), is("955a84bcec7dad1a4d9b05e28ebfa21b17ac9552cc0aabbc459c73d63ab530b0"));
+        assertThat(systemEntries.get(0).getV1ItemHash().getValue(), is("955a84bcec7dad1a4d9b05e28ebfa21b17ac9552cc0aabbc459c73d63ab530b0"));
         assertThat(systemEntries.get(1).getEntryNumber(), is(2));
-        assertThat(systemEntries.get(1).getItemHash().getValue(), is("ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f"));
+        assertThat(systemEntries.get(1).getV1ItemHash().getValue(), is("ceae38992b310fba3ae77fd84e21cdb6838c90b36bcb558de02acd2f6589bd3f"));
         assertThat(systemEntries.get(2).getEntryNumber(), is(3));
-        assertThat(systemEntries.get(2).getItemHash().getValue(), is("4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2"));
+        assertThat(systemEntries.get(2).getV1ItemHash().getValue(), is("4624c413d90e125141a92f28c9ea4300a568d9b5d9c1c7ad13623433c4a370f2"));
         assertThat(systemEntries.get(3).getEntryNumber(), is(4));
-        assertThat(systemEntries.get(3).getItemHash().getValue(), is("1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4"));
+        assertThat(systemEntries.get(3).getV1ItemHash().getValue(), is("1c5a799079c97f1dcea1b244d9962b0de248ba1282145c2e815839815db1d0a4"));
         assertThat(systemEntries.get(4).getEntryNumber(), is(5));
-        assertThat(systemEntries.get(4).getItemHash().getValue(), is("c7e5a90c020f7686d9a275cb0cc164636745b10ae168a72538772692cc90d633"));
+        assertThat(systemEntries.get(4).getV1ItemHash().getValue(), is("c7e5a90c020f7686d9a275cb0cc164636745b10ae168a72538772692cc90d633"));
         assertThat(systemEntries.get(5).getEntryNumber(), is(6));
-        assertThat(systemEntries.get(5).getItemHash().getValue(), is("61138002a7ae8a53f3ad16bb91ee41fe73cc7ab7c8b24a8afd2569eb0e6a1c26"));
+        assertThat(systemEntries.get(5).getV1ItemHash().getValue(), is("61138002a7ae8a53f3ad16bb91ee41fe73cc7ab7c8b24a8afd2569eb0e6a1c26"));
         assertThat(systemEntries.get(6).getEntryNumber(), is(7));
-        assertThat(systemEntries.get(6).getItemHash().getValue(), is("f404b4739b51afeb39bba26f3bbf1aa8c6f7d25f0d54444992fc00f24587ef77"));
+        assertThat(systemEntries.get(6).getV1ItemHash().getValue(), is("f404b4739b51afeb39bba26f3bbf1aa8c6f7d25f0d54444992fc00f24587ef77"));
 
         List<Entry> userEntries = testEntryDAO.getAllEntries(schema);
 
         assertThat(userEntries.get(0).getEntryNumber(), is(1));
-        assertThat(userEntries.get(0).getItemHash().getValue(), is("3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254"));
+        assertThat(userEntries.get(0).getV1ItemHash().getValue(), is("3cee6dfc567f2157208edc4a0ef9c1b417302bad69ee06b3e96f80988b37f254"));
         assertThat(userEntries.get(1).getEntryNumber(), is(2));
-        assertThat(userEntries.get(1).getItemHash().getValue(), is("b8b56d0329b4a82ce55217cfbb3803c322bf43711f82649757e9c2df5f5b8371"));
+        assertThat(userEntries.get(1).getV1ItemHash().getValue(), is("b8b56d0329b4a82ce55217cfbb3803c322bf43711f82649757e9c2df5f5b8371"));
 
         Record record1 = testRecordDAO.getRecord("ft_openregister_test", schema, "entry").get();
         assertThat(record1.getEntry().getEntryNumber(), equalTo(1));

--- a/src/test/java/uk/gov/register/views/BlobListViewTest.java
+++ b/src/test/java/uk/gov/register/views/BlobListViewTest.java
@@ -15,6 +15,7 @@ import uk.gov.register.core.Item;
 import uk.gov.register.core.RegisterId;
 import uk.gov.register.util.HashValue;
 import uk.gov.register.views.representations.CsvWriter;
+import uk.gov.register.views.v2.BlobListView;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -25,12 +26,12 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class ItemListViewTest {
+public class BlobListViewTest {
 
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
     private JsonNode itemNode1;
     private JsonNode itemNode2;
-    private ItemListView view;
+    private BlobListView view;
 
     @Before
     public void setup() throws IOException {
@@ -45,7 +46,7 @@ public class ItemListViewTest {
                 "address", new Field("address", "string", new RegisterId("foo"), Cardinality.ONE, "bla")
         );
 
-        this.view = new ItemListView(ImmutableList.of(item1, item2), fieldsByName);
+        this.view = new BlobListView(ImmutableList.of(item1, item2), fieldsByName);
     }
 
     @Test

--- a/src/test/java/uk/gov/register/views/v2/EntryViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/EntryViewTest.java
@@ -24,6 +24,7 @@ public class EntryViewTest {
     private final Entry entry = new Entry(
             1,
             new HashValue(HashingAlgorithm.SHA256,"ab"),
+            new HashValue(HashingAlgorithm.SHA256,"cd"),
             Instant.ofEpochSecond(1470403440),
             "b",
             EntryType.user
@@ -38,7 +39,7 @@ public class EntryViewTest {
                 "\"entry-number\":1," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:00Z\"," +
                 "\"key\":\"b\"," +
-                "\"blob-hash\":\"sha-256:ab\"" +
+                "\"blob-hash\":\"sha-256:cd\"" +
                 "}"));
     }
 
@@ -58,7 +59,7 @@ public class EntryViewTest {
 
         assertThat(result, equalTo(
                 "entry-number,entry-timestamp,key,blob-hash\r\n" +
-                "1,2016-08-05T13:24:00Z,b,sha-256:ab\r\n"
+                "1,2016-08-05T13:24:00Z,b,sha-256:cd\r\n"
         ));
     }
 }


### PR DESCRIPTION
### Context
This is part of https://trello.com/c/JBenqGkg/3103-implement-rfc0010-item-hashing-algorithm-with-redactability and follows on from https://github.com/openregister/openregister-java/pull/537

### Changes proposed in this pull request
Make the V2 API return hashes from the new `blob_hash` column in `/entries` and `/blobs`, and use this column to resolve the blob lookup for `/blobs/{blob-hash}`.

At the moment, these fields still store the same data as the `sha256Hex` column. This PR only addresses the read part.

### Guidance to review
- Have I missed any endpoints?
- This should have no effect on production yet, because we're still storing old hashes in the new column - I'll change this in the next PR
- I'll deal with the TODO about removing the old constructor at the end, after I've integrated the new algorithm. This mostly affects tests at the moment, but it's also called from the RSF code
- I've changed all the `equals()` and `hashCode()` implementations for `Item` and `Record` - please check this makes sense