### PR TITLE
Add a DropWizard command to populate v2 hash data

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -22,6 +22,7 @@ import uk.gov.register.auth.BasicAuthFilter;
 import uk.gov.register.auth.RegisterAuthDynamicFeature;
 import uk.gov.register.configuration.*;
 import uk.gov.register.core.*;
+import uk.gov.register.commands.HashDataMigrationCommand;
 import uk.gov.register.db.Factories;
 import uk.gov.register.filters.CorsBundle;
 import uk.gov.register.filters.StripTrailingSlashRedirectFilter;
@@ -84,6 +85,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
         bootstrap.addBundle(new AssetsBundle("/assets"));
         bootstrap.addBundle(new CorsBundle());
         bootstrap.addBundle(new LogstashBundle());
+        bootstrap.addCommand(new HashDataMigrationCommand(this));
 
         System.setProperty("java.protocol.handler.pkgs", "uk.gov.register.protocols");
     }

--- a/src/main/java/uk/gov/register/commands/HashDataMigrationCommand.java
+++ b/src/main/java/uk/gov/register/commands/HashDataMigrationCommand.java
@@ -1,0 +1,65 @@
+package uk.gov.register.commands;
+
+import io.dropwizard.Application;
+import io.dropwizard.cli.EnvironmentCommand;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.setup.Environment;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.skife.jdbi.v2.DBI;
+import uk.gov.register.RegisterConfiguration;
+import uk.gov.register.configuration.ConfigManager;
+import uk.gov.register.configuration.DatabaseManager;
+import uk.gov.register.core.AllTheRegisters;
+import uk.gov.register.core.Register;
+import uk.gov.register.core.RegisterContext;
+import uk.gov.register.service.EnvironmentValidator;
+import uk.gov.register.util.JsonToBlobHash;
+
+// TODO: remove once hashes on production are correctly populated
+public class HashDataMigrationCommand extends EnvironmentCommand<RegisterConfiguration> {
+    public HashDataMigrationCommand(Application<RegisterConfiguration> application) {
+        super(application, "migrateHashes", "Populate hashes for V2 hashing algorithm");
+    }
+
+    private static boolean isRunningOnCloudFoundry() {
+        return System.getenv().containsKey("CF_INSTANCE_GUID");
+    }
+
+    @Override
+    protected void run(Environment environment, Namespace namespace, RegisterConfiguration configuration) throws Exception {
+        ConfigManager configManager = new ConfigManager(configuration);
+        configManager.refreshConfig();
+        EnvironmentValidator environmentValidator = new EnvironmentValidator(configManager);
+        DBIFactory dbiFactory = new DBIFactory();
+        DatabaseManager databaseManager = new DatabaseManager(configuration, environment, dbiFactory, isRunningOnCloudFoundry());
+        DBI dbi = databaseManager.getDbi();
+
+        AllTheRegisters allTheRegisters = configuration.getAllTheRegisters().build(configManager, databaseManager, environmentValidator, configuration);
+
+        allTheRegisters.stream().forEach(registerContext -> {
+            String registerName = registerContext.getRegisterId().value();
+            String schema = registerContext.getSchema();
+            Register register = registerContext.buildOnDemandRegister();
+
+            migrateRegister(dbi, schema, register);
+
+            if(!registerContext.hasConsistentState()) {
+                throw new RuntimeException(String.format("WARNING: Register '%s' doesn't match its specification! API requests will fail! Aborting further migrations.", registerName));
+            }
+        });
+    }
+
+    private void migrateRegister(DBI dbi, String schema, Register register) {
+        RegisterContext.useTransaction(dbi, handle -> {
+            register.getAllItems().stream().forEach(item -> {
+                String oldHashValue = item.getSha256hex().getValue();
+                String newHashValue = JsonToBlobHash.apply(item.getContent()).getValue();
+                System.out.println("Updating " + oldHashValue + " -> " + newHashValue);
+
+                handle.execute("update " + schema + ".item set blob_hash=? where sha256hex = ?", newHashValue, oldHashValue);
+                handle.execute("update " + schema + ".entry set blob_hash=? where sha256hex = ?", newHashValue, oldHashValue);
+                handle.execute("update " + schema + ".entry_system set blob_hash=? where sha256hex = ?", newHashValue, oldHashValue);
+            });
+        });
+    }
+}


### PR DESCRIPTION
### Context
Trello: https://trello.com/c/JBenqGkg/3103-implement-rfc0010-item-hashing-algorithm-with-redactability

Now that ORJ supports 2 concurrent hashing algorithms, we can populate the new hashes that will be read by the V2 API.

### Changes proposed in this pull request
Add a command to populate `blob_hash` with objecthash hashes for all items, entries, and system entries. Previously `blob_hash` values were set to the V1 hashes.

### Guidance to review
- I made this a command rather than a migration, because I don't want it to block application startup if it takes a long time to run
- The command is run by passing `migrateHashes config.yaml` as arguments to the jar instead of `server config.yaml`
- It shouldn't matter too much if this command fails to execute, because only the `/next` API reads it, and the update is idempotent
- I used the imperative JDBI style instead of the declarative one, because I don't think the queries will be useful for anything else
- We can remove the command again once we're happy the V2 hashes are correct