### PR TITLE
Generate object hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 
 dependencies {
     compile dropwizard, stringTemplate, apacheCommonsCodec, apacheCommonsCollections, apacheCommonsLang3, apachePoi, apachePoiOoxml, awsS3, jaxb, javaxActivation
-    compile jacksonCsv, jacksonDatabind, jena, jerseyMedia, markdown, thymeleaf, verifiableLog
+    compile jacksonCsv, jacksonDatabind, jena, jerseyMedia, markdown, thymeleaf, verifiableLog, objectHash
     compile jdbi, jersey_client
     compile dropwizardLogstash
     compile(postgresClient) {

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -7,6 +7,7 @@ ext {
     jacksonDatabind = 'com.fasterxml.jackson.core:jackson-databind:2.8.11.1'
 
     verifiableLog = 'verifiable-log:verifiable-log:0.2.77'
+    objectHash = 'objecthash-java:objecthash-java:0.1.54'
 
     dropwizard = [
             "io.dropwizard:dropwizard-core:${dropwizard_version}",

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     jacksonDatabind = 'com.fasterxml.jackson.core:jackson-databind:2.8.11.1'
 
     verifiableLog = 'verifiable-log:verifiable-log:0.2.77'
-    objectHash = 'objecthash-java:objecthash-java:0.1.54'
+    objectHash = 'objecthash-java:objecthash-java:0.1.63'
 
     dropwizard = [
             "io.dropwizard:dropwizard-core:${dropwizard_version}",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jul 05 17:14:04 BST 2016
+#Thu Nov 29 11:54:18 GMT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip

--- a/src/main/java/uk/gov/register/core/Entry.java
+++ b/src/main/java/uk/gov/register/core/Entry.java
@@ -22,17 +22,6 @@ public class Entry {
         this.entryType = entryType;
     }
 
-    // TODO: Move all usages to the other constructor
-    @Deprecated
-    public Entry(int entryNumber, HashValue v1ItemHash, Instant timestamp, String key, EntryType entryType) {
-        this.entryNumber = entryNumber;
-        this.v1ItemHash = v1ItemHash;
-        this.blobHash = v1ItemHash;
-        this.timestamp = timestamp;
-        this.key = key;
-        this.entryType = entryType;
-    }
-
     public Instant getTimestamp() {
         return timestamp;
     }

--- a/src/main/java/uk/gov/register/core/Item.java
+++ b/src/main/java/uk/gov/register/core/Item.java
@@ -31,12 +31,6 @@ public class Item {
         this.content = content;
     }
 
-    @Deprecated
-    public Item(HashValue v1HashValue, JsonNode content) {
-        // TODO: This should be removed
-        this(v1HashValue, v1HashValue, content);
-    }
-
     public static HashValue objectHash(JsonNode content) {
         return JsonToBlobHash.apply(content);
     }

--- a/src/main/java/uk/gov/register/core/Item.java
+++ b/src/main/java/uk/gov/register/core/Item.java
@@ -22,17 +22,13 @@ public class Item {
     private final HashValue blobHash;
 
     public Item(JsonNode content) {
-        this(itemHash(content), objectHash(content), content);
+        this(itemHash(content), JsonToBlobHash.apply(content), content);
     }
 
     public Item(HashValue v1HashValue, HashValue blobHash, JsonNode content) {
         this.v1HashValue = v1HashValue;
         this.blobHash = blobHash;
         this.content = content;
-    }
-
-    public static HashValue objectHash(JsonNode content) {
-        return JsonToBlobHash.apply(content);
     }
 
     public static HashValue itemHash(JsonNode content) {

--- a/src/main/java/uk/gov/register/core/Item.java
+++ b/src/main/java/uk/gov/register/core/Item.java
@@ -6,6 +6,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.postgresql.util.PGobject;
 import uk.gov.register.util.CanonicalJsonMapper;
 import uk.gov.register.util.HashValue;
+import uk.gov.register.util.JsonToBlobHash;
 
 import java.sql.SQLException;
 import java.util.Map;
@@ -37,8 +38,7 @@ public class Item {
     }
 
     public static HashValue objectHash(JsonNode content) {
-        // TODO
-        return itemHash(content);
+        return JsonToBlobHash.apply(content);
     }
 
     public static HashValue itemHash(JsonNode content) {

--- a/src/main/java/uk/gov/register/db/EntryDAO.java
+++ b/src/main/java/uk/gov/register/db/EntryDAO.java
@@ -11,7 +11,7 @@ import uk.gov.register.store.postgres.BindEntry;
 
 @UseStringTemplate3StatementLocator
 public interface EntryDAO {
-    @SqlBatch("insert into \"<schema>\".<entry_table>(entry_number, timestamp, key, type, sha256hex, blob_hash) values(:entry_number, :timestampAsLong, :key, :entryType::\"<schema>\".ENTRY_TYPE, :itemHash, :itemHash)")
+    @SqlBatch("insert into \"<schema>\".<entry_table>(entry_number, timestamp, key, type, sha256hex, blob_hash) values(:entry_number, :timestampAsLong, :key, :entryType::\"<schema>\".ENTRY_TYPE, :itemHash, :blobHash)")
     @BatchChunkSize(1000)
     void insertInBatch(@BindEntry Iterable<Entry> entries, @Define("schema") String schema, @Define("entry_table") String entryTable);
 

--- a/src/main/java/uk/gov/register/db/mappers/RecordMapper.java
+++ b/src/main/java/uk/gov/register/db/mappers/RecordMapper.java
@@ -26,13 +26,12 @@ public class RecordMapper implements ResultSetMapper<Record> {
     @Override
     public Record map(int index, ResultSet r, StatementContext ctx) throws SQLException {
         String itemHash = r.getString("sha256hex");
+        String blobHash = r.getString("blob_hash");
         String itemContent = r.getString("content");
-
-        // TODO: add new blob hash column to result set
 
         Item item = null;
         try {
-            item = new Item(new HashValue(HashingAlgorithm.SHA256, itemHash), new HashValue(HashingAlgorithm.SHA256, itemHash), objectMapper.readValue(itemContent, JsonNode.class));
+            item = new Item(new HashValue(HashingAlgorithm.SHA256, itemHash), new HashValue(HashingAlgorithm.SHA256, blobHash), objectMapper.readValue(itemContent, JsonNode.class));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
@@ -21,8 +21,8 @@ public class AppendEntryCommandHandler extends RegisterCommandHandler {
         try {
             List<String> parts = command.getCommandArguments();
             HashValue itemHash = HashValue.decode(SHA256, parts.get(RSFFormatter.RSF_HASH_POSITION));
-            Item item = register.getItemByV1Hash(itemHash).get();
-            HashValue blobHash = item.getBlobHash();
+            HashValue blobHash = register.getItemByV1Hash(itemHash).map(Item::getBlobHash)
+                    .orElse(itemHash); // TODO: this should raise an error, not generate wrong hashes
             EntryType entryType = EntryType.valueOf(parts.get(RSFFormatter.RSF_ENTRY_TYPE_POSITION));
             int newEntryNo = register.getTotalEntries(entryType) + 1;
             Entry entry = new Entry(newEntryNo, itemHash, blobHash, Instant.parse(parts.get(RSFFormatter.RSF_TIMESTAMP_POSITION)), parts.get(RSFFormatter.RSF_KEY_POSITION), entryType);

--- a/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
@@ -22,12 +22,15 @@ public class AppendEntryCommandHandler extends RegisterCommandHandler {
             List<String> parts = command.getCommandArguments();
             HashValue itemHash = HashValue.decode(SHA256, parts.get(RSFFormatter.RSF_HASH_POSITION));
             HashValue blobHash = register.getItemByV1Hash(itemHash).map(Item::getBlobHash)
-                    .orElse(itemHash); // TODO: this should raise an error, not generate wrong hashes
+                    .orElseThrow(() -> new RSFParseException("Item not found for hash " + itemHash.getValue()));
             EntryType entryType = EntryType.valueOf(parts.get(RSFFormatter.RSF_ENTRY_TYPE_POSITION));
             int newEntryNo = register.getTotalEntries(entryType) + 1;
             Entry entry = new Entry(newEntryNo, itemHash, blobHash, Instant.parse(parts.get(RSFFormatter.RSF_TIMESTAMP_POSITION)), parts.get(RSFFormatter.RSF_KEY_POSITION), entryType);
             register.appendEntry(entry);
-        } catch (Exception e) {
+        } catch(RSFParseException e) {
+            throw e;
+        }
+        catch (Exception e) {
             throw new RSFParseException("Exception when executing command: " + command, e);
         }
     }

--- a/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
@@ -2,6 +2,7 @@ package uk.gov.register.serialization.handlers;
 
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.EntryType;
+import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.serialization.RSFFormatter;
@@ -20,9 +21,11 @@ public class AppendEntryCommandHandler extends RegisterCommandHandler {
         try {
             List<String> parts = command.getCommandArguments();
             HashValue itemHash = HashValue.decode(SHA256, parts.get(RSFFormatter.RSF_HASH_POSITION));
+            Item item = register.getItemByV1Hash(itemHash).get();
+            HashValue blobHash = item.getBlobHash();
             EntryType entryType = EntryType.valueOf(parts.get(RSFFormatter.RSF_ENTRY_TYPE_POSITION));
             int newEntryNo = register.getTotalEntries(entryType) + 1;
-            Entry entry = new Entry(newEntryNo, itemHash, Instant.parse(parts.get(RSFFormatter.RSF_TIMESTAMP_POSITION)), parts.get(RSFFormatter.RSF_KEY_POSITION), entryType);
+            Entry entry = new Entry(newEntryNo, itemHash, blobHash, Instant.parse(parts.get(RSFFormatter.RSF_TIMESTAMP_POSITION)), parts.get(RSFFormatter.RSF_KEY_POSITION), entryType);
             register.appendEntry(entry);
         } catch (Exception e) {
             throw new RSFParseException("Exception when executing command: " + command, e);

--- a/src/main/java/uk/gov/register/store/postgres/BindEntry.java
+++ b/src/main/java/uk/gov/register/store/postgres/BindEntry.java
@@ -19,6 +19,7 @@ public @interface BindEntry {
                 q.bind("key", arg.getKey());
                 q.bind("entryType", arg.getEntryType());
                 q.bind("itemHash", arg.getV1ItemHash().getValue());
+                q.bind("blobHash", arg.getBlobHash().getValue());
             };
         }
     }

--- a/src/main/java/uk/gov/register/util/JsonToBlobHash.java
+++ b/src/main/java/uk/gov/register/util/JsonToBlobHash.java
@@ -3,12 +3,15 @@ package uk.gov.register.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.objecthash.ObjectHash;
 import uk.gov.objecthash.ObjectHashable;
+import uk.gov.objecthash.SetValue;
 import uk.gov.objecthash.StringValue;
 import uk.gov.register.core.HashingAlgorithm;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
@@ -18,17 +21,25 @@ import java.util.stream.StreamSupport;
 public class JsonToBlobHash {
 
     public static HashValue apply (JsonNode jsonNode){
-
+        Map<String, ObjectHashable> data = new HashMap<>();
         Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.fields();
         Stream<Map.Entry<String, JsonNode>> stream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(fields, Spliterator.ORDERED), false);
         String result = stream.map(node -> {
             String key = node.getKey();
-                     Boolean valueIsArray = node.getValue().isArray();
-                    String value = node.getValue().asText();
-                    Map<String, ObjectHashable> data = new HashMap<>();
-                    data.put(key, new StringValue(value));
-                    return ObjectHash.toHexDigest(data);
-                }
+            Boolean valueIsArray = node.getValue().isArray();
+
+            if(valueIsArray) {
+                Set<ObjectHashable> values = new HashSet<>();
+                node.getValue().elements().forEachRemaining(value -> values.add(new StringValue(value.asText())));
+                SetValue setValue = new SetValue(values);
+                data.put(key, setValue);
+                return ObjectHash.toHexDigest(data);
+            } else {
+                String value = node.getValue().asText();
+                data.put(key, new StringValue(value));
+                return ObjectHash.toHexDigest(data);
+            }
+        }
         ).collect(Collectors.joining(""));
         return new HashValue(HashingAlgorithm.SHA256, result);
     }

--- a/src/main/java/uk/gov/register/util/JsonToBlobHash.java
+++ b/src/main/java/uk/gov/register/util/JsonToBlobHash.java
@@ -21,10 +21,11 @@ import java.util.stream.StreamSupport;
 public class JsonToBlobHash {
 
     public static HashValue apply (JsonNode jsonNode){
-        Map<String, ObjectHashable> data = new HashMap<>();
         Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.fields();
         Stream<Map.Entry<String, JsonNode>> stream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(fields, Spliterator.ORDERED), false);
-        String result = stream.map(node -> {
+
+        Map<String, ObjectHashable> data = new HashMap<>();
+        stream.forEach(node -> {
             String key = node.getKey();
             Boolean valueIsArray = node.getValue().isArray();
 
@@ -33,14 +34,16 @@ public class JsonToBlobHash {
                 node.getValue().elements().forEachRemaining(value -> values.add(new StringValue(value.asText())));
                 SetValue setValue = new SetValue(values);
                 data.put(key, setValue);
-                return ObjectHash.toHexDigest(data);
             } else {
                 String value = node.getValue().asText();
-                data.put(key, new StringValue(value));
-                return ObjectHash.toHexDigest(data);
+                if(!value.equals("")) {
+                    data.put(key, new StringValue(value));
+                }
             }
         }
-        ).collect(Collectors.joining(""));
+        );
+
+        String result = ObjectHash.toHexDigest(data);
         return new HashValue(HashingAlgorithm.SHA256, result);
     }
 

--- a/src/main/java/uk/gov/register/util/JsonToBlobHash.java
+++ b/src/main/java/uk/gov/register/util/JsonToBlobHash.java
@@ -1,0 +1,38 @@
+package uk.gov.register.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.objecthash.ObjectHash;
+import uk.gov.objecthash.ObjectHashable;
+import uk.gov.objecthash.StringValue;
+import uk.gov.register.core.HashingAlgorithm;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class JsonToBlobHash {
+
+    public static HashValue apply (JsonNode jsonNode){
+
+        Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.fields();
+        Stream<Map.Entry<String, JsonNode>> stream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(fields, Spliterator.ORDERED), false);
+        String result = stream.map(node -> {
+            String key = node.getKey();
+                     Boolean valueIsArray = node.getValue().isArray();
+                    String value = node.getValue().asText();
+                    Map<String, ObjectHashable> data = new HashMap<>();
+                    data.put(key, new StringValue(value));
+                    return ObjectHash.toHexDigest(data);
+                }
+        ).collect(Collectors.joining(""));
+        return new HashValue(HashingAlgorithm.SHA256, result);
+    }
+
+
+    }
+

--- a/src/test/java/uk/gov/register/core/EntryTest.java
+++ b/src/test/java/uk/gov/register/core/EntryTest.java
@@ -12,107 +12,109 @@ import static org.junit.Assert.assertThat;
 public class EntryTest {
     private final HashValue hash1 = new HashValue(HashingAlgorithm.SHA256, "hash1");
     private final HashValue hash2 = new HashValue(HashingAlgorithm.SHA256, "hash2");
+    private final HashValue blobHash1 = new HashValue(HashingAlgorithm.SHA256, "blobHash1");
+    private final HashValue blobHash2 = new HashValue(HashingAlgorithm.SHA256, "blobHash2");
 
     @Test
     public void getTimestampAsISOFormat_returnsTheFormattedTimestamp() {
-        Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), Instant.ofEpochSecond(1470403440), "sample-key", EntryType.user);
+        Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), new HashValue(HashingAlgorithm.SHA256, "abc-blob-hash"), Instant.ofEpochSecond(1470403440), "sample-key", EntryType.user);
         assertThat(entry.getTimestampAsISOFormat(), equalTo("2016-08-05T13:24:00Z"));
     }
 
     @Test
     public void getSha256hex_returnsTheSha256HexOfItem() {
-        Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), Instant.ofEpochSecond(1470403440), "sample-key", EntryType.user);
+        Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), new HashValue(HashingAlgorithm.SHA256, "abc-blob-hash"), Instant.ofEpochSecond(1470403440), "sample-key", EntryType.user);
         assertThat(entry.getV1ItemHash().getValue(), equalTo("abc"));
     }
 
     @Test
     public void getItemHash_returnsSha256AsItemHash() {
-        Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), Instant.ofEpochSecond(1470403440), "sample-key", EntryType.user);
+        Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), new HashValue(HashingAlgorithm.SHA256, "abc-blob-hash"), Instant.ofEpochSecond(1470403440), "sample-key", EntryType.user);
         assertThat(entry.getV1ItemHash().toString(), equalTo("sha-256:abc"));
     }
 
     @Test
     public void getkey_returnskeyValue() {
-        Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), Instant.ofEpochSecond(1470403440), "sample-key", EntryType.user);
+        Entry entry = new Entry(123, new HashValue(HashingAlgorithm.SHA256, "abc"), new HashValue(HashingAlgorithm.SHA256, "abc-blob-hash"), Instant.ofEpochSecond(1470403440), "sample-key", EntryType.user);
         assertThat(entry.getKey(), equalTo("sample-key"));
     }
 
     @Test
     public void equals_shouldReturnTrue_whenEntriesAreEqual() {
-        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
-        Entry entry2 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry1 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry2 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
 
         assertThat(entry1, equalTo(entry2));
     }
 
     @Test
     public void equals_shouldReturnFalse_whenKeyIsNotEqual() {
-        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "GB", EntryType.user);
-        Entry entry2 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "US", EntryType.user);
+        Entry entry1 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "GB", EntryType.user);
+        Entry entry2 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "US", EntryType.user);
 
         assertThat(entry1, not(entry2));
     }
 
     @Test
     public void equals_shouldReturnFalse_whenTimestampIsNotEqual() {
-        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
-        Entry entry2 = new Entry(1, hash1, Instant.parse("2020-10-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry1 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry2 = new Entry(1, hash1, blobHash1, Instant.parse("2020-10-10T00:00:00Z"), "key", EntryType.user);
 
         assertThat(entry1, not(entry2));
     }
 
     @Test
     public void equals_shouldReturnFalse_whenItemHashIsNotEqual() {
-        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
-        Entry entry2 = new Entry(1, hash2, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry1 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry2 = new Entry(1, hash2, blobHash2, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
 
         assertThat(entry1, not(entry2));
     }
 
     @Test
     public void equals_shouldReturnFalse_whenTypeIsNotEqual() {
-        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
-        Entry entry2 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.system);
+        Entry entry1 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry2 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.system);
 
         assertThat(entry1, not(entry2));
     }
 
     @Test
     public void hashcode_shouldReturnSameHashcode_whenEntriesAreEqual() {
-        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
-        Entry entry2 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry1 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry2 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
 
         assertThat(entry1.hashCode(), equalTo(entry2.hashCode()));
     }
 
     @Test
     public void hashcode_shouldReturnDifferentHashCode_whenKeyIsNotEqual() {
-        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "GB", EntryType.user);
-        Entry entry2 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "US", EntryType.user);
+        Entry entry1 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "GB", EntryType.user);
+        Entry entry2 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "US", EntryType.user);
 
         assertThat(entry1.hashCode(), not(entry2.hashCode()));
     }
 
     @Test
     public void hashcode_shouldReturnDifferentHashCode_whenTimestampIsNotEqual() {
-        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
-        Entry entry2 = new Entry(1, hash1, Instant.parse("2020-10-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry1 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry2 = new Entry(1, hash1, blobHash1, Instant.parse("2020-10-10T00:00:00Z"), "key", EntryType.user);
 
         assertThat(entry1.hashCode(), not(entry2.hashCode()));
     }
 
     @Test
     public void hashcode_shouldReturnDifferentHashCode_whenItemHashIsNotEqual() {
-        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
-        Entry entry2 = new Entry(1, hash2, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry1 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry2 = new Entry(1, hash2, blobHash2, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
 
         assertThat(entry1.hashCode(), not(entry2.hashCode()));
     }
 
     @Test
     public void hashcode_shouldReturnDifferentHashCode_whenTypeIsNotEqual() {
-        Entry entry1 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
-        Entry entry2 = new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.system);
+        Entry entry1 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user);
+        Entry entry2 = new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.system);
 
         assertThat(entry1.hashCode(), not(entry2.hashCode()));
     }

--- a/src/test/java/uk/gov/register/core/RecordTest.java
+++ b/src/test/java/uk/gov/register/core/RecordTest.java
@@ -14,6 +14,8 @@ import static org.hamcrest.core.Is.is;
 public class RecordTest {
     private final HashValue hash1 = new HashValue(HashingAlgorithm.SHA256, "hash1");
     private final HashValue hash2 = new HashValue(HashingAlgorithm.SHA256, "hash2");
+    private final HashValue blobHash1 = new HashValue(HashingAlgorithm.SHA256, "blobHash1");
+    private final HashValue blobHash2 = new HashValue(HashingAlgorithm.SHA256, "blobHash2");
 
     private final Item item1 = getItem("{\"key1\":\"value1\"}");
     private final Item item2 = getItem("{\"key2\":\"value2\"}");
@@ -21,9 +23,9 @@ public class RecordTest {
     @Test
     public void recordsShouldBeEqualWithSameEntryAndItem() throws IOException {
         Record record1 = new Record(
-                new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
+                new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
         Record record2 = new Record(
-                new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
+                new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
 
         assertThat(record1.equals(record2), is(true));
     }
@@ -31,9 +33,9 @@ public class RecordTest {
     @Test
     public void recordsShouldHaveSameHashCodeWithSameEntryAndItem() throws IOException {
         Record record1 = new Record(
-                new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
+                new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
         Record record2 = new Record(
-                new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
+                new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
 
         assertThat(record1.hashCode(), is(record2.hashCode()));
     }
@@ -41,9 +43,9 @@ public class RecordTest {
     @Test
     public void recordsShouldNotBeEqualWithDifferentEntry() throws IOException {
         Record record1 = new Record(
-                new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
+                new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
         Record record2 = new Record(
-                new Entry(2, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
+                new Entry(2, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
 
         assertThat(record1.equals(record2), is(false));
     }
@@ -51,9 +53,9 @@ public class RecordTest {
     @Test
     public void recordsShouldHaveDifferentHashCodesWithDifferentEntry() throws IOException {
         Record record1 = new Record(
-                new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
+                new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
         Record record2 = new Record(
-                new Entry(2, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
+                new Entry(2, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
 
         assertThat(record1.hashCode(), not(record2.hashCode()));
     }
@@ -61,9 +63,9 @@ public class RecordTest {
     @Test
     public void recordsShouldNotBeEqualWithDifferentItems() throws IOException {
         Record record1 = new Record(
-                new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
+                new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
         Record record2 = new Record(
-                new Entry(1, hash2, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item2);
+                new Entry(1, hash2, blobHash2, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item2);
 
         assertThat(record1.equals(record2), is(false));
     }
@@ -71,9 +73,9 @@ public class RecordTest {
     @Test
     public void recordsShouldHaveDifferentHashCodeWithDifferentItems() throws IOException {
         Record record1 = new Record(
-                new Entry(1, hash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
+                new Entry(1, hash1, blobHash1, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item1);
         Record record2 = new Record(
-                new Entry(1, hash2, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item2);
+                new Entry(1, hash2, blobHash2, Instant.parse("2017-03-10T00:00:00Z"), "key", EntryType.user), item2);
 
         assertThat(record1.hashCode(), not(record2.hashCode()));
     }

--- a/src/test/java/uk/gov/register/core/RegisterImplTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterImplTest.java
@@ -88,9 +88,10 @@ public class RegisterImplTest {
     @Test
     public void shouldNotFailForValidItem() throws IOException {
         JsonNode content = mapper.readTree("{\"postcode\":\"sw1a 1aa\"}");
-        HashValue hashValue = new HashValue(HashingAlgorithm.SHA256, "abc");
-        Item item = new Item(hashValue, content);
-        Entry entry = new Entry(1, hashValue, Instant.now(),"key", EntryType.user);
+        HashValue v1HashValue = new HashValue(HashingAlgorithm.SHA256, "abc");
+        HashValue blobHashValue = new HashValue(HashingAlgorithm.SHA256, "abc-blob-hash");
+        Item item = new Item(v1HashValue, blobHashValue, content);
+        Entry entry = new Entry(1, v1HashValue, blobHashValue, Instant.now(),"key", EntryType.user);
 
         when(itemStore.getItemByV1Hash(entry.getV1ItemHash())).thenReturn(Optional.of(item));
 
@@ -100,9 +101,10 @@ public class RegisterImplTest {
     @Test(expected = AppendEntryException.class)
     public void shouldFailIfItemValidationFails() throws IOException {
         JsonNode content = mapper.readTree("{\"foo\":\"bar\"}");
-        HashValue hashValue = new HashValue(HashingAlgorithm.SHA256, "abc");
-        Item item = new Item(hashValue, content);
-        Entry entry = new Entry(1, hashValue, Instant.now(),"key", EntryType.user);
+        HashValue v1HashValue = new HashValue(HashingAlgorithm.SHA256, "abc");
+        HashValue blobHashValue = new HashValue(HashingAlgorithm.SHA256, "abc-blob-hash");
+        Item item = new Item(v1HashValue, blobHashValue, content);
+        Entry entry = new Entry(1, v1HashValue, blobHashValue, Instant.now(),"key", EntryType.user);
 
         when(itemStore.getItemByV1Hash(entry.getV1ItemHash())).thenReturn(Optional.of(item));
 

--- a/src/test/java/uk/gov/register/core/RegisterImplTest.java
+++ b/src/test/java/uk/gov/register/core/RegisterImplTest.java
@@ -78,7 +78,7 @@ public class RegisterImplTest {
 
     @Test(expected = AppendEntryException.class)
     public void shouldFailForUnreferencedItem() {
-        Entry entry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "abc"), Instant.now(),
+        Entry entry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "abc"), new HashValue(HashingAlgorithm.SHA256, "abc-blob-hash"), Instant.now(),
                 "key", EntryType.user);
 
         when(itemStore.getItemByV1Hash(entry.getV1ItemHash())).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
@@ -21,6 +21,8 @@ import uk.gov.register.functional.db.TestEntryDAO;
 import uk.gov.register.functional.db.TestItemCommandDAO;
 import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.util.CanonicalJsonMapper;
+import uk.gov.register.util.HashValue;
+import uk.gov.register.util.JsonToBlobHash;
 
 import javax.ws.rs.core.Response;
 import java.time.Instant;
@@ -74,7 +76,7 @@ public class DataUploadFunctionalTest {
         assertThat(storedItem.hashValue, equalTo(Item.itemHash(inputItem)));
 
         Entry entry = testEntryDAO.getAllEntries(schema).get(0);
-        assertThat(entry, equalTo(new Entry(1, storedItem.hashValue, entry.getTimestamp(), "ft_openregister_test", EntryType.user)));
+        assertThat(entry, equalTo(new Entry(1, storedItem.hashValue, JsonToBlobHash.apply(storedItem.contents), entry.getTimestamp(), "ft_openregister_test", EntryType.user)));
 
         Record record = testRecordDAO.getRecord("ft_openregister_test", schema, "entry").get();
         assertThat(record.getEntry().getEntryNumber(), equalTo(1));
@@ -111,8 +113,8 @@ public class DataUploadFunctionalTest {
         Instant timestamp = entries.get(0).getTimestamp();
         assertThat(entries,
                 contains(
-                        new Entry(1, Item.itemHash(canonicalItem1), timestamp, "register1", EntryType.user),
-                        new Entry(2, Item.itemHash(canonicalItem2), timestamp, "register2", EntryType.user)
+                        new Entry(1, Item.itemHash(canonicalItem1), JsonToBlobHash.apply(canonicalItem1), timestamp, "register1", EntryType.user),
+                        new Entry(2, Item.itemHash(canonicalItem2), JsonToBlobHash.apply(canonicalItem2), timestamp, "register2", EntryType.user)
                 )
         );
 
@@ -150,8 +152,8 @@ public class DataUploadFunctionalTest {
 
         assertThat(entries,
                 contains(
-                        new Entry(1, Item.itemHash(canonicalItem), entries.get(0).getTimestamp(), "register1", EntryType.user),
-                        new Entry(2, Item.itemHash(canonicalItem), entries.get(1).getTimestamp(), "register2", EntryType.user)
+                        new Entry(1, Item.itemHash(canonicalItem), JsonToBlobHash.apply(canonicalItem), entries.get(0).getTimestamp(), "register1", EntryType.user),
+                        new Entry(2, Item.itemHash(canonicalItem), JsonToBlobHash.apply(canonicalItem), entries.get(1).getTimestamp(), "register2", EntryType.user)
                 )
         );
 
@@ -187,10 +189,12 @@ public class DataUploadFunctionalTest {
 
         List<Entry> entries = testEntryDAO.getAllEntries(schema);
         Instant timestamp = entries.get(0).getTimestamp();
+        HashValue item1BlobHash = JsonToBlobHash.apply(canonicalItem1);
+        HashValue item1V1ItemHash = Item.itemHash(canonicalItem1);
         assertThat(entries,
                 contains(
-                        new Entry(1, Item.itemHash(canonicalItem1), timestamp, "register1", EntryType.user),
-                        new Entry(2, Item.itemHash(canonicalItem1), timestamp, "register2", EntryType.user)
+                        new Entry(1, item1V1ItemHash, item1BlobHash, timestamp, "register1", EntryType.user),
+                        new Entry(2, item1V1ItemHash, item1BlobHash, timestamp, "register2", EntryType.user)
                 )
         );
 

--- a/src/test/java/uk/gov/register/functional/db/RecordQueryFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/db/RecordQueryFunctionalTest.java
@@ -76,16 +76,16 @@ public class RecordQueryFunctionalTest {
         itemDAO = handle.attach(ItemDAO.class);
 
         entries = Arrays.asList(
-                new Entry(1, new HashValue(SHA256, "item1"), timestamp, "key1", EntryType.user),
-                new Entry(2, new HashValue(SHA256, "item2"), timestamp, "key2", EntryType.user),
-                new Entry(3, new HashValue(SHA256, "item3"), timestamp, "key1", EntryType.user),
-                new Entry(4, new HashValue(SHA256, "item4"), timestamp, "key3", EntryType.user));
+                new Entry(1, new HashValue(SHA256, "item1"), new HashValue(SHA256, "item1-blob-hash"), timestamp, "key1", EntryType.user),
+                new Entry(2, new HashValue(SHA256, "item2"), new HashValue(SHA256, "item2-blob-hash"), timestamp, "key2", EntryType.user),
+                new Entry(3, new HashValue(SHA256, "item3"), new HashValue(SHA256, "item3-blob-hash"), timestamp, "key1", EntryType.user),
+                new Entry(4, new HashValue(SHA256, "item4"), new HashValue(SHA256, "item4-blob-hash"), timestamp, "key3", EntryType.user));
 
         items = Arrays.asList(
-                new Item(new HashValue(SHA256, "item1"), objectMapper.readTree("{\"field1\":\"value1\",\"field2\":\"valueA\"}")),
-                new Item(new HashValue(SHA256, "item2"), objectMapper.readTree("{\"field1\":\"value2\",\"field2\":\"valueB\"}")),
-                new Item(new HashValue(SHA256, "item3"), objectMapper.readTree("{\"field1\":\"value3\",\"field2\":\"valueC\"}")),
-                new Item(new HashValue(SHA256, "item4"), objectMapper.readTree("{\"field1\":\"value4\",\"field2\":\"valueC\"}")));
+                new Item(new HashValue(SHA256, "item1"), new HashValue(SHA256, "item1-blob-hash"), objectMapper.readTree("{\"field1\":\"value1\",\"field2\":\"valueA\"}")),
+                new Item(new HashValue(SHA256, "item2"), new HashValue(SHA256, "item2-blob-hash"), objectMapper.readTree("{\"field1\":\"value2\",\"field2\":\"valueB\"}")),
+                new Item(new HashValue(SHA256, "item3"), new HashValue(SHA256, "item3-blob-hash"), objectMapper.readTree("{\"field1\":\"value3\",\"field2\":\"valueC\"}")),
+                new Item(new HashValue(SHA256, "item4"), new HashValue(SHA256, "item4-blob-hash"), objectMapper.readTree("{\"field1\":\"value4\",\"field2\":\"valueC\"}")));
     }
 
     @After

--- a/src/test/java/uk/gov/register/functional/db/TestEntryDAO.java
+++ b/src/test/java/uk/gov/register/functional/db/TestEntryDAO.java
@@ -1,7 +1,6 @@
 package uk.gov.register.functional.db;
 
 import org.skife.jdbi.v2.ResultIterator;
-import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
@@ -9,17 +8,10 @@ import org.skife.jdbi.v2.sqlobject.customizers.Define;
 import org.skife.jdbi.v2.sqlobject.customizers.FetchSize;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
-import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import uk.gov.register.core.Entry;
-import uk.gov.register.core.EntryType;
-import uk.gov.register.util.HashValue;
+import uk.gov.register.db.mappers.EntryMapper;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.time.Instant;
 import java.util.List;
-
-import static uk.gov.register.core.HashingAlgorithm.*;
 
 @UseStringTemplate3StatementLocator
 public interface TestEntryDAO {
@@ -41,11 +33,4 @@ public interface TestEntryDAO {
     @RegisterMapper(EntryMapper.class)
     @FetchSize(262144) // Has to be non-zero to enable cursor mode https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
     ResultIterator<Entry> entriesIteratorFrom(@Bind("entryNumber") int entryNumber, @Define("schema") String schema);
-
-    class EntryMapper implements ResultSetMapper<Entry> {
-        @Override
-        public Entry map(int index, ResultSet r, StatementContext ctx) throws SQLException {
-            return new Entry(r.getInt("entry_number"), new HashValue(SHA256, r.getString("sha256hex")), Instant.ofEpochSecond(r.getLong("timestamp")), r.getString("key"), EntryType.user);
-        }
-    }
 }

--- a/src/test/java/uk/gov/register/functional/store/postgres/RegisterImplTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/RegisterImplTransactionalFunctionalTest.java
@@ -96,7 +96,6 @@ public class RegisterImplTransactionalFunctionalTest {
         assertThat(registerImpl.getItemByV1Hash(blobHash), equalTo(Optional.empty()));
     }
 
-
     @Test
     public void useTransactionShouldApplyChangesAtomicallyToDatabase() {
 

--- a/src/test/java/uk/gov/register/functional/store/postgres/RegisterImplTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/RegisterImplTransactionalFunctionalTest.java
@@ -17,8 +17,26 @@ import org.skife.jdbi.v2.Handle;
 import uk.gov.register.configuration.ConfigManager;
 import uk.gov.register.configuration.FieldsConfiguration;
 import uk.gov.register.configuration.RegistersConfiguration;
-import uk.gov.register.core.*;
-import uk.gov.register.db.*;
+import uk.gov.register.core.Cardinality;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.EntryLog;
+import uk.gov.register.core.EntryLogImpl;
+import uk.gov.register.core.EntryType;
+import uk.gov.register.core.Field;
+import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.core.Item;
+import uk.gov.register.core.ItemStore;
+import uk.gov.register.core.ItemStoreImpl;
+import uk.gov.register.core.Record;
+import uk.gov.register.core.RegisterContext;
+import uk.gov.register.core.RegisterId;
+import uk.gov.register.core.RegisterImpl;
+import uk.gov.register.core.RegisterMetadata;
+import uk.gov.register.db.EntryDAO;
+import uk.gov.register.db.EntryQueryDAO;
+import uk.gov.register.db.ItemDAO;
+import uk.gov.register.db.ItemQueryDAO;
+import uk.gov.register.db.RecordQueryDAO;
 import uk.gov.register.db.RecordSet;
 import uk.gov.register.functional.app.WipeDatabaseRule;
 import uk.gov.register.functional.db.TestEntryDAO;
@@ -32,11 +50,16 @@ import uk.gov.register.util.HashValue;
 import uk.gov.verifiablelog.store.memoization.DoNothing;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -99,9 +122,9 @@ public class RegisterImplTransactionalFunctionalTest {
     @Test
     public void useTransactionShouldApplyChangesAtomicallyToDatabase() {
 
-        Item item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash1"), new ObjectMapper().createObjectNode());
-        Item item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash2"), new ObjectMapper().createObjectNode());
-        Item item3 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash3"), new ObjectMapper().createObjectNode());
+        Item item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash1"), new HashValue(HashingAlgorithm.SHA256, "blobhash1"), new ObjectMapper().createObjectNode());
+        Item item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash2"), new HashValue(HashingAlgorithm.SHA256, "blobhash2"), new ObjectMapper().createObjectNode());
+        Item item3 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash3"), new HashValue(HashingAlgorithm.SHA256, "blobhash3"), new ObjectMapper().createObjectNode());
 
         RegisterContext.useTransaction(dbi, handle -> {
             RegisterImpl registerImpl = getPostgresRegister(getTransactionalDataAccessLayer(handle));
@@ -126,9 +149,9 @@ public class RegisterImplTransactionalFunctionalTest {
 
     @Test
     public void useTransactionShouldRollbackIfExceptionThrown() {
-        Item item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash1"), new ObjectMapper().createObjectNode());
-        Item item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash2"), new ObjectMapper().createObjectNode());
-        Item item3 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash3"), new ObjectMapper().createObjectNode());
+        Item item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash1"), new HashValue(HashingAlgorithm.SHA256, "blobhash1"), new ObjectMapper().createObjectNode());
+        Item item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash2"), new HashValue(HashingAlgorithm.SHA256, "blobhash2"), new ObjectMapper().createObjectNode());
+        Item item3 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash3"), new HashValue(HashingAlgorithm.SHA256, "blobhash3"), new ObjectMapper().createObjectNode());
 
         try {
             RegisterContext.useTransaction(dbi, handle -> {
@@ -167,16 +190,16 @@ public class RegisterImplTransactionalFunctionalTest {
         JsonNode addressRegisterJson = MAPPER.readTree("{\"fields\":[\"address\"],\"phase\":\"alpha\",\"register\":\"address\",\"registry\":\"office-for-national-statistics\",\"text\":\"Register of addresses\"}");
         JsonNode addressFieldJson = MAPPER.readTree("{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"address\",\"phase\":\"alpha\",\"register\":\"address\",\"text\":\"A place in the UK with a postal address.\"}");
 
-        Item addressField = new Item(new HashValue(HashingAlgorithm.SHA256, "cf5700d23d4cd933574fbafb48ba6ace1c3b374b931a6183eeefab6f37106011"), addressFieldJson);
-        Item addressRegister = new Item(new HashValue(HashingAlgorithm.SHA256, "5e7a41b4d05ae4dfb910f3376453b21790c1ea439ef580d6dc63f067800cd9f1"), addressRegisterJson);
-        Item item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash1"), new ObjectMapper().readTree("{\"address\":\"aaa\"}"));
-        Item item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash2"), new ObjectMapper().readTree("{\"address\":\"bbb\"}"));
-        Item item3 = new Item(new HashValue(HashingAlgorithm.SHA256, "itemhash3"), new ObjectMapper().readTree("{\"address\":\"ccc\"}"));
-        Entry addressFieldEntry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "cf5700d23d4cd933574fbafb48ba6ace1c3b374b931a6183eeefab6f37106011"), Instant.parse("2017-03-10T00:00:00Z"), "field:address", EntryType.system);
-        Entry addressRegisterEntry = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "5e7a41b4d05ae4dfb910f3376453b21790c1ea439ef580d6dc63f067800cd9f1"), Instant.parse("2017-03-10T00:00:00Z"), "register:address", EntryType.system);
-        Entry entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "itemhash1"), Instant.parse("2017-03-10T00:00:00Z"), "aaa", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "itemhash2"), Instant.parse("2017-03-10T00:00:00Z"), "bbb", EntryType.user);
-        Entry entry3 = new Entry(3, new HashValue(HashingAlgorithm.SHA256, "itemhash3"), Instant.parse("2017-03-10T00:00:00Z"), "ccc", EntryType.user);
+        Item addressField = new Item(addressFieldJson);
+        Item addressRegister = new Item(addressRegisterJson);
+        Item item1 = new Item(new ObjectMapper().readTree("{\"address\":\"aaa\"}"));
+        Item item2 = new Item(new ObjectMapper().readTree("{\"address\":\"bbb\"}"));
+        Item item3 = new Item(new ObjectMapper().readTree("{\"address\":\"ccc\"}"));
+        Entry addressFieldEntry = new Entry(1, addressField.getSha256hex(), addressField.getBlobHash(), Instant.parse("2017-03-10T00:00:00Z"), "field:address", EntryType.system);
+        Entry addressRegisterEntry = new Entry(2, addressRegister.getSha256hex(), addressField.getBlobHash(), Instant.parse("2017-03-10T00:00:00Z"), "register:address", EntryType.system);
+        Entry entry1 = new Entry(1, item1.getSha256hex(), item1.getBlobHash(), Instant.parse("2017-03-10T00:00:00Z"), "aaa", EntryType.user);
+        Entry entry2 = new Entry(2, item2.getSha256hex(), item2.getBlobHash(), Instant.parse("2017-03-10T00:00:00Z"), "bbb", EntryType.user);
+        Entry entry3 = new Entry(3, item3.getSha256hex(), item3.getBlobHash(), Instant.parse("2017-03-10T00:00:00Z"), "ccc", EntryType.user);
 
         Record addressRegisterRecord = mock(Record.class);
         when(addressRegisterRecord.getItem()).thenReturn(addressRegister);

--- a/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
@@ -63,28 +63,28 @@ public class RSFCreatorTest {
         sutCreator.register(new EntryToCommandMapper());
         sutCreator.register(new ItemToCommandMapper());
 
-        systemItem = new Item(new HashValue(HashingAlgorithm.SHA256, "systemitemsha"), jsonFactory.objectNode()
+        systemItem = new Item(jsonFactory.objectNode()
                 .put("system-field-1", "system-field-1-value")
                 .put("system-field-2", "system-field-2-value"));
-        item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "item1sha"), jsonFactory.objectNode()
+        item1 = new Item(jsonFactory.objectNode()
                 .put("field-1", "entry1-field-1-value")
                 .put("field-2", "entry1-field-2-value"));
-        item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "item2sha"), jsonFactory.objectNode()
+        item2 = new Item(jsonFactory.objectNode()
                 .put("field-1", "entry2-field-1-value")
                 .put("field-2", "entry2-field-2-value"));
 
-        systemEntry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "systemitemsha"), Instant.parse("2016-07-24T16:54:00Z"), "system-key", EntryType.system);
-        entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "item1sha"), Instant.parse("2016-07-24T16:55:00Z"), "entry1-field-1-value", EntryType.user);
-        entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "item2sha"), Instant.parse("2016-07-24T16:56:00Z"), "entry2-field-1-value", EntryType.user);
+        systemEntry = new Entry(1, systemItem.getSha256hex(), systemItem.getBlobHash(), Instant.parse("2016-07-24T16:54:00Z"), "system-key", EntryType.system);
+        entry1 = new Entry(1, item1.getSha256hex(), item1.getBlobHash(), Instant.parse("2016-07-24T16:55:00Z"), "entry1-field-1-value", EntryType.user);
+        entry2 = new Entry(2, item2.getSha256hex(), item2.getBlobHash(), Instant.parse("2016-07-24T16:56:00Z"), "entry2-field-1-value", EntryType.user);
 
         assertEmptyRootHashCommand = new RegisterCommand("assert-root-hash", Collections.singletonList(emptyRegisterHash.encode()));
 
         addSystemItemCommand  = new RegisterCommand("add-item", Collections.singletonList("{\"system-field-1\":\"system-field-1-value\",\"system-field-2\":\"system-field-2-value\"}"));
         addItem1Command = new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}"));
         addItem2Command = new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}"));
-        appendSystemEntryCommand = new RegisterCommand("append-entry", Arrays.asList("system", "system-key", "2016-07-24T16:54:00Z", "sha-256:systemitemsha"));
-        appendEntry1Command = new RegisterCommand("append-entry", Arrays.asList("user", "entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item1sha"));
-        appendEntry2Command = new RegisterCommand("append-entry", Arrays.asList("user", "entry2-field-1-value","2016-07-24T16:56:00Z", "sha-256:item2sha" ));
+        appendSystemEntryCommand = new RegisterCommand("append-entry", Arrays.asList("system", "system-key", "2016-07-24T16:54:00Z", systemItem.getSha256hex().encode()));
+        appendEntry1Command = new RegisterCommand("append-entry", Arrays.asList("user", "entry1-field-1-value", "2016-07-24T16:55:00Z", item1.getSha256hex().encode()));
+        appendEntry2Command = new RegisterCommand("append-entry", Arrays.asList("user", "entry2-field-1-value","2016-07-24T16:56:00Z", item2.getSha256hex().encode()));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
@@ -65,7 +65,7 @@ public class RSFExecutorTest {
         sutExecutor.register(appendEntryHandler);
         sutExecutor.register(addItemHandler);
 
-        item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c"), jsonFactory.objectNode()
+        item1 = new Item(jsonFactory.objectNode()
                 .put("field-1", "entry1-field-1-value")
                 .put("field-2", "entry1-field-2-value"));
 

--- a/src/test/java/uk/gov/register/serialization/handlers/AddItemCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AddItemCommandHandlerTest.java
@@ -52,7 +52,7 @@ public class AddItemCommandHandlerTest {
     public void execute_addsItemToRegister() {
         sutHandler.execute(addItemCommand, register);
 
-        Item expectedItem = new Item(new HashValue(HashingAlgorithm.SHA256, "3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c"), jsonFactory.objectNode()
+        Item expectedItem = new Item(new HashValue(HashingAlgorithm.SHA256, "3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c"), new HashValue(HashingAlgorithm.SHA256, "bc7242dd795173a3632f3385b8ecd4f5b37a10130925b9c2aadfafbfc73a19c4"), jsonFactory.objectNode()
                 .put("field-1", "entry1-field-1-value")
                 .put("field-2", "entry1-field-2-value"));
 

--- a/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
@@ -1,7 +1,9 @@
 package uk.gov.register.serialization.handlers;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -9,6 +11,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.EntryType;
+import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.serialization.RegisterCommand;
@@ -17,6 +20,7 @@ import uk.gov.register.util.HashValue;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Optional;
 
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,6 +28,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,6 +44,9 @@ public class AppendEntryCommandHandlerTest {
     private RegisterCommand appendEntryCommand;
     private Instant july24 = Instant.parse("2016-07-24T16:55:00Z");
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
     @Before
     public void setUp() throws Exception {
         sutHandler = new AppendEntryCommandHandler();
@@ -52,23 +60,31 @@ public class AppendEntryCommandHandlerTest {
 
     @Test
     public void execute_appendsEntryToRegister() {
+        Item item = mock(Item.class);
+        when(item.getBlobHash()).thenReturn(new HashValue(SHA256, "blob-sha"));
+        when(register.getItemByV1Hash(new HashValue(SHA256, "item-sha"))).thenReturn(Optional.of(item));
         when(register.getTotalEntries(EntryType.user)).thenReturn(2);
-
         sutHandler.execute(appendEntryCommand, register);
-
-
-        Entry expectedEntry = new Entry(3, new HashValue(SHA256, "item-sha"), new HashValue(SHA256, "item-sha"), july24, "entry1-field-1-value", EntryType.user);
+        Entry expectedEntry = new Entry(3, new HashValue(SHA256, "item-sha"), new HashValue(SHA256, "blob-sha"), july24, "entry1-field-1-value", EntryType.user);
         verify(register, times(1)).appendEntry(expectedEntry);
+    }
+
+    @Test
+    public void execute_appendsEntryToRegisterWithoutItemThrowsException() {
+        expectedException.expect(RSFParseException.class);
+        expectedException.expectMessage("Item not found for hash item-sha");
+        sutHandler.execute(appendEntryCommand, register);
     }
 
     @Test (expected = RSFParseException.class)
     public void execute_catchesExceptionsAndReturnsFailRSFResult() {
-        doAnswer(new Answer<Void>() {
-            public Void answer(InvocationOnMock invocation) throws IOException {
-                throw new IOException("Forced exception");
-            }
-        }).when(register).appendEntry(any(Entry.class));
 
+        Item item = mock(Item.class);
+        when(item.getBlobHash()).thenReturn(new HashValue(SHA256, "blob-sha"));
+        when(register.getItemByV1Hash(new HashValue(SHA256, "item-sha"))).thenReturn(Optional.of(item));
+        doAnswer((Answer<Void>) invocation -> {
+            throw new IOException("Forced exception");
+        }).when(register).appendEntry(any(Entry.class));
         assertExceptionThrown(appendEntryCommand, "Exception when executing command: RegisterCommand");
     }
 

--- a/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
@@ -57,7 +57,7 @@ public class AppendEntryCommandHandlerTest {
         sutHandler.execute(appendEntryCommand, register);
 
 
-        Entry expectedEntry = new Entry(3, new HashValue(SHA256, "item-sha"), july24, "entry1-field-1-value", EntryType.user);
+        Entry expectedEntry = new Entry(3, new HashValue(SHA256, "item-sha"), new HashValue(SHA256, "item-sha"), july24, "entry1-field-1-value", EntryType.user);
         verify(register, times(1)).appendEntry(expectedEntry);
     }
 

--- a/src/test/java/uk/gov/register/serialization/mappers/EntryToCommandMapperTest.java
+++ b/src/test/java/uk/gov/register/serialization/mappers/EntryToCommandMapperTest.java
@@ -25,7 +25,7 @@ public class EntryToCommandMapperTest {
 
     @Test
     public void apply_returnsAppendEntryCommandForEntry() {
-        Entry entryToMap = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "item-sha"), Instant.parse("2016-07-24T16:55:00Z"), "entry1-field-1-value", EntryType.user);
+        Entry entryToMap = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "item-sha"), new HashValue(HashingAlgorithm.SHA256, "blob-sha"), Instant.parse("2016-07-24T16:55:00Z"), "entry1-field-1-value", EntryType.user);
 
         RegisterCommand mapResult = sutMapper.apply(entryToMap);
 

--- a/src/test/java/uk/gov/register/serialization/mappers/ItemToCommandMapperTest.java
+++ b/src/test/java/uk/gov/register/serialization/mappers/ItemToCommandMapperTest.java
@@ -24,7 +24,7 @@ public class ItemToCommandMapperTest {
 
     @Test
     public void apply_returnsAddItemCommandForItem() {
-        Item itemToMap = new Item(new HashValue(HashingAlgorithm.SHA256, "item1sha"), jsonFactory.objectNode()
+        Item itemToMap = new Item(jsonFactory.objectNode()
                 .put("field-1", "entry1-field-1-value")
                 .put("field-2", "entry1-field-2-value"));
 

--- a/src/test/java/uk/gov/register/store/postgres/BatchedPostgresDataAccessLayerTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/BatchedPostgresDataAccessLayerTest.java
@@ -255,8 +255,8 @@ public class BatchedPostgresDataAccessLayerTest {
 
     @Test
     public void canAddAndGetItem() throws IOException {
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"foo\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"bar\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"foo\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"bar\"}"));
 
         batchedPostgresDataAccessLayer.addItem(item1);
         batchedPostgresDataAccessLayer.addItem(item2);
@@ -268,8 +268,8 @@ public class BatchedPostgresDataAccessLayerTest {
 
     @Test
     public void doesNotDuplicateItems() throws IOException {
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"foo\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"bar\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"foo\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"bar\"}"));
 
         batchedPostgresDataAccessLayer.addItem(item1);
         batchedPostgresDataAccessLayer.addItem(item2);
@@ -288,8 +288,8 @@ public class BatchedPostgresDataAccessLayerTest {
 
         assertThat(batchedPostgresDataAccessLayer.getAllItems().size(), is(0));
 
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"foo\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"bar\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"foo\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"bar\"}"));
 
         batchedPostgresDataAccessLayer.addItem(item1);
         batchedPostgresDataAccessLayer.addItem(item2);
@@ -305,19 +305,19 @@ public class BatchedPostgresDataAccessLayerTest {
         Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
         Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
         Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key4", EntryType.user);
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"value1\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"value2\"}"));
-        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), objectMapper.readTree("{\"field\":\"value3\"}"));
-        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), objectMapper.readTree("{\"field\":\"value4\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
+        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
+        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
 
         Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), timestamp, "key5", EntryType.system);
         Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), timestamp, "key6", EntryType.system);
         Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), timestamp, "key7", EntryType.system);
         Entry systemEntry4 = new Entry(4, new HashValue(SHA256, "itemhash8"), timestamp, "key8", EntryType.system);
-        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), objectMapper.readTree("{\"field\":\"value5\"}"));
-        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), objectMapper.readTree("{\"field\":\"value6\"}"));
-        Item item7 = new Item(new HashValue(SHA256, "itemhash7"), objectMapper.readTree("{\"field\":\"value7\"}"));
-        Item item8 = new Item(new HashValue(SHA256, "itemhash8"), objectMapper.readTree("{\"field\":\"value8\"}"));
+        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
+        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
+        Item item7 = new Item(new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "itemhash7-blob-hash"), objectMapper.readTree("{\"field\":\"value7\"}"));
+        Item item8 = new Item(new HashValue(SHA256, "itemhash8"), new HashValue(SHA256, "itemhash8-blob-hash"), objectMapper.readTree("{\"field\":\"value8\"}"));
 
         batchedPostgresDataAccessLayer.appendEntry(userEntry1);
         batchedPostgresDataAccessLayer.appendEntry(userEntry2);
@@ -354,16 +354,16 @@ public class BatchedPostgresDataAccessLayerTest {
         Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
         Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
         Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"value1\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"value2\"}"));
-        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), objectMapper.readTree("{\"field\":\"value3\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
+        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
 
         Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), timestamp, "key5", EntryType.system);
         Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), timestamp, "key6", EntryType.system);
         Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), timestamp, "key5", EntryType.system);
-        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), objectMapper.readTree("{\"field\":\"value4\"}"));
-        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), objectMapper.readTree("{\"field\":\"value5\"}"));
-        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), objectMapper.readTree("{\"field\":\"value6\"}"));
+        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
+        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
+        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
 
         batchedPostgresDataAccessLayer.appendEntry(userEntry1);
         batchedPostgresDataAccessLayer.appendEntry(userEntry2);
@@ -414,17 +414,17 @@ public class BatchedPostgresDataAccessLayerTest {
         Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
         Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
         Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key3", EntryType.user);
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"value1\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"value1\"}"));
-        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), objectMapper.readTree("{\"field\":\"value2\"}"));
-        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), objectMapper.readTree("{\"field\":\"value2\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
+        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
+        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
 
         Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), timestamp, "key5", EntryType.system);
         Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), timestamp, "key6", EntryType.system);
         Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), timestamp, "key5", EntryType.system);
-        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), objectMapper.readTree("{\"field\":\"value3\"}"));
-        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), objectMapper.readTree("{\"field\":\"value4\"}"));
-        Item item7 = new Item(new HashValue(SHA256, "itemhash7"), objectMapper.readTree("{\"field\":\"value4\"}"));
+        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
+        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
+        Item item7 = new Item(new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "itemhash7-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
 
         batchedPostgresDataAccessLayer.appendEntry(userEntry1);
         batchedPostgresDataAccessLayer.appendEntry(userEntry2);
@@ -580,16 +580,16 @@ public class BatchedPostgresDataAccessLayerTest {
         Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
         Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
         Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"value1\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"value2\"}"));
-        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), objectMapper.readTree("{\"field\":\"value3\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
+        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
 
         Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), timestamp, "key5", EntryType.system);
         Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), timestamp, "key6", EntryType.system);
         Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), timestamp, "key5", EntryType.system);
-        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), objectMapper.readTree("{\"field\":\"value4\"}"));
-        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), objectMapper.readTree("{\"field\":\"value5\"}"));
-        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), objectMapper.readTree("{\"field\":\"value6\"}"));
+        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
+        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
+        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
 
         batchedPostgresDataAccessLayer.appendEntry(userEntry1); // entry goes to memory
         batchedPostgresDataAccessLayer.appendEntry(userEntry2); // entry goes to memory
@@ -631,16 +631,16 @@ public class BatchedPostgresDataAccessLayerTest {
         Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
         Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
         Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"value1\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"value2\"}"));
-        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), objectMapper.readTree("{\"field\":\"value3\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
+        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
 
         Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), timestamp, "key5", EntryType.system);
         Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), timestamp, "key6", EntryType.system);
         Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), timestamp, "key5", EntryType.system);
-        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), objectMapper.readTree("{\"field\":\"value4\"}"));
-        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), objectMapper.readTree("{\"field\":\"value5\"}"));
-        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), objectMapper.readTree("{\"field\":\"value6\"}"));
+        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
+        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
+        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
 
         postgresDataAccessLayer.appendEntry(userEntry1); // entry goes to database
         postgresDataAccessLayer.appendEntry(userEntry2); // entry goes to database

--- a/src/test/java/uk/gov/register/store/postgres/BatchedPostgresDataAccessLayerTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/BatchedPostgresDataAccessLayerTest.java
@@ -69,9 +69,9 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void canAppendAndGetEntry() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
 
         batchedPostgresDataAccessLayer.appendEntry(systemEntry1);
         batchedPostgresDataAccessLayer.appendEntry(entry1);
@@ -84,9 +84,9 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test(expected = IllegalArgumentException.class)
     public void appendUserEntriesThatSkipEntryNumberThrowsException() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(3, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(3, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
 
         batchedPostgresDataAccessLayer.appendEntry(systemEntry1);
         batchedPostgresDataAccessLayer.appendEntry(entry1);
@@ -96,9 +96,9 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test(expected = IllegalArgumentException.class)
     public void appendUserEntriesWithDuplicateEntryNumberThrowsException() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
 
         batchedPostgresDataAccessLayer.appendEntry(systemEntry1);
         batchedPostgresDataAccessLayer.appendEntry(entry1);
@@ -108,8 +108,8 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test(expected = IllegalArgumentException.class)
     public void appendSystemEntriesThatSkipEntryNumberThrowsException() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry2 = new Entry(3, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.system);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry2 = new Entry(3, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.system);
 
         batchedPostgresDataAccessLayer.appendEntry(entry1);
         batchedPostgresDataAccessLayer.appendEntry(entry2);
@@ -118,8 +118,8 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test(expected = IllegalArgumentException.class)
     public void appendSystemEntriesWithDuplicateEntryNumberThrowsException() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.system);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.system);
 
         batchedPostgresDataAccessLayer.appendEntry(entry1);
         batchedPostgresDataAccessLayer.appendEntry(entry2);
@@ -128,11 +128,11 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void canGetMultipleEntries() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry entry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
-        Entry entry4 = new Entry(4, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry entry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
+        Entry entry4 = new Entry(4, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
 
         batchedPostgresDataAccessLayer.appendEntry(systemEntry1);
         batchedPostgresDataAccessLayer.appendEntry(entry1);
@@ -151,14 +151,14 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void canGetEntryIterator() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
-        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key4", EntryType.user);
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.system);
-        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.system);
-        Entry systemEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key4", EntryType.system);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
+        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key4", EntryType.user);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.system);
+        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.system);
+        Entry systemEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key4", EntryType.system);
 
         batchedPostgresDataAccessLayer.appendEntry(userEntry1);
         batchedPostgresDataAccessLayer.appendEntry(userEntry2);
@@ -187,11 +187,11 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void canGetEntriesByKey() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry entry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
-        Entry entry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key3", EntryType.user);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry entry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
+        Entry entry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key3", EntryType.user);
 
         batchedPostgresDataAccessLayer.appendEntry(systemEntry1);
         batchedPostgresDataAccessLayer.appendEntry(entry1);
@@ -213,10 +213,10 @@ public class BatchedPostgresDataAccessLayerTest {
         assertThat(batchedPostgresDataAccessLayer.getTotalEntries(EntryType.system), is(0));
 
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
-        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key4", EntryType.user);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
+        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key4", EntryType.user);
 
         batchedPostgresDataAccessLayer.appendEntry(userEntry1);
         batchedPostgresDataAccessLayer.appendEntry(userEntry2);
@@ -225,8 +225,8 @@ public class BatchedPostgresDataAccessLayerTest {
 
         assertThat(batchedPostgresDataAccessLayer.getTotalEntries(EntryType.user), is(4));
 
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.system);
 
         batchedPostgresDataAccessLayer.appendEntry(systemEntry1);
         batchedPostgresDataAccessLayer.appendEntry(systemEntry2);
@@ -242,9 +242,9 @@ public class BatchedPostgresDataAccessLayerTest {
         Instant timestamp2 = timestamp1.plus(Duration.ofDays(1));
         Instant timestamp3 = timestamp2.plus(Duration.ofDays(1));
 
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp1, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp2, "key2", EntryType.user);
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp3, "key1", EntryType.system);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp1, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp2, "key2", EntryType.user);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp3, "key1", EntryType.system);
 
         batchedPostgresDataAccessLayer.appendEntry(userEntry1);
         batchedPostgresDataAccessLayer.appendEntry(userEntry2);
@@ -283,7 +283,7 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void canGetMultipleItems() throws IOException {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
         batchedPostgresDataAccessLayer.appendEntry(systemEntry1);
 
         assertThat(batchedPostgresDataAccessLayer.getAllItems().size(), is(0));
@@ -301,19 +301,19 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void canGetItemIterator() throws IOException {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
-        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key4", EntryType.user);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
+        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key4", EntryType.user);
         Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
         Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
         Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
         Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
 
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), timestamp, "key5", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), timestamp, "key6", EntryType.system);
-        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), timestamp, "key7", EntryType.system);
-        Entry systemEntry4 = new Entry(4, new HashValue(SHA256, "itemhash8"), timestamp, "key8", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "blobhash5"), timestamp, "key5", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "blobhash6") , timestamp, "key6", EntryType.system);
+        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "blobhash7"), timestamp, "key7", EntryType.system);
+        Entry systemEntry4 = new Entry(4, new HashValue(SHA256, "itemhash8"), new HashValue(SHA256, "blobhash8"), timestamp, "key8", EntryType.system);
         Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
         Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
         Item item7 = new Item(new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "itemhash7-blob-hash"), objectMapper.readTree("{\"field\":\"value7\"}"));
@@ -351,16 +351,16 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void canGetRecordsAndTotalRecords() throws IOException {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key2", EntryType.user);
         Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
         Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
         Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
 
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), timestamp, "key5", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), timestamp, "key6", EntryType.system);
-        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), timestamp, "key5", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key5", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "blobhash5"), timestamp, "key6", EntryType.system);
+        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "blobhash6"), timestamp, "key5", EntryType.system);
         Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
         Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
         Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
@@ -410,18 +410,18 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void canGetRecordsByKeyValue() throws IOException {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
-        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key3", EntryType.user);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key2", EntryType.user);
+        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key3", EntryType.user);
         Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
         Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
         Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
         Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
 
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), timestamp, "key5", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), timestamp, "key6", EntryType.system);
-        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), timestamp, "key5", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "blobhash5"), timestamp, "key5", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "blobhash6") , timestamp, "key6", EntryType.system);
+        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "blobhash7"), timestamp, "key5", EntryType.system);
         Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
         Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
         Item item7 = new Item(new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "itemhash7-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
@@ -464,8 +464,8 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void getEntryCanGetFromMemoryAndDB() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
 
         postgresDataAccessLayer.appendEntry(entry1); // entry goes to database
         assertThat(postgresDataAccessLayer.getTotalEntries(EntryType.user), is(1)); // value in database
@@ -484,9 +484,9 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void getEntriesGetsFromMemoryIfAllEntriesInMemory() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry entry3 = new Entry(2, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry entry3 = new Entry(2, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
 
         batchedPostgresDataAccessLayer.appendEntry(entry1); // entry goes to memory
         batchedPostgresDataAccessLayer.appendEntry(entry2); // entry goes to memory
@@ -505,9 +505,9 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void getEntriesGetsFromDBIfEntriesAreNotInMemory() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry entry3 = new Entry(2, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry entry3 = new Entry(2, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
 
         postgresDataAccessLayer.appendEntry(entry1); // entry goes to database
         assertThat(postgresDataAccessLayer.getTotalEntries(EntryType.system), is(1)); // value in database
@@ -536,9 +536,9 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void getEntriesByKeyGetsFromMemoryIfAllEntriesInMemory() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry entry3 = new Entry(2, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry entry3 = new Entry(2, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
 
         batchedPostgresDataAccessLayer.appendEntry(entry1); // entry goes to memory
         batchedPostgresDataAccessLayer.appendEntry(entry2); // entry goes to memory
@@ -555,9 +555,9 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void getEntriesByKeyGetsFromDBIfEntriesAreNotInMemory() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry entry3 = new Entry(2, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry entry3 = new Entry(2, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
 
         postgresDataAccessLayer.appendEntry(entry1); // entry goes to database
         assertThat(postgresDataAccessLayer.getTotalEntries(EntryType.system), is(1)); // value in database
@@ -577,16 +577,16 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void getRecordGetsFromMemoryIfAllDataInMemory() throws IOException {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key2", EntryType.user);
         Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
         Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
         Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
 
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), timestamp, "key5", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), timestamp, "key6", EntryType.system);
-        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), timestamp, "key5", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key5", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "blobhash5"), timestamp, "key6", EntryType.system);
+        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "blobhash6"), timestamp, "key5", EntryType.system);
         Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
         Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
         Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
@@ -628,16 +628,16 @@ public class BatchedPostgresDataAccessLayerTest {
     @Test
     public void getRecordGetsFromDBIfDataNotInMemory() throws IOException {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key2", EntryType.user);
         Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
         Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
         Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
 
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), timestamp, "key5", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), timestamp, "key6", EntryType.system);
-        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), timestamp, "key5", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key5", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "blobhash5"), timestamp, "key6", EntryType.system);
+        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "blobhash6"), timestamp, "key5", EntryType.system);
         Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
         Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
         Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDataAccessLayerTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDataAccessLayerTest.java
@@ -256,8 +256,8 @@ public class PostgresDataAccessLayerTest {
 
     @Test
     public void canAddAndGetItem() throws IOException {
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"foo\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"bar\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"foo\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"bar\"}"));
 
         postgresDataAccessLayer.addItem(item1);
         postgresDataAccessLayer.addItem(item2);
@@ -269,8 +269,8 @@ public class PostgresDataAccessLayerTest {
 
     @Test
     public void canAddItemsInBatch() throws IOException {
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"foo\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"bar\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"foo\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"bar\"}"));
 
         postgresDataAccessLayer.addItems(Arrays.asList(item1, item2));
 
@@ -281,8 +281,8 @@ public class PostgresDataAccessLayerTest {
 
     @Test
     public void doesNotDuplicateItems() throws IOException {
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"foo\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"bar\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"foo\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"bar\"}"));
 
         postgresDataAccessLayer.addItem(item1);
         postgresDataAccessLayer.addItem(item2);
@@ -297,8 +297,8 @@ public class PostgresDataAccessLayerTest {
     public void canGetMultipleItems() throws IOException {
         assertThat(postgresDataAccessLayer.getAllItems().size(), is(0));
 
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"foo\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"bar\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"foo\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"bar\"}"));
 
         postgresDataAccessLayer.addItem(item1);
         postgresDataAccessLayer.addItem(item2);
@@ -314,19 +314,19 @@ public class PostgresDataAccessLayerTest {
         Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
         Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
         Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key4", EntryType.user);
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"value1\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"value2\"}"));
-        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), objectMapper.readTree("{\"field\":\"value3\"}"));
-        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), objectMapper.readTree("{\"field\":\"value4\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
+        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
+        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
 
         Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), timestamp, "key5", EntryType.system);
         Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), timestamp, "key6", EntryType.system);
         Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), timestamp, "key7", EntryType.system);
         Entry systemEntry4 = new Entry(4, new HashValue(SHA256, "itemhash8"), timestamp, "key8", EntryType.system);
-        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), objectMapper.readTree("{\"field\":\"value5\"}"));
-        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), objectMapper.readTree("{\"field\":\"value6\"}"));
-        Item item7 = new Item(new HashValue(SHA256, "itemhash7"), objectMapper.readTree("{\"field\":\"value7\"}"));
-        Item item8 = new Item(new HashValue(SHA256, "itemhash8"), objectMapper.readTree("{\"field\":\"value8\"}"));
+        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
+        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
+        Item item7 = new Item(new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "itemhash7-blob-hash"), objectMapper.readTree("{\"field\":\"value7\"}"));
+        Item item8 = new Item(new HashValue(SHA256, "itemhash8"), new HashValue(SHA256, "itemhash8-blob-hash"), objectMapper.readTree("{\"field\":\"value8\"}"));
 
         postgresDataAccessLayer.appendEntry(userEntry1);
         postgresDataAccessLayer.appendEntry(userEntry2);
@@ -363,16 +363,16 @@ public class PostgresDataAccessLayerTest {
         Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
         Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
         Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"value1\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"value2\"}"));
-        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), objectMapper.readTree("{\"field\":\"value3\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
+        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
 
         Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), timestamp, "key5", EntryType.system);
         Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), timestamp, "key6", EntryType.system);
         Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), timestamp, "key5", EntryType.system);
-        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), objectMapper.readTree("{\"field\":\"value4\"}"));
-        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), objectMapper.readTree("{\"field\":\"value5\"}"));
-        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), objectMapper.readTree("{\"field\":\"value6\"}"));
+        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
+        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
+        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
 
         postgresDataAccessLayer.appendEntry(userEntry1);
         postgresDataAccessLayer.appendEntry(userEntry2);
@@ -423,17 +423,17 @@ public class PostgresDataAccessLayerTest {
         Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
         Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
         Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key3", EntryType.user);
-        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), objectMapper.readTree("{\"field\":\"value1\"}"));
-        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), objectMapper.readTree("{\"field\":\"value1\"}"));
-        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), objectMapper.readTree("{\"field\":\"value2\"}"));
-        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), objectMapper.readTree("{\"field\":\"value2\"}"));
+        Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
+        Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
+        Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
+        Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
 
         Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), timestamp, "key5", EntryType.system);
         Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), timestamp, "key6", EntryType.system);
         Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), timestamp, "key5", EntryType.system);
-        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), objectMapper.readTree("{\"field\":\"value3\"}"));
-        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), objectMapper.readTree("{\"field\":\"value4\"}"));
-        Item item7 = new Item(new HashValue(SHA256, "itemhash7"), objectMapper.readTree("{\"field\":\"value4\"}"));
+        Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
+        Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
+        Item item7 = new Item(new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "itemhash7-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
 
         postgresDataAccessLayer.appendEntry(userEntry1);
         postgresDataAccessLayer.appendEntry(userEntry2);

--- a/src/test/java/uk/gov/register/store/postgres/PostgresDataAccessLayerTest.java
+++ b/src/test/java/uk/gov/register/store/postgres/PostgresDataAccessLayerTest.java
@@ -68,8 +68,8 @@ public class PostgresDataAccessLayerTest {
     @Test
     public void canAppendAndGetEntry() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
 
         postgresDataAccessLayer.appendEntry(entry1);
         postgresDataAccessLayer.appendEntry(entry2);
@@ -81,8 +81,8 @@ public class PostgresDataAccessLayerTest {
     @Test
     public void canAppendEntriesInBatch() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
 
         postgresDataAccessLayer.appendEntries(Arrays.asList(entry1, entry2));
         assertThat(postgresDataAccessLayer.getEntry(1), is(Optional.of(entry1)));
@@ -93,8 +93,8 @@ public class PostgresDataAccessLayerTest {
     @Test(expected = IllegalArgumentException.class)
     public void appendUserEntriesThatSkipEntryNumberThrowsException() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(3, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(3, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
 
         postgresDataAccessLayer.appendEntry(entry1);
         postgresDataAccessLayer.appendEntry(entry2);
@@ -103,8 +103,8 @@ public class PostgresDataAccessLayerTest {
     @Test(expected = IllegalArgumentException.class)
     public void appendUserEntriesWithDuplicateEntryNumberThrowsException() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
 
         postgresDataAccessLayer.appendEntry(entry1);
         postgresDataAccessLayer.appendEntry(entry2);
@@ -113,8 +113,8 @@ public class PostgresDataAccessLayerTest {
     @Test(expected = IllegalArgumentException.class)
     public void appendSystemEntriesThatSkipEntryNumberThrowsException() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry2 = new Entry(3, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.system);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry2 = new Entry(3, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.system);
 
         postgresDataAccessLayer.appendEntry(entry1);
         postgresDataAccessLayer.appendEntry(entry2);
@@ -123,8 +123,8 @@ public class PostgresDataAccessLayerTest {
     @Test(expected = IllegalArgumentException.class)
     public void appendSystemEntriesWithDuplicateEntryNumberThrowsException() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.system);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry entry2 = new Entry(1, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.system);
 
         postgresDataAccessLayer.appendEntry(entry1);
         postgresDataAccessLayer.appendEntry(entry2);
@@ -133,10 +133,10 @@ public class PostgresDataAccessLayerTest {
     @Test
     public void canGetMultipleEntries() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry entry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
-        Entry entry4 = new Entry(4, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry entry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
+        Entry entry4 = new Entry(4, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
 
         postgresDataAccessLayer.appendEntry(entry1);
         postgresDataAccessLayer.appendEntry(entry2);
@@ -154,14 +154,14 @@ public class PostgresDataAccessLayerTest {
     @Test
     public void canGetEntryIterator() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
-        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key4", EntryType.user);
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.system);
-        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.system);
-        Entry systemEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key4", EntryType.system);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
+        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key4", EntryType.user);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.system);
+        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.system);
+        Entry systemEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key4", EntryType.system);
 
         postgresDataAccessLayer.appendEntry(userEntry1);
         postgresDataAccessLayer.appendEntry(userEntry2);
@@ -190,10 +190,10 @@ public class PostgresDataAccessLayerTest {
     @Test
     public void canGetEntriesByKey() {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry entry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
-        Entry entry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key3", EntryType.user);
+        Entry entry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry entry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry entry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
+        Entry entry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key3", EntryType.user);
 
         postgresDataAccessLayer.appendEntry(entry1);
         postgresDataAccessLayer.appendEntry(entry2);
@@ -214,10 +214,10 @@ public class PostgresDataAccessLayerTest {
         assertThat(postgresDataAccessLayer.getTotalEntries(EntryType.system), is(0));
 
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
-        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key4", EntryType.user);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
+        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key4", EntryType.user);
 
         postgresDataAccessLayer.appendEntry(userEntry1);
         postgresDataAccessLayer.appendEntry(userEntry2);
@@ -226,8 +226,8 @@ public class PostgresDataAccessLayerTest {
 
         assertThat(postgresDataAccessLayer.getTotalEntries(EntryType.user), is(4));
 
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.system);
 
         postgresDataAccessLayer.appendEntry(systemEntry1);
         postgresDataAccessLayer.appendEntry(systemEntry2);
@@ -243,9 +243,9 @@ public class PostgresDataAccessLayerTest {
         Instant timestamp2 = timestamp1.plus(Duration.ofDays(1));
         Instant timestamp3 = timestamp2.plus(Duration.ofDays(1));
 
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp1, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp2, "key2", EntryType.user);
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp3, "key1", EntryType.system);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp1, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp2, "key2", EntryType.user);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp3, "key1", EntryType.system);
 
         postgresDataAccessLayer.appendEntry(userEntry1);
         postgresDataAccessLayer.appendEntry(userEntry2);
@@ -310,19 +310,19 @@ public class PostgresDataAccessLayerTest {
     @Test
     public void canGetItemIterator() throws IOException {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key3", EntryType.user);
-        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key4", EntryType.user);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key3", EntryType.user);
+        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key4", EntryType.user);
         Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
         Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
         Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
         Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
 
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), timestamp, "key5", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), timestamp, "key6", EntryType.system);
-        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), timestamp, "key7", EntryType.system);
-        Entry systemEntry4 = new Entry(4, new HashValue(SHA256, "itemhash8"), timestamp, "key8", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "blobhash5"), timestamp, "key5", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "blobhash6") , timestamp, "key6", EntryType.system);
+        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "blobhash7"), timestamp, "key7", EntryType.system);
+        Entry systemEntry4 = new Entry(4, new HashValue(SHA256, "itemhash8"), new HashValue(SHA256, "blobhash8"), timestamp, "key8", EntryType.system);
         Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
         Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
         Item item7 = new Item(new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "itemhash7-blob-hash"), objectMapper.readTree("{\"field\":\"value7\"}"));
@@ -360,16 +360,16 @@ public class PostgresDataAccessLayerTest {
     @Test
     public void canGetRecordsAndTotalRecords() throws IOException {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key2", EntryType.user);
         Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
         Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
         Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
 
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), timestamp, "key5", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), timestamp, "key6", EntryType.system);
-        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), timestamp, "key5", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key5", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "blobhash5"), timestamp, "key6", EntryType.system);
+        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "blobhash6"), timestamp, "key5", EntryType.system);
         Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
         Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value5\"}"));
         Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value6\"}"));
@@ -419,18 +419,18 @@ public class PostgresDataAccessLayerTest {
     @Test
     public void canGetRecordsByKeyValue() throws IOException {
         Instant timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), timestamp, "key1", EntryType.user);
-        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), timestamp, "key2", EntryType.user);
-        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), timestamp, "key2", EntryType.user);
-        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), timestamp, "key3", EntryType.user);
+        Entry userEntry1 = new Entry(1, new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "blobhash1"), timestamp, "key1", EntryType.user);
+        Entry userEntry2 = new Entry(2, new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "blobhash2"), timestamp, "key2", EntryType.user);
+        Entry userEntry3 = new Entry(3, new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "blobhash3"), timestamp, "key2", EntryType.user);
+        Entry userEntry4 = new Entry(4, new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "blobhash4"), timestamp, "key3", EntryType.user);
         Item item1 = new Item(new HashValue(SHA256, "itemhash1"), new HashValue(SHA256, "itemhash1-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
         Item item2 = new Item(new HashValue(SHA256, "itemhash2"), new HashValue(SHA256, "itemhash2-blob-hash"), objectMapper.readTree("{\"field\":\"value1\"}"));
         Item item3 = new Item(new HashValue(SHA256, "itemhash3"), new HashValue(SHA256, "itemhash3-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
         Item item4 = new Item(new HashValue(SHA256, "itemhash4"), new HashValue(SHA256, "itemhash4-blob-hash"), objectMapper.readTree("{\"field\":\"value2\"}"));
 
-        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), timestamp, "key5", EntryType.system);
-        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), timestamp, "key6", EntryType.system);
-        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), timestamp, "key5", EntryType.system);
+        Entry systemEntry1 = new Entry(1, new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "blobhash5"), timestamp, "key5", EntryType.system);
+        Entry systemEntry2 = new Entry(2, new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "blobhash6") , timestamp, "key6", EntryType.system);
+        Entry systemEntry3 = new Entry(3, new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "blobhash7"), timestamp, "key5", EntryType.system);
         Item item5 = new Item(new HashValue(SHA256, "itemhash5"), new HashValue(SHA256, "itemhash5-blob-hash"), objectMapper.readTree("{\"field\":\"value3\"}"));
         Item item6 = new Item(new HashValue(SHA256, "itemhash6"), new HashValue(SHA256, "itemhash6-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));
         Item item7 = new Item(new HashValue(SHA256, "itemhash7"), new HashValue(SHA256, "itemhash7-blob-hash"), objectMapper.readTree("{\"field\":\"value4\"}"));

--- a/src/test/java/uk/gov/register/util/ArchiveCreatorTest.java
+++ b/src/test/java/uk/gov/register/util/ArchiveCreatorTest.java
@@ -27,16 +27,16 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class ArchiveCreatorTest {
     private static final JsonNodeFactory jsonFactory = JsonNodeFactory.instance;
 
-    private final Entry entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "entry1sha"), Instant.parse("2016-07-24T16:55:00Z"), "entry1-field-1-value", EntryType.user);
-    private final Entry entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "entry2sha"), Instant.parse("2016-07-24T16:56:00Z"), "entry2-field-1-value", EntryType.user);
+    private final Item item1 = new Item(jsonFactory.objectNode()
+            .put("field-1", "entry1-field-1-value")
+            .put("field-2", "entry1-field-2-value"));
 
-    private final Item item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "entry1sha"), jsonFactory.objectNode()
-        .put("field-1", "entry1-field-1-value")
-        .put("field-2", "entry1-field-2-value"));
+    private final Item item2 = new Item(jsonFactory.objectNode()
+            .put("field-1", "entry2-field-1-value")
+            .put("field-2", "entry2-field-2-value"));
 
-    private final Item item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "entry2sha"), jsonFactory.objectNode()
-        .put("field-1", "entry2-field-1-value")
-        .put("field-2", "entry2-field-2-value"));
+    private final Entry entry1 = new Entry(1, item1.getSha256hex(), item1.getBlobHash(), Instant.parse("2016-07-24T16:55:00Z"), "entry1-field-1-value", EntryType.user);
+    private final Entry entry2 = new Entry(2, item1.getSha256hex(), item1.getBlobHash(), Instant.parse("2016-07-24T16:56:00Z"), "entry2-field-1-value", EntryType.user);
 
     @Test
     public void create_shouldCreateAnArchiveWithRegisterInfoEntriesAndItems() throws IOException {
@@ -79,20 +79,20 @@ public class ArchiveCreatorTest {
         JsonNode actualEntry1Node = archiveEntries.get("entry/1.json");
         assertThat(actualEntry1Node.get("entry-number").asInt(), equalTo(1));
         assertThat(actualEntry1Node.get("entry-timestamp").asText(), equalTo("2016-07-24T16:55:00Z"));
-        assertThat(actualEntry1Node.get("item-hash").get(0).asText(), equalTo("sha-256:entry1sha"));
+        assertThat(actualEntry1Node.get("item-hash").get(0).asText(), equalTo(entry1.getV1ItemHash().encode()));
         assertThat(actualEntry1Node.get("key").asText(), equalTo("entry1-field-1-value"));
 
         JsonNode actualEntry2Node = archiveEntries.get("entry/2.json");
         assertThat(actualEntry2Node.get("entry-number").asInt(), equalTo(2));
         assertThat(actualEntry2Node.get("entry-timestamp").asText(), equalTo("2016-07-24T16:56:00Z"));
-        assertThat(actualEntry2Node.get("item-hash").get(0).asText(), equalTo("sha-256:entry2sha"));
+        assertThat(actualEntry2Node.get("item-hash").get(0).asText(), equalTo(entry2.getV1ItemHash().encode()));
         assertThat(actualEntry2Node.get("key").asText(), equalTo("entry2-field-1-value"));
 
-        JsonNode actualEntry1ItemNode = archiveEntries.get("item/entry1sha.json");
+        JsonNode actualEntry1ItemNode = archiveEntries.get("item/" + item1.getSha256hex().getValue() + ".json");
         assertThat(actualEntry1ItemNode.get("field-1").asText(), equalTo("entry1-field-1-value"));
         assertThat(actualEntry1ItemNode.get("field-2").asText(), equalTo("entry1-field-2-value"));
 
-        JsonNode actualEntry2ItemNode = archiveEntries.get("item/entry2sha.json");
+        JsonNode actualEntry2ItemNode = archiveEntries.get("item/" + item2.getSha256hex().getValue() + ".json");
         assertThat(actualEntry2ItemNode.get("field-1").asText(), equalTo("entry2-field-1-value"));
         assertThat(actualEntry2ItemNode.get("field-2").asText(), equalTo("entry2-field-2-value"));
 

--- a/src/test/java/uk/gov/register/util/JsonToBlobHashTest.java
+++ b/src/test/java/uk/gov/register/util/JsonToBlobHashTest.java
@@ -46,4 +46,47 @@ public class JsonToBlobHashTest {
         assertEquals("4852254a3c685b90d480353ba128e238aee77dc45d085af0993b6aa2a5d2ae23", JsonToBlobHash.apply(jsonNode).getValue());
     }
 
+    @Test
+    public void hashesJsonNodeWithEmptySetValue() throws IOException {
+        JsonNode jsonNode = new ObjectMapper().readTree("{\n" +
+                "\t\"foo\": \"bar\",\n" +
+                "\t\"baz\": \"quo\",\n" +
+                "\t\"fieldWithMissingValue\": []" +
+                "}");
+
+        assertEquals("4852254a3c685b90d480353ba128e238aee77dc45d085af0993b6aa2a5d2ae23", JsonToBlobHash.apply(jsonNode).getValue());
+    }
+
+    @Test
+    public void hashesJsonNodeWithNullValue() throws IOException {
+        JsonNode jsonNode = new ObjectMapper().readTree("{\n" +
+                "\t\"foo\": \"bar\",\n" +
+                "\t\"baz\": \"quo\",\n" +
+                "\t\"fieldWithMissingValue\": null" +
+                "}");
+
+        assertEquals("4852254a3c685b90d480353ba128e238aee77dc45d085af0993b6aa2a5d2ae23", JsonToBlobHash.apply(jsonNode).getValue());
+    }
+
+    @Test
+    public void hashesJsonNodeWithNullValueInSet() throws IOException {
+        JsonNode jsonNode = new ObjectMapper().readTree("{\n" +
+                "\t\"foo\": \"bar\",\n" +
+                "\t\"baz\": \"quo\",\n" +
+                "\t\"fieldWithMissingValue\": [null]" +
+                "}");
+
+        assertEquals("4852254a3c685b90d480353ba128e238aee77dc45d085af0993b6aa2a5d2ae23", JsonToBlobHash.apply(jsonNode).getValue());
+    }
+
+    @Test
+    public void hashesJsonNodeWithEmptyStringValueInSet() throws IOException {
+        JsonNode jsonNode = new ObjectMapper().readTree("{\n" +
+                "\t\"foo\": \"bar\",\n" +
+                "\t\"baz\": \"quo\",\n" +
+                "\t\"fieldWithMissingValue\": [\"\"]" +
+                "}");
+
+        assertEquals("4852254a3c685b90d480353ba128e238aee77dc45d085af0993b6aa2a5d2ae23", JsonToBlobHash.apply(jsonNode).getValue());
+    }
 }

--- a/src/test/java/uk/gov/register/util/JsonToBlobHashTest.java
+++ b/src/test/java/uk/gov/register/util/JsonToBlobHashTest.java
@@ -12,10 +12,17 @@ import static org.junit.Assert.*;
 public class JsonToBlobHashTest {
 
     @Test
-    public void hashesJsonNode() throws IOException {
+    public void hashesJsonNodeWithCardinality1() throws IOException {
         JsonNode jsonNode = new ObjectMapper().readTree("{\"foo\": \"bar\"}");
 
         assertEquals("7ef5237c3027d6c58100afadf37796b3d351025cf28038280147d42fdc53b960", JsonToBlobHash.apply(jsonNode).getValue());
+    }
+
+    @Test
+    public void hashesJsonNodeWithCardinalityN() throws IOException {
+        JsonNode jsonNode = new ObjectMapper().readTree("{\"foo\": [\"bar\", \"baz\"]}");
+
+        assertEquals("e64c38241421a64d3cbe3e0f1a7b1a429bd7b9b5ce3bb4d0840f70ecee3cd460", JsonToBlobHash.apply(jsonNode).getValue());
     }
 
 }

--- a/src/test/java/uk/gov/register/util/JsonToBlobHashTest.java
+++ b/src/test/java/uk/gov/register/util/JsonToBlobHashTest.java
@@ -25,4 +25,25 @@ public class JsonToBlobHashTest {
         assertEquals("e64c38241421a64d3cbe3e0f1a7b1a429bd7b9b5ce3bb4d0840f70ecee3cd460", JsonToBlobHash.apply(jsonNode).getValue());
     }
 
+    @Test
+    public void hashesJsonNodeWithMultipleKeys() throws IOException {
+        JsonNode jsonNode = new ObjectMapper().readTree("{\n" +
+                "\t\"foo\": \"bar\",\n" +
+                "\t\"baz\": \"quo\"\n" +
+                "}");
+
+        assertEquals("4852254a3c685b90d480353ba128e238aee77dc45d085af0993b6aa2a5d2ae23", JsonToBlobHash.apply(jsonNode).getValue());
+    }
+
+    @Test
+    public void hashesJsonNodeWithEmptyStringValue() throws IOException {
+        JsonNode jsonNode = new ObjectMapper().readTree("{\n" +
+                "\t\"foo\": \"bar\",\n" +
+                "\t\"baz\": \"quo\",\n" +
+                "\t\"fieldWithMissingValue\": \"\"\n" +
+                "}");
+
+        assertEquals("4852254a3c685b90d480353ba128e238aee77dc45d085af0993b6aa2a5d2ae23", JsonToBlobHash.apply(jsonNode).getValue());
+    }
+
 }

--- a/src/test/java/uk/gov/register/util/JsonToBlobHashTest.java
+++ b/src/test/java/uk/gov/register/util/JsonToBlobHashTest.java
@@ -1,0 +1,21 @@
+package uk.gov.register.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import uk.gov.objecthash.ObjectHash;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class JsonToBlobHashTest {
+
+    @Test
+    public void hashesJsonNode() throws IOException {
+        JsonNode jsonNode = new ObjectMapper().readTree("{\"foo\": \"bar\"}");
+
+        assertEquals("7ef5237c3027d6c58100afadf37796b3d351025cf28038280147d42fdc53b960", JsonToBlobHash.apply(jsonNode).getValue());
+    }
+
+}

--- a/src/test/java/uk/gov/register/views/RecordViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordViewTest.java
@@ -28,8 +28,8 @@ public class RecordViewTest {
 
     @Before
     public void setup() throws IOException {
-        Entry entry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), Instant.ofEpochSecond(1470403440), "b", EntryType.user);
-        Item item = new Item(new HashValue(HashingAlgorithm.SHA256, "ab"), objectMapper.readTree("{\"a\":\"b\"}"));
+        Item item = new Item(objectMapper.readTree("{\"a\":\"b\"}"));
+        Entry entry = new Entry(1, item.getSha256hex(), item.getBlobHash(), Instant.ofEpochSecond(1470403440), "b", EntryType.user);
         Record record = new Record(entry, item);
 
         ItemConverter itemConverter = mock(ItemConverter.class);

--- a/src/test/java/uk/gov/register/views/RecordsViewTest.java
+++ b/src/test/java/uk/gov/register/views/RecordsViewTest.java
@@ -29,10 +29,12 @@ public class RecordsViewTest {
         Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
         Instant t2 = Instant.parse("2016-03-28T09:49:26Z");
 
-        Entry entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cd"), t2, "456", EntryType.user);
-        Item item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "ab"), objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}"));
-        Item item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "cd"), objectMapper.readTree("{\"address\":\"456\",\"street\":\"bar\"}"));
+        Item item1 = new Item(objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}"));
+        Item item2 = new Item( objectMapper.readTree("{\"address\":\"456\",\"street\":\"bar\"}"));
+
+        Entry entry1 = new Entry(1, item1.getSha256hex(), item1.getBlobHash(), t1, "123", EntryType.user);
+        Entry entry2 = new Entry(2, item2.getSha256hex(), item2.getBlobHash(), t2, "456", EntryType.user);
+
         Record record1 = new Record(entry1, item1);
         Record record2 = new Record(entry2, item2);
 

--- a/src/test/java/uk/gov/register/views/representations/CsvWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/CsvWriterTest.java
@@ -117,8 +117,8 @@ public class CsvWriterTest {
     public void writeEntriesTo_writeRecordView() throws Exception {
         ObjectMapper objectMapper = Jackson.newObjectMapper();
 
-        Entry entry = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), Instant.ofEpochSecond(1470403440), "key1", EntryType.user);
-        Item item = new Item(new HashValue(HashingAlgorithm.SHA256, "aaa"), objectMapper.readTree("{\"key1\":\"item1\"}"));
+        Item item = new Item(objectMapper.readTree("{\"key1\":\"item1\"}"));
+        Entry entry = new Entry(1, item.getSha256hex(), item.getBlobHash(), Instant.ofEpochSecond(1470403440), "key1", EntryType.user);
         Record record = new Record(entry, item);
 
         ImmutableMap<String, Field> fields = ImmutableMap.of(
@@ -152,10 +152,12 @@ public class CsvWriterTest {
         Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
         Instant t2 = Instant.parse("2016-03-28T09:49:26Z");
 
-        Entry entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123", EntryType.user);
-        Entry entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cd"), t2, "456", EntryType.user);
-        Item item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "ab"), objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}"));
-        Item item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "cd"), objectMapper.readTree("{\"address\":\"456\",\"street\":\"bar\"}"));
+        Item item1 = new Item(objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}"));
+        Item item2 = new Item(objectMapper.readTree("{\"address\":\"456\",\"street\":\"bar\"}"));
+
+        Entry entry1 = new Entry(1, item1.getSha256hex(), item1.getBlobHash(), t1, "123", EntryType.user);
+        Entry entry2 = new Entry(2, item2.getSha256hex(), item2.getBlobHash(), t2, "456", EntryType.user);
+
         Record record1 = new Record(entry1, item1);
         Record record2 = new Record(entry2, item2);
 

--- a/src/test/java/uk/gov/register/views/representations/CsvWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/CsvWriterTest.java
@@ -38,7 +38,7 @@ public class CsvWriterTest {
     public void writes_EntryListView_to_output_stream() throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         csvWriter.writeTo(new EntryListView(
-                        ImmutableList.of(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "1234abcd"), Instant.ofEpochSecond(1400000000L), "abc", EntryType.user))),
+                        ImmutableList.of(new Entry(1, new HashValue(HashingAlgorithm.SHA256, "1234abcd"), new HashValue(HashingAlgorithm.SHA256, "1234abcd-blob-hash"), Instant.ofEpochSecond(1400000000L), "abc", EntryType.user))),
                 EntryListView.class,
                 null,
                 null,

--- a/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
+++ b/src/test/java/uk/gov/register/views/representations/turtle/TurtleRepresentationWriterTest.java
@@ -51,7 +51,7 @@ public class TurtleRepresentationWriterTest {
 
     @Test
     public void rendersEntryIdentifierFromRequestContext() throws Exception {
-        Entry entry = new Entry(52, new HashValue(HashingAlgorithm.SHA256, "hash"), Instant.now(), "key", EntryType.user);
+        Entry entry = new Entry(52, new HashValue(HashingAlgorithm.SHA256, "hash"), new HashValue(HashingAlgorithm.SHA256, "blob-hash"), Instant.now(), "key", EntryType.user);
         EntryView entryView = new EntryView(entry);
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/src/test/java/uk/gov/register/views/v2/EntryListViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/EntryListViewTest.java
@@ -24,6 +24,7 @@ public class EntryListViewTest {
     private final Entry entry1 = new Entry(
             1,
             new HashValue(HashingAlgorithm.SHA256,"ab"),
+            new HashValue(HashingAlgorithm.SHA256,"ab-blob-hash"),
             Instant.ofEpochSecond(1470403440),
             "b",
             EntryType.user
@@ -31,6 +32,7 @@ public class EntryListViewTest {
     private final Entry entry2 = new Entry(
             2,
             new HashValue(HashingAlgorithm.SHA256,"cd"),
+            new HashValue(HashingAlgorithm.SHA256,"cd-blob-hash"),
             Instant.ofEpochSecond(1470403441),
             "c",
             EntryType.user
@@ -46,13 +48,13 @@ public class EntryListViewTest {
                 "\"entry-number\":1," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:00Z\"," +
                 "\"key\":\"b\"," +
-                "\"blob-hash\":\"sha-256:ab\"" +
+                "\"blob-hash\":\"sha-256:ab-blob-hash\"" +
                 "}," +
                 "{" +
                 "\"entry-number\":2," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:01Z\"," +
                 "\"key\":\"c\"," +
-                "\"blob-hash\":\"sha-256:cd\"" +
+                "\"blob-hash\":\"sha-256:cd-blob-hash\"" +
                 "}" +
                 "]"));
     }
@@ -73,8 +75,8 @@ public class EntryListViewTest {
 
         assertThat(result, equalTo(
                 "entry-number,entry-timestamp,key,blob-hash\r\n" +
-                        "1,2016-08-05T13:24:00Z,b,sha-256:ab\r\n" +
-                        "2,2016-08-05T13:24:01Z,c,sha-256:cd\r\n"
+                        "1,2016-08-05T13:24:00Z,b,sha-256:ab-blob-hash\r\n" +
+                        "2,2016-08-05T13:24:01Z,c,sha-256:cd-blob-hash\r\n"
         ));
     }
 }

--- a/src/test/java/uk/gov/register/views/v2/RecordListViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/RecordListViewTest.java
@@ -46,14 +46,14 @@ public class RecordListViewTest {
         Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
         Instant t2 = Instant.parse("2016-03-28T09:49:26Z");
 
-        this.entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123", EntryType.user);
-        this.entry2 = new Entry(2, new HashValue(HashingAlgorithm.SHA256, "cd"), t2, "456", EntryType.user);
-
         itemNode1 = objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}");
         itemNode2 = objectMapper.readTree("{\"address\":\"456\",\"street\":\"bar\"}");
 
-        this.item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "ab"), itemNode1);
-        this.item2 = new Item(new HashValue(HashingAlgorithm.SHA256, "cd"), itemNode2);
+        this.item1 = new Item(itemNode1);
+        this.item2 = new Item(itemNode2);
+
+        this.entry1 = new Entry(1, item1.getSha256hex(), item1.getBlobHash(), t1, "123", EntryType.user);
+        this.entry2 = new Entry(2, item2.getSha256hex(), item2.getBlobHash(), t2, "456", EntryType.user);
 
         this.record1 = new Record(entry1, item1);
         this.record2 = new Record(entry2, item2);

--- a/src/test/java/uk/gov/register/views/v2/RecordViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/RecordViewTest.java
@@ -42,8 +42,8 @@ public class RecordViewTest {
         Instant t1 = Instant.parse("2016-03-29T08:59:25Z");
         itemNode1 = objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}");
 
-        this.entry1 = new Entry(1, new HashValue(HashingAlgorithm.SHA256, "ab"), t1, "123", EntryType.user);
-        this.item1 = new Item(new HashValue(HashingAlgorithm.SHA256, "ab"), itemNode1);
+        this.item1 = new Item(itemNode1);
+        this.entry1 = new Entry(1, item1.getSha256hex(), item1.getBlobHash(), t1, "123", EntryType.user);
         this.record1 = new Record(entry1, item1);
 
         this.fieldsByName = ImmutableMap.of(


### PR DESCRIPTION
### Context
V2 of the registers API will use a new hashing algorithm for blobs.

Trello: https://trello.com/c/JBenqGkg/3103-implement-rfc0010-item-hashing-algorithm-with-redactability

### Changes proposed in this pull request
- Use the blob hash to build blob hashes
- When loading RSF, calculate and store the blob hash on the entry and item rows
- Remove the deprecated `Entry` and `Item` constructors that do not accept both hashes

### Guidance to review
This is probably easiest to review commit by commit, because there's a lot of small test changes. I'll rebase before merging.