### PR TITLE
V2 Proofs and entry hashing

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -155,7 +155,6 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);
                 bind(ItemConverter.class).to(ItemConverter.class).in(Singleton.class);
                 bindFactory(Factories.PostgresRegisterFactory.class).to(Register.class).to(RegisterReadOnly.class);
-                bindFactory(Factories.EntryLogFactory.class).to(EntryLog.class);
                 bind(UriTemplateRegisterResolver.class).to(RegisterResolver.class);
                 bind(configuration);
                 bind(client).to(Client.class);

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -26,6 +26,7 @@ import uk.gov.register.commands.HashDataMigrationCommand;
 import uk.gov.register.db.Factories;
 import uk.gov.register.filters.CorsBundle;
 import uk.gov.register.filters.StripTrailingSlashRedirectFilter;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.resources.SchemeContext;
 import uk.gov.register.serialization.RSFCreator;
@@ -111,7 +112,8 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
             registerContext.migrate();
             registerContext.validate();
             
-            CompletableFuture.runAsync(() -> registerContext.buildOnDemandRegister().getV1RegisterProof());
+            CompletableFuture.runAsync(() -> registerContext.withV1VerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getRootHash()));
+            CompletableFuture.runAsync(() -> registerContext.withVerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getRootHash()));
         });
 
         RSFExecutor rsfExecutor = new RSFExecutor();

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -111,7 +111,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
             registerContext.migrate();
             registerContext.validate();
             
-            CompletableFuture.runAsync(() -> registerContext.buildOnDemandRegister().getRegisterProof());
+            CompletableFuture.runAsync(() -> registerContext.buildOnDemandRegister().getV1RegisterProof());
         });
 
         RSFExecutor rsfExecutor = new RSFExecutor();
@@ -153,6 +153,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);
                 bind(ItemConverter.class).to(ItemConverter.class).in(Singleton.class);
                 bindFactory(Factories.PostgresRegisterFactory.class).to(Register.class).to(RegisterReadOnly.class);
+                bindFactory(Factories.EntryLogFactory.class).to(EntryLog.class);
                 bind(UriTemplateRegisterResolver.class).to(RegisterResolver.class);
                 bind(configuration);
                 bind(client).to(Client.class);

--- a/src/main/java/uk/gov/register/core/EntryLog.java
+++ b/src/main/java/uk/gov/register/core/EntryLog.java
@@ -26,11 +26,4 @@ public interface EntryLog {
     int getTotalEntries(EntryType entryType);
 
     Optional<Instant> getLastUpdatedTime();
-
-    RegisterProof getV1RegisterProof();
-    RegisterProof getV1RegisterProof(int totalEntries);
-
-    EntryProof getV1EntryProof(int entryNumber, int totalEntries);
-
-    ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2);
 }

--- a/src/main/java/uk/gov/register/core/EntryLog.java
+++ b/src/main/java/uk/gov/register/core/EntryLog.java
@@ -27,10 +27,10 @@ public interface EntryLog {
 
     Optional<Instant> getLastUpdatedTime();
 
-    RegisterProof getRegisterProof();
-    RegisterProof getRegisterProof(int totalEntries);
+    RegisterProof getV1RegisterProof();
+    RegisterProof getV1RegisterProof(int totalEntries);
 
-    EntryProof getEntryProof(int entryNumber, int totalEntries);
+    EntryProof getV1EntryProof(int entryNumber, int totalEntries);
 
-    ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2);
+    ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2);
 }

--- a/src/main/java/uk/gov/register/core/EntryLogImpl.java
+++ b/src/main/java/uk/gov/register/core/EntryLogImpl.java
@@ -1,7 +1,7 @@
 package uk.gov.register.core;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import uk.gov.register.db.EntryMerkleLeafStore;
+import uk.gov.register.db.V1EntryMerkleLeafStore;
 import uk.gov.register.exceptions.IndexingException;
 import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.util.HashValue;
@@ -76,21 +76,21 @@ public class EntryLogImpl implements EntryLog {
     }
 
     @Override
-    public RegisterProof getRegisterProof() {
+    public RegisterProof getV1RegisterProof() {
         String rootHash = withVerifiableLog(verifiableLog -> bytesToString(verifiableLog.getCurrentRootHash()));
 
         return new RegisterProof(new HashValue(HashingAlgorithm.SHA256, rootHash), getTotalEntries(EntryType.user));
     }
 
     @Override
-    public RegisterProof getRegisterProof(int totalEntries) {
+    public RegisterProof getV1RegisterProof(int totalEntries) {
         String rootHash = withVerifiableLog(verifiableLog -> bytesToString(verifiableLog.getSpecificRootHash(totalEntries)));
 
         return new RegisterProof(new HashValue(HashingAlgorithm.SHA256, rootHash), totalEntries);
     }
 
     @Override
-    public EntryProof getEntryProof(int entryNumber, int totalEntries) {
+    public EntryProof getV1EntryProof(int entryNumber, int totalEntries) {
         List<HashValue> auditProof = withVerifiableLog(verifiableLog ->
                 verifiableLog.auditProof(entryNumber - 1, totalEntries)
                         .stream()
@@ -101,7 +101,7 @@ public class EntryLogImpl implements EntryLog {
     }
 
     @Override
-    public ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2) {
+    public ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2) {
         List<HashValue> consistencyProof = withVerifiableLog(verifiableLog ->
             verifiableLog.consistencyProof(totalEntries1, totalEntries2)
                     .stream()
@@ -117,7 +117,7 @@ public class EntryLogImpl implements EntryLog {
 
     private <R> R withVerifiableLog(Function<VerifiableLog, R> callback) {
         return dataAccessLayer.withEntryIterator(entryIterator -> {
-            VerifiableLog verifiableLog = new VerifiableLog(DigestUtils.getSha256Digest(), new EntryMerkleLeafStore(entryIterator), memoizationStore);
+            VerifiableLog verifiableLog = new VerifiableLog(DigestUtils.getSha256Digest(), new V1EntryMerkleLeafStore(entryIterator), memoizationStore);
             return callback.apply(verifiableLog);
         });
     }

--- a/src/main/java/uk/gov/register/core/EntryLogImpl.java
+++ b/src/main/java/uk/gov/register/core/EntryLogImpl.java
@@ -1,7 +1,7 @@
 package uk.gov.register.core;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import uk.gov.register.db.V1EntryMerkleLeafStore;
+import uk.gov.register.proofs.V1EntryMerkleLeafStore;
 import uk.gov.register.exceptions.IndexingException;
 import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.util.HashValue;

--- a/src/main/java/uk/gov/register/core/EntryLogImpl.java
+++ b/src/main/java/uk/gov/register/core/EntryLogImpl.java
@@ -1,32 +1,18 @@
 package uk.gov.register.core;
 
-import org.apache.commons.codec.digest.DigestUtils;
-import uk.gov.register.proofs.V1EntryMerkleLeafStore;
 import uk.gov.register.exceptions.IndexingException;
 import uk.gov.register.store.DataAccessLayer;
-import uk.gov.register.util.HashValue;
-import uk.gov.register.views.ConsistencyProof;
-import uk.gov.register.views.EntryProof;
-import uk.gov.register.views.RegisterProof;
-import uk.gov.verifiablelog.VerifiableLog;
-import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
-import javax.xml.bind.DatatypeConverter;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class EntryLogImpl implements EntryLog {
     private final DataAccessLayer dataAccessLayer;
-    private final MemoizationStore memoizationStore;
 
-    public EntryLogImpl(DataAccessLayer dataAccessLayer, MemoizationStore memoizationStore) {
+    public EntryLogImpl(DataAccessLayer dataAccessLayer) {
         this.dataAccessLayer = dataAccessLayer;
-        this.memoizationStore = memoizationStore;
     }
 
     @Override
@@ -73,52 +59,5 @@ public class EntryLogImpl implements EntryLog {
     @Override
     public Optional<Instant> getLastUpdatedTime() {
         return dataAccessLayer.getLastUpdatedTime();
-    }
-
-    @Override
-    public RegisterProof getV1RegisterProof() {
-        String rootHash = withVerifiableLog(verifiableLog -> bytesToString(verifiableLog.getCurrentRootHash()));
-
-        return new RegisterProof(new HashValue(HashingAlgorithm.SHA256, rootHash), getTotalEntries(EntryType.user));
-    }
-
-    @Override
-    public RegisterProof getV1RegisterProof(int totalEntries) {
-        String rootHash = withVerifiableLog(verifiableLog -> bytesToString(verifiableLog.getSpecificRootHash(totalEntries)));
-
-        return new RegisterProof(new HashValue(HashingAlgorithm.SHA256, rootHash), totalEntries);
-    }
-
-    @Override
-    public EntryProof getV1EntryProof(int entryNumber, int totalEntries) {
-        List<HashValue> auditProof = withVerifiableLog(verifiableLog ->
-                verifiableLog.auditProof(entryNumber - 1, totalEntries)
-                        .stream()
-                        .map(hashBytes -> new HashValue(HashingAlgorithm.SHA256, bytesToString(hashBytes)))
-                        .collect(Collectors.toList()));
-
-        return new EntryProof(Integer.toString(entryNumber), auditProof);
-    }
-
-    @Override
-    public ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2) {
-        List<HashValue> consistencyProof = withVerifiableLog(verifiableLog ->
-            verifiableLog.consistencyProof(totalEntries1, totalEntries2)
-                    .stream()
-                    .map(hashBytes -> new HashValue(HashingAlgorithm.SHA256, bytesToString(hashBytes)))
-                    .collect(Collectors.toList()));
-
-        return new ConsistencyProof(consistencyProof);
-    }
-
-    private String bytesToString(byte[] bytes) {
-        return DatatypeConverter.printHexBinary(bytes).toLowerCase();
-    }
-
-    private <R> R withVerifiableLog(Function<VerifiableLog, R> callback) {
-        return dataAccessLayer.withEntryIterator(entryIterator -> {
-            VerifiableLog verifiableLog = new VerifiableLog(DigestUtils.getSha256Digest(), new V1EntryMerkleLeafStore(entryIterator), memoizationStore);
-            return callback.apply(verifiableLog);
-        });
     }
 }

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -1,6 +1,7 @@
 package uk.gov.register.core;
 
 import com.google.common.base.Throwables;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.flywaydb.core.Flyway;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
@@ -13,17 +14,21 @@ import uk.gov.register.db.RecordSet;
 import uk.gov.register.exceptions.FieldDefinitionException;
 import uk.gov.register.exceptions.NoSuchConfigException;
 import uk.gov.register.exceptions.RegisterDefinitionException;
+import uk.gov.register.proofs.EntryMerkleLeafStore;
+import uk.gov.register.proofs.V1EntryMerkleLeafStore;
 import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.ItemValidator;
 import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.store.postgres.BatchedPostgresDataAccessLayer;
 import uk.gov.register.store.postgres.PostgresDataAccessLayer;
+import uk.gov.verifiablelog.VerifiableLog;
 import uk.gov.verifiablelog.store.memoization.InMemoryPowOfTwoNoLeaves;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 
 public class RegisterContext implements
@@ -76,14 +81,14 @@ public class RegisterContext implements
     public EntryLog buildEntryLog() {
         DataAccessLayer dataAccessLayer = getOnDemandDataAccessLayer();
 
-        return new EntryLogImpl(dataAccessLayer, memoizationStore.get());
+        return new EntryLogImpl(dataAccessLayer);
     }
 
     public Register buildOnDemandRegister() {
         DataAccessLayer dataAccessLayer = getOnDemandDataAccessLayer();
 
         return new RegisterImpl(registerId,
-                new EntryLogImpl(dataAccessLayer, memoizationStore.get()),
+                new EntryLogImpl(dataAccessLayer),
                 new ItemStoreImpl(dataAccessLayer),
                 new RecordSet(dataAccessLayer),
                 itemValidator,
@@ -92,7 +97,7 @@ public class RegisterContext implements
 
     private Register buildTransactionalRegister(DataAccessLayer dataAccessLayer, TransactionalMemoizationStore memoizationStore) {
         return new RegisterImpl(registerId,
-                new EntryLogImpl(dataAccessLayer, memoizationStore),
+                new EntryLogImpl(dataAccessLayer),
                 new ItemStoreImpl(dataAccessLayer),
                 new RecordSet(dataAccessLayer),
                 itemValidator,
@@ -137,6 +142,26 @@ public class RegisterContext implements
                 dbi.onDemand(ItemQueryDAO.class),
                 dbi.onDemand(RecordQueryDAO.class),
                 schema);
+    }
+
+    public <R> R withV1VerifiableLog(Function<VerifiableLog, R> callback) {
+        return getOnDemandDataAccessLayer().withEntryIterator(entryIterator -> {
+            VerifiableLog verifiableLog = new VerifiableLog(
+                    DigestUtils.getSha256Digest(),
+                    new V1EntryMerkleLeafStore(entryIterator),
+                    memoizationStore.get());
+            return callback.apply(verifiableLog);
+        });
+    }
+
+    public <R> R withVerifiableLog(Function<VerifiableLog, R> callback) {
+        return getOnDemandDataAccessLayer().withEntryIterator(entryIterator -> {
+            VerifiableLog verifiableLog = new VerifiableLog(
+                    DigestUtils.getSha256Digest(),
+                    new EntryMerkleLeafStore(entryIterator),
+                    memoizationStore.get());
+            return callback.apply(verifiableLog);
+        });
     }
 
     private BatchedPostgresDataAccessLayer getTransactionalDataAccessLayer(Handle handle) {

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -73,6 +73,12 @@ public class RegisterContext implements
         return flyway.migrate();
     }
 
+    public EntryLog buildEntryLog() {
+        DataAccessLayer dataAccessLayer = getOnDemandDataAccessLayer();
+
+        return new EntryLogImpl(dataAccessLayer, memoizationStore.get());
+    }
+
     public Register buildOnDemandRegister() {
         DataAccessLayer dataAccessLayer = getOnDemandDataAccessLayer();
 

--- a/src/main/java/uk/gov/register/core/RegisterImpl.java
+++ b/src/main/java/uk/gov/register/core/RegisterImpl.java
@@ -184,30 +184,6 @@ public class RegisterImpl implements Register {
 
     //endregion
 
-    //region Verifiable Log
-
-    @Override
-    public RegisterProof getV1RegisterProof() {
-        return entryLog.getV1RegisterProof();
-    }
-
-    @Override
-    public RegisterProof getV1RegisterProof(int totalEntries) {
-        return entryLog.getV1RegisterProof(totalEntries);
-    }
-
-    @Override
-    public EntryProof getV1EntryProof(int entryNumber, int totalEntries) {
-        return entryLog.getV1EntryProof(entryNumber, totalEntries);
-    }
-
-    @Override
-    public ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2) {
-        return entryLog.getV1ConsistencyProof(totalEntries1, totalEntries2);
-    }
-
-    //endregion
-
     //region Metadata
 
     @Override

--- a/src/main/java/uk/gov/register/core/RegisterImpl.java
+++ b/src/main/java/uk/gov/register/core/RegisterImpl.java
@@ -187,23 +187,23 @@ public class RegisterImpl implements Register {
     //region Verifiable Log
 
     @Override
-    public RegisterProof getRegisterProof() {
-        return entryLog.getRegisterProof();
+    public RegisterProof getV1RegisterProof() {
+        return entryLog.getV1RegisterProof();
     }
 
     @Override
-    public RegisterProof getRegisterProof(int totalEntries) {
-        return entryLog.getRegisterProof(totalEntries);
+    public RegisterProof getV1RegisterProof(int totalEntries) {
+        return entryLog.getV1RegisterProof(totalEntries);
     }
 
     @Override
-    public EntryProof getEntryProof(int entryNumber, int totalEntries) {
-        return entryLog.getEntryProof(entryNumber, totalEntries);
+    public EntryProof getV1EntryProof(int entryNumber, int totalEntries) {
+        return entryLog.getV1EntryProof(entryNumber, totalEntries);
     }
 
     @Override
-    public ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2) {
-        return entryLog.getConsistencyProof(totalEntries1, totalEntries2);
+    public ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2) {
+        return entryLog.getV1ConsistencyProof(totalEntries1, totalEntries2);
     }
 
     //endregion

--- a/src/main/java/uk/gov/register/core/RegisterReadOnly.java
+++ b/src/main/java/uk/gov/register/core/RegisterReadOnly.java
@@ -36,11 +36,6 @@ public interface RegisterReadOnly {
     List<Record> max100RecordsFacetedByKeyValue(String key, String value) throws NoSuchFieldException;
     int getTotalRecords(EntryType entryType);
 
-    RegisterProof getV1RegisterProof();
-    RegisterProof getV1RegisterProof(int entryNo);
-    EntryProof getV1EntryProof(int entryNumber, int totalEntries);
-    ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2);
-
     RegisterId getRegisterId();
     Optional<String> getRegisterName();
     Optional<String> getCustodianName();

--- a/src/main/java/uk/gov/register/core/RegisterReadOnly.java
+++ b/src/main/java/uk/gov/register/core/RegisterReadOnly.java
@@ -36,10 +36,10 @@ public interface RegisterReadOnly {
     List<Record> max100RecordsFacetedByKeyValue(String key, String value) throws NoSuchFieldException;
     int getTotalRecords(EntryType entryType);
 
-    RegisterProof getRegisterProof();
-    RegisterProof getRegisterProof(int entryNo);
-    EntryProof getEntryProof(int entryNumber, int totalEntries);
-    ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2);
+    RegisterProof getV1RegisterProof();
+    RegisterProof getV1RegisterProof(int entryNo);
+    EntryProof getV1EntryProof(int entryNumber, int totalEntries);
+    ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2);
 
     RegisterId getRegisterId();
     Optional<String> getRegisterName();

--- a/src/main/java/uk/gov/register/db/Factories.java
+++ b/src/main/java/uk/gov/register/db/Factories.java
@@ -2,6 +2,7 @@ package uk.gov.register.db;
 
 import org.glassfish.hk2.api.Factory;
 import uk.gov.register.core.AllTheRegisters;
+import uk.gov.register.core.EntryLog;
 import uk.gov.register.core.Register;
 import uk.gov.register.core.RegisterContext;
 import uk.gov.register.core.RegisterId;
@@ -17,6 +18,20 @@ public abstract class Factories {
         @Override
         public void dispose(T instance) {
             // do nothing
+        }
+    }
+
+    public static class EntryLogFactory extends SimpleFactory<EntryLog> {
+        private final RegisterContext registerContext;
+
+        @Inject
+        public EntryLogFactory(RegisterContext registerContext) {
+            this.registerContext = registerContext;
+        }
+
+        @Override
+        public EntryLog provide() {
+            return registerContext.buildEntryLog();
         }
     }
 

--- a/src/main/java/uk/gov/register/db/Factories.java
+++ b/src/main/java/uk/gov/register/db/Factories.java
@@ -21,20 +21,6 @@ public abstract class Factories {
         }
     }
 
-    public static class EntryLogFactory extends SimpleFactory<EntryLog> {
-        private final RegisterContext registerContext;
-
-        @Inject
-        public EntryLogFactory(RegisterContext registerContext) {
-            this.registerContext = registerContext;
-        }
-
-        @Override
-        public EntryLog provide() {
-            return registerContext.buildEntryLog();
-        }
-    }
-
     public static class PostgresRegisterFactory extends SimpleFactory<Register> {
         private final RegisterContext registerContext;
 

--- a/src/main/java/uk/gov/register/db/V1EntryMerkleLeafStore.java
+++ b/src/main/java/uk/gov/register/db/V1EntryMerkleLeafStore.java
@@ -1,0 +1,42 @@
+package uk.gov.register.db;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import uk.gov.register.core.Entry;
+import uk.gov.register.views.EntryView;
+import uk.gov.verifiablelog.store.MerkleLeafStore;
+
+public class V1EntryMerkleLeafStore implements MerkleLeafStore {
+    private final EntryIterator entryIterator;
+
+
+    public V1EntryMerkleLeafStore(EntryIterator entryIterator) {
+        this.entryIterator = entryIterator;
+    }
+
+    @Override
+    public byte[] getLeafValue(int i) {
+        return bytesFromEntry(entryIterator.findByEntryNumber(i + 1));
+    }
+
+    @Override
+    public int totalLeaves() {
+        return entryIterator.getTotalEntries();
+    }
+
+    private byte[] bytesFromEntry(Entry entry) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+            mapper.getFactory().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
+            EntryView entryView = new EntryView(entry);
+            String value = mapper.writeValueAsString(entryView);
+            return value.getBytes();
+        } catch (JsonProcessingException e) {
+            // FIXME swallow for now and return null byte
+            return new byte[]{0x00};
+        }
+    }
+}

--- a/src/main/java/uk/gov/register/proofs/EntryIterator.java
+++ b/src/main/java/uk/gov/register/proofs/EntryIterator.java
@@ -1,7 +1,8 @@
-package uk.gov.register.db;
+package uk.gov.register.proofs;
 
 import org.skife.jdbi.v2.ResultIterator;
 import uk.gov.register.core.Entry;
+import uk.gov.register.db.EntryQueryDAO;
 
 import java.util.function.Function;
 

--- a/src/main/java/uk/gov/register/proofs/EntryMerkleLeafStore.java
+++ b/src/main/java/uk/gov/register/proofs/EntryMerkleLeafStore.java
@@ -1,4 +1,4 @@
-package uk.gov.register.db;
+package uk.gov.register.proofs;
 
 import uk.gov.objecthash.IntegerValue;
 import uk.gov.objecthash.ListValue;

--- a/src/main/java/uk/gov/register/proofs/ProofGenerator.java
+++ b/src/main/java/uk/gov/register/proofs/ProofGenerator.java
@@ -1,0 +1,54 @@
+package uk.gov.register.proofs;
+
+import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.util.HashValue;
+import uk.gov.register.views.ConsistencyProof;
+import uk.gov.register.views.EntryProof;
+import uk.gov.register.views.RegisterProof;
+import uk.gov.verifiablelog.VerifiableLog;
+
+import javax.xml.bind.DatatypeConverter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ProofGenerator {
+    private final VerifiableLog verifiableLog;
+
+    public ProofGenerator(VerifiableLog verifiableLog) {
+        this.verifiableLog = verifiableLog;
+    }
+
+    public RegisterProof getRegisterProof(int totalEntries) {
+        return new RegisterProof(getRootHash(totalEntries), totalEntries);
+    }
+
+    public HashValue getRootHash(int totalEntries) {
+        return new HashValue(HashingAlgorithm.SHA256, bytesToString(verifiableLog.getSpecificRootHash(totalEntries)));
+    }
+
+    public HashValue getRootHash() {
+        return new HashValue(HashingAlgorithm.SHA256, bytesToString(verifiableLog.getCurrentRootHash()));
+    }
+
+    public EntryProof getEntryProof(int entryNumber, int totalEntries) {
+        List<HashValue> auditProof = verifiableLog.auditProof(entryNumber - 1, totalEntries)
+                        .stream()
+                        .map(hashBytes -> new HashValue(HashingAlgorithm.SHA256, bytesToString(hashBytes)))
+                        .collect(Collectors.toList());
+
+        return new EntryProof(Integer.toString(entryNumber), auditProof);
+    }
+
+    public ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2) {
+        List<HashValue> consistencyProof = verifiableLog.consistencyProof(totalEntries1, totalEntries2)
+                        .stream()
+                        .map(hashBytes -> new HashValue(HashingAlgorithm.SHA256, bytesToString(hashBytes)))
+                        .collect(Collectors.toList());
+
+        return new ConsistencyProof(consistencyProof);
+    }
+
+    private String bytesToString(byte[] bytes) {
+        return DatatypeConverter.printHexBinary(bytes).toLowerCase();
+    }
+}

--- a/src/main/java/uk/gov/register/proofs/V1EntryMerkleLeafStore.java
+++ b/src/main/java/uk/gov/register/proofs/V1EntryMerkleLeafStore.java
@@ -1,4 +1,4 @@
-package uk.gov.register.db;
+package uk.gov.register.proofs;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/uk/gov/register/resources/v1/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/VerifiableLogResource.java
@@ -38,7 +38,7 @@ public class VerifiableLogResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public RegisterProof registerProof() {
-        return registerContext.withVerifiableLog(verifiableLog -> {
+        return registerContext.withV1VerifiableLog(verifiableLog -> {
             int totalEntries = entryLog.getTotalEntries(EntryType.user);
             return new ProofGenerator(verifiableLog).getRegisterProof(totalEntries);
         });
@@ -59,7 +59,7 @@ public class VerifiableLogResource {
     @Timed
     public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) {
         validateEntryProofParams(entryNumber, totalEntries);
-        return registerContext.withVerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getEntryProof(entryNumber, totalEntries));
+        return registerContext.withV1VerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getEntryProof(entryNumber, totalEntries));
     }
 
     @GET
@@ -68,7 +68,7 @@ public class VerifiableLogResource {
     @Timed
     public ConsistencyProof consistencyProof(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) {
         validateConsistencyProofParams(totalEntries1, totalEntries2);
-        return registerContext.withVerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getConsistencyProof(totalEntries1, totalEntries2));
+        return registerContext.withV1VerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getConsistencyProof(totalEntries1, totalEntries2));
     }
 
     private void validateEntryProofParams(int entryNumber, int totalEntries) {

--- a/src/main/java/uk/gov/register/resources/v1/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/VerifiableLogResource.java
@@ -1,14 +1,82 @@
 package uk.gov.register.resources.v1;
 
-import uk.gov.register.core.RegisterReadOnly;
+import com.codahale.metrics.annotation.Timed;
+import uk.gov.register.core.EntryLog;
+import uk.gov.register.core.EntryType;
+import uk.gov.register.views.ConsistencyProof;
+import uk.gov.register.views.EntryProof;
+import uk.gov.register.views.RegisterProof;
 
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static uk.gov.register.resources.RedirectResource.redirectByPath;
 
 @Path("/proof")
-public class VerifiableLogResource extends uk.gov.register.resources.v2.VerifiableLogResource {
+public class VerifiableLogResource {
+    private final EntryLog entryLog;
+
     @Inject
-    public VerifiableLogResource(RegisterReadOnly register) {
-        super(register);
+    public VerifiableLogResource(EntryLog entryLog) {
+        this.entryLog = entryLog;
+    }
+
+    @GET
+    @Path("/register/merkle:sha-256")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    public RegisterProof registerProof() {
+        return entryLog.getV1RegisterProof();
+    }
+
+    @GET
+    @Path("/entry/{entry-number}/{total-entries}/merkle:sha-256")
+    public Response getProofRedirect(
+            @Context HttpServletRequest request
+    )
+    {
+        return redirectByPath(request, "/entry/", "/entries/");
+    }
+
+    @GET
+    @Path("/entries/{entry-number}/{total-entries}/merkle:sha-256")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) {
+        validateEntryProofParams(entryNumber, totalEntries);
+        return entryLog.getV1EntryProof(entryNumber, totalEntries);
+    }
+
+    @GET
+    @Path("/consistency/{total-entries-1}/{total-entries-2}/merkle:sha-256")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    public ConsistencyProof consistencyProof(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) {
+        validateConsistencyProofParams(totalEntries1, totalEntries2);
+        return entryLog.getV1ConsistencyProof(totalEntries1, totalEntries2);
+    }
+
+    private void validateEntryProofParams(int entryNumber, int totalEntries) {
+        if (entryNumber < 1 ||
+                entryNumber > totalEntries ||
+                totalEntries > entryLog.getTotalEntries(EntryType.user)) {
+            throw new BadRequestException("Invalid parameters");
+        }
+    }
+
+    private void validateConsistencyProofParams(int totalEntries1, int totalEntries2) {
+        if (totalEntries1 < 1 ||
+                totalEntries1 > totalEntries2 ||
+                totalEntries2 > entryLog.getTotalEntries(EntryType.user)) {
+            throw new BadRequestException("Invalid parameters");
+        }
     }
 }

--- a/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
@@ -72,6 +72,4 @@ public class VerifiableLogResource {
             throw new BadRequestException("Invalid parameters");
         }
     }
-
-
 }

--- a/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
@@ -1,69 +1,59 @@
 package uk.gov.register.resources.v2;
 
 import com.codahale.metrics.annotation.Timed;
+import uk.gov.register.core.EntryLog;
 import uk.gov.register.core.EntryType;
-import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.*;
-import javax.ws.rs.core.Context;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
-import static uk.gov.register.resources.RedirectResource.redirectByPath;
 
 @Path("/next/proof")
 public class VerifiableLogResource {
-    private final RegisterReadOnly register;
+    private final EntryLog entryLog;
 
     @Inject
-    public VerifiableLogResource(RegisterReadOnly register) {
-        this.register = register;
+    public VerifiableLogResource(EntryLog entryLog) {
+        this.entryLog = entryLog;
     }
 
     @GET
-    @Path("/register/merkle:sha-256")
+    @Path("/register")
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public RegisterProof registerProof() {
-        return register.getRegisterProof();
+        return entryLog.getV1RegisterProof();
     }
 
     @GET
-    @Path("/entry/{entry-number}/{total-entries}/merkle:sha-256")
-    public Response getProofRedirect(
-            @Context HttpServletRequest request
-    )
-    {
-        return redirectByPath(request, "/entry/", "/entries/");
-    }
-
-    @GET
-    @Path("/entries/{entry-number}/{total-entries}/merkle:sha-256")
+    @Path("/entry/{entry-number}/{total-entries}")
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) {
         validateEntryProofParams(entryNumber, totalEntries);
-        return register.getEntryProof(entryNumber, totalEntries);
+        return entryLog.getV1EntryProof(entryNumber, totalEntries);
     }
 
     @GET
-    @Path("/consistency/{total-entries-1}/{total-entries-2}/merkle:sha-256")
+    @Path("/consistency/{total-entries-1}/{total-entries-2}")
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public ConsistencyProof consistencyProof(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) {
         validateConsistencyProofParams(totalEntries1, totalEntries2);
-        return register.getConsistencyProof(totalEntries1, totalEntries2);
+        return entryLog.getV1ConsistencyProof(totalEntries1, totalEntries2);
     }
 
     private void validateEntryProofParams(int entryNumber, int totalEntries) {
         if (entryNumber < 1 ||
                 entryNumber > totalEntries ||
-                totalEntries > register.getTotalEntries(EntryType.user)) {
+                totalEntries > entryLog.getTotalEntries(EntryType.user)) {
             throw new BadRequestException("Invalid parameters");
         }
     }
@@ -71,7 +61,7 @@ public class VerifiableLogResource {
     private void validateConsistencyProofParams(int totalEntries1, int totalEntries2) {
         if (totalEntries1 < 1 ||
                 totalEntries1 > totalEntries2 ||
-                totalEntries2 > register.getTotalEntries(EntryType.user)) {
+                totalEntries2 > entryLog.getTotalEntries(EntryType.user)) {
             throw new BadRequestException("Invalid parameters");
         }
     }

--- a/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
@@ -3,6 +3,8 @@ package uk.gov.register.resources.v2;
 import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.EntryLog;
 import uk.gov.register.core.EntryType;
+import uk.gov.register.core.RegisterContext;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
@@ -18,10 +20,12 @@ import javax.ws.rs.core.MediaType;
 @Path("/next/proof")
 public class VerifiableLogResource {
     private final EntryLog entryLog;
+    private final RegisterContext registerContext;
 
     @Inject
-    public VerifiableLogResource(EntryLog entryLog) {
-        this.entryLog = entryLog;
+    public VerifiableLogResource(RegisterContext registerContext) {
+        this.registerContext = registerContext;
+        this.entryLog = registerContext.buildEntryLog();
     }
 
     @GET
@@ -29,7 +33,10 @@ public class VerifiableLogResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public RegisterProof registerProof() {
-        return entryLog.getV1RegisterProof();
+        return registerContext.withVerifiableLog(verifiableLog -> {
+            int totalEntries = entryLog.getTotalEntries(EntryType.user);
+            return new ProofGenerator(verifiableLog).getRegisterProof(totalEntries);
+        });
     }
 
     @GET
@@ -38,7 +45,7 @@ public class VerifiableLogResource {
     @Timed
     public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) {
         validateEntryProofParams(entryNumber, totalEntries);
-        return entryLog.getV1EntryProof(entryNumber, totalEntries);
+        return registerContext.withVerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getEntryProof(entryNumber, totalEntries));
     }
 
     @GET
@@ -47,7 +54,7 @@ public class VerifiableLogResource {
     @Timed
     public ConsistencyProof consistencyProof(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) {
         validateConsistencyProofParams(totalEntries1, totalEntries2);
-        return entryLog.getV1ConsistencyProof(totalEntries1, totalEntries2);
+        return registerContext.withVerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getConsistencyProof(totalEntries1, totalEntries2));
     }
 
     private void validateEntryProofParams(int entryNumber, int totalEntries) {
@@ -65,4 +72,6 @@ public class VerifiableLogResource {
             throw new BadRequestException("Invalid parameters");
         }
     }
+
+
 }

--- a/src/main/java/uk/gov/register/serialization/RSFCreator.java
+++ b/src/main/java/uk/gov/register/serialization/RSFCreator.java
@@ -27,7 +27,7 @@ public class RSFCreator {
                 register.getItemIterator(EntryType.user),
                 register.getEntryIterator(EntryType.system),
                 register.getEntryIterator(EntryType.user),
-                Iterators.singletonIterator(register.getRegisterProof().getRootHash()));
+                Iterators.singletonIterator(register.getV1RegisterProof().getRootHash()));
 
         Iterator<RegisterCommand> commands = Iterators.transform(iterators, obj -> (RegisterCommand) getMapper(obj.getClass()).apply(obj));
         return new RegisterSerialisationFormat(commands);
@@ -37,11 +37,11 @@ public class RSFCreator {
         Iterator<?> iterators;
 
         if (totalEntries1 > 0 && totalEntries1 == totalEntries2) {
-            iterators = Iterators.singletonIterator(register.getRegisterProof(totalEntries1).getRootHash());
+            iterators = Iterators.singletonIterator(register.getV1RegisterProof(totalEntries1).getRootHash());
         } else {
 
-            HashValue previousRootHash = totalEntries1 == 0 ? EMPTY_ROOT_HASH : register.getRegisterProof(totalEntries1).getRootHash();
-            HashValue nextRootHash = register.getRegisterProof(totalEntries2).getRootHash();
+            HashValue previousRootHash = totalEntries1 == 0 ? EMPTY_ROOT_HASH : register.getV1RegisterProof(totalEntries1).getRootHash();
+            HashValue nextRootHash = register.getV1RegisterProof(totalEntries2).getRootHash();
             Iterator<Item> metadataItemIterator = totalEntries1 == 0 ? register.getItemIterator(EntryType.system) : Collections.emptyIterator();
             Iterator<Entry> metadataEntryIterator = totalEntries1 == 0 ? register.getEntryIterator(EntryType.system) : Collections.emptyIterator();
 

--- a/src/main/java/uk/gov/register/serialization/RSFCreator.java
+++ b/src/main/java/uk/gov/register/serialization/RSFCreator.java
@@ -6,6 +6,7 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.util.HashValue;
 
 import java.util.*;
@@ -20,28 +21,28 @@ public class RSFCreator {
         this.registeredMappers = new HashMap<>();
     }
 
-    public RegisterSerialisationFormat create(Register register) {
+    public RegisterSerialisationFormat create(Register register, ProofGenerator proofGenerator) {
         Iterator<?> iterators = Iterators.concat(
                 Iterators.singletonIterator(EMPTY_ROOT_HASH),
                 register.getItemIterator(EntryType.system),
                 register.getItemIterator(EntryType.user),
                 register.getEntryIterator(EntryType.system),
                 register.getEntryIterator(EntryType.user),
-                Iterators.singletonIterator(register.getV1RegisterProof().getRootHash()));
+                Iterators.singletonIterator(proofGenerator.getRootHash()));
 
         Iterator<RegisterCommand> commands = Iterators.transform(iterators, obj -> (RegisterCommand) getMapper(obj.getClass()).apply(obj));
         return new RegisterSerialisationFormat(commands);
     }
 
-    public RegisterSerialisationFormat create(Register register, int totalEntries1, int totalEntries2) {
+    public RegisterSerialisationFormat create(Register register, ProofGenerator proofGenerator, int totalEntries1, int totalEntries2) {
         Iterator<?> iterators;
 
         if (totalEntries1 > 0 && totalEntries1 == totalEntries2) {
-            iterators = Iterators.singletonIterator(register.getV1RegisterProof(totalEntries1).getRootHash());
+            iterators = Iterators.singletonIterator(proofGenerator.getRootHash(totalEntries1));
         } else {
 
-            HashValue previousRootHash = totalEntries1 == 0 ? EMPTY_ROOT_HASH : register.getV1RegisterProof(totalEntries1).getRootHash();
-            HashValue nextRootHash = register.getV1RegisterProof(totalEntries2).getRootHash();
+            HashValue previousRootHash = totalEntries1 == 0 ? EMPTY_ROOT_HASH : proofGenerator.getRootHash(totalEntries1);
+            HashValue nextRootHash = proofGenerator.getRootHash(totalEntries2);
             Iterator<Item> metadataItemIterator = totalEntries1 == 0 ? register.getItemIterator(EntryType.system) : Collections.emptyIterator();
             Iterator<Entry> metadataEntryIterator = totalEntries1 == 0 ? register.getEntryIterator(EntryType.system) : Collections.emptyIterator();
 

--- a/src/main/java/uk/gov/register/serialization/RSFExecutor.java
+++ b/src/main/java/uk/gov/register/serialization/RSFExecutor.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.util.HashValue;
 
 import java.nio.charset.StandardCharsets;
@@ -27,7 +28,7 @@ public class RSFExecutor {
         registeredHandlers.put(registerCommandHandler.getCommandName(), registerCommandHandler);
     }
 
-    public void execute(RegisterSerialisationFormat rsf, Register register) throws RSFParseException {
+    public void execute(RegisterSerialisationFormat rsf, Register register, ProofGenerator proofGenerator) throws RSFParseException {
         // HashValue and RSF file line number
         Map<HashValue, Integer> hashRefLine = new HashMap<>();
         Iterator<RegisterCommand> commands = rsf.getCommands();
@@ -36,7 +37,7 @@ public class RSFExecutor {
             RegisterCommand command = commands.next();
 
             validate(command, register, rsfLine, hashRefLine);
-            execute(command, register);
+            execute(command, register, proofGenerator);
 
             rsfLine++;
         }
@@ -44,10 +45,10 @@ public class RSFExecutor {
         validateOrphanAddItems(hashRefLine);
     }
 
-    private void execute(RegisterCommand command, Register register) throws RSFParseException {
+    private void execute(RegisterCommand command, Register register, ProofGenerator proofGenerator) throws RSFParseException {
         if (registeredHandlers.containsKey(command.getCommandName())) {
             RegisterCommandHandler registerCommandHandler = registeredHandlers.get(command.getCommandName());
-            registerCommandHandler.execute(command, register);
+            registerCommandHandler.execute(command, register, proofGenerator);
         } else {
             throw new RSFParseException("Handler not registered for command: " + command.getCommandName());
         }

--- a/src/main/java/uk/gov/register/serialization/RegisterCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/RegisterCommandHandler.java
@@ -2,15 +2,16 @@ package uk.gov.register.serialization;
 
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 
 public abstract class RegisterCommandHandler {
-    protected abstract void executeCommand(RegisterCommand command, Register register);
+    protected abstract void executeCommand(RegisterCommand command, Register register, ProofGenerator proofGenerator);
 
     public abstract String getCommandName();
 
-    public void execute(RegisterCommand command, Register register) {
+    public void execute(RegisterCommand command, Register register, ProofGenerator proofGenerator) {
         if (command.getCommandName().equals(getCommandName())) {
-            executeCommand(command, register);
+            executeCommand(command, register, proofGenerator);
         } else {
             throw new RSFParseException("Incompatible handler (" + getCommandName() + ") and command type (" + command.getCommandName() + ")");
         }

--- a/src/main/java/uk/gov/register/serialization/handlers/AddItemCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AddItemCommandHandler.java
@@ -18,7 +18,7 @@ public class AddItemCommandHandler extends RegisterCommandHandler {
     }
 
     @Override
-    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator _proofGenerator) {
+    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator proofGenerator) {
         try {
             String jsonContent = command.getCommandArguments().get(RSFFormatter.RSF_ITEM_ARGUMENT_POSITION);
             Item item = new Item(objectReconstructor.reconstruct(jsonContent));

--- a/src/main/java/uk/gov/register/serialization/handlers/AddItemCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AddItemCommandHandler.java
@@ -3,6 +3,7 @@ package uk.gov.register.serialization.handlers;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RSFFormatter;
 import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.serialization.RegisterCommand;
@@ -17,7 +18,7 @@ public class AddItemCommandHandler extends RegisterCommandHandler {
     }
 
     @Override
-    protected void executeCommand(RegisterCommand command, Register register) {
+    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator _proofGenerator) {
         try {
             String jsonContent = command.getCommandArguments().get(RSFFormatter.RSF_ITEM_ARGUMENT_POSITION);
             Item item = new Item(objectReconstructor.reconstruct(jsonContent));

--- a/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
@@ -5,6 +5,7 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RSFFormatter;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.serialization.RegisterCommandHandler;
@@ -17,7 +18,7 @@ import static uk.gov.register.core.HashingAlgorithm.SHA256;
 
 public class AppendEntryCommandHandler extends RegisterCommandHandler {
     @Override
-    protected void executeCommand(RegisterCommand command, Register register) {
+    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator proofGenerator) {
         try {
             List<String> parts = command.getCommandArguments();
             HashValue itemHash = HashValue.decode(SHA256, parts.get(RSFFormatter.RSF_HASH_POSITION));

--- a/src/main/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandler.java
@@ -4,6 +4,7 @@ import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.AssertRootHashException;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RSFFormatter;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.serialization.RegisterCommandHandler;
@@ -12,10 +13,10 @@ import uk.gov.register.util.HashValue;
 
 public class AssertRootHashCommandHandler extends RegisterCommandHandler {
     @Override
-    protected void executeCommand(RegisterCommand command, Register register) {
+    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator proofGenerator) {
         try {
             HashValue expectedHash = HashValue.decode(HashingAlgorithm.SHA256, command.getCommandArguments().get(RSFFormatter.RSF_ASSERT_ROOT_HASH_ARGUMENT_POSITION));
-            HashValue actualHash = register.getV1RegisterProof().getRootHash();
+            HashValue actualHash = proofGenerator.getRootHash();
             if (!actualHash.equals(expectedHash)) {
                 throw new AssertRootHashException(expectedHash, actualHash);
             }

--- a/src/main/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandler.java
@@ -15,7 +15,7 @@ public class AssertRootHashCommandHandler extends RegisterCommandHandler {
     protected void executeCommand(RegisterCommand command, Register register) {
         try {
             HashValue expectedHash = HashValue.decode(HashingAlgorithm.SHA256, command.getCommandArguments().get(RSFFormatter.RSF_ASSERT_ROOT_HASH_ARGUMENT_POSITION));
-            HashValue actualHash = register.getRegisterProof().getRootHash();
+            HashValue actualHash = register.getV1RegisterProof().getRootHash();
             if (!actualHash.equals(expectedHash)) {
                 throw new AssertRootHashException(expectedHash, actualHash);
             }

--- a/src/main/java/uk/gov/register/store/DataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/DataAccessLayer.java
@@ -4,7 +4,7 @@ import uk.gov.register.core.Entry;
 import uk.gov.register.core.EntryType;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
-import uk.gov.register.db.EntryIterator;
+import uk.gov.register.proofs.EntryIterator;
 import uk.gov.register.exceptions.IndexingException;
 import uk.gov.register.util.HashValue;
 

--- a/src/main/java/uk/gov/register/store/postgres/BatchedPostgresDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/BatchedPostgresDataAccessLayer.java
@@ -2,7 +2,7 @@ package uk.gov.register.store.postgres;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.register.core.*;
-import uk.gov.register.db.*;
+import uk.gov.register.proofs.EntryIterator;
 import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.util.HashValue;
 

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDataAccessLayer.java
@@ -5,7 +5,7 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
 import uk.gov.register.db.EntryDAO;
-import uk.gov.register.db.EntryIterator;
+import uk.gov.register.proofs.EntryIterator;
 import uk.gov.register.db.EntryQueryDAO;
 import uk.gov.register.db.ItemDAO;
 import uk.gov.register.db.ItemQueryDAO;

--- a/src/test/java/uk/gov/register/db/EntryMerkleLeafStoreTest.java
+++ b/src/test/java/uk/gov/register/db/EntryMerkleLeafStoreTest.java
@@ -1,0 +1,44 @@
+package uk.gov.register.db;
+
+import org.junit.Test;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.EntryType;
+import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.util.HashValue;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EntryMerkleLeafStoreTest {
+    @Test
+    public void testEntryMerkleLeafStoreComputesObjecthash() {
+        Entry entry = new Entry(
+                6,
+                new HashValue(HashingAlgorithm.SHA256, "v1Hash"),
+                new HashValue(HashingAlgorithm.SHA256, "6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb"),
+                OffsetDateTime.of(2016,4,5,13, 23, 5, 0, ZoneOffset.UTC).toInstant(),
+                "GB",
+                EntryType.user
+        );
+        EntryIterator entryIterator = mock(EntryIterator.class);
+        when(entryIterator.findByEntryNumber(1)).thenReturn(entry);
+        EntryMerkleLeafStore store = new EntryMerkleLeafStore(entryIterator);
+
+        byte[] value = store.getLeafValue(0);
+        String valueHex = bytesToHex(value);
+
+        assertEquals("34e124de59e73cb802474faba5b5434983eaeef902d6ec24e3421ebb78bf2c69", valueHex);
+    }
+
+    private String bytesToHex(byte[] value) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : value) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/uk/gov/register/db/EntryMerkleLeafStoreTest.java
+++ b/src/test/java/uk/gov/register/db/EntryMerkleLeafStoreTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.EntryType;
 import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.proofs.EntryIterator;
+import uk.gov.register.proofs.EntryMerkleLeafStore;
 import uk.gov.register.util.HashValue;
 
 import java.time.OffsetDateTime;

--- a/src/test/java/uk/gov/register/functional/db/EntryIteratorFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/db/EntryIteratorFunctionalTest.java
@@ -3,7 +3,7 @@ package uk.gov.register.functional.db;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import uk.gov.register.db.EntryIterator;
+import uk.gov.register.proofs.EntryIterator;
 import uk.gov.register.db.EntryQueryDAO;
 import uk.gov.register.functional.app.RegisterRule;
 import uk.gov.register.functional.app.RsfRegisterDefinition;

--- a/src/test/java/uk/gov/register/functional/store/postgres/RegisterImplTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/RegisterImplTransactionalFunctionalTest.java
@@ -47,7 +47,6 @@ import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.store.postgres.BatchedPostgresDataAccessLayer;
 import uk.gov.register.store.postgres.PostgresDataAccessLayer;
 import uk.gov.register.util.HashValue;
-import uk.gov.verifiablelog.store.memoization.DoNothing;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -231,7 +230,7 @@ public class RegisterImplTransactionalFunctionalTest {
     }
 
     private RegisterImpl getPostgresRegister(DataAccessLayer dataAccessLayer) {
-        EntryLog entryLog = new EntryLogImpl(dataAccessLayer, new DoNothing());
+        EntryLog entryLog = new EntryLogImpl(dataAccessLayer);
         ItemValidator itemValidator = mock(ItemValidator.class);
         ItemStore itemStore = new ItemStoreImpl(dataAccessLayer);
         RegisterId registerId = new RegisterId("address");

--- a/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
@@ -2,6 +2,7 @@ package uk.gov.register.resources;
 
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
+import uk.gov.register.core.EntryLog;
 import uk.gov.register.core.EntryType;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.RegisterReadOnly;
@@ -26,13 +27,13 @@ public class VerifiableLogResourceTest {
     @Test
     public void shouldUseServiceToGetRegisterProof() {
         RegisterProof expectedProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, sampleHash1), 12345);
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getRegisterProof()).thenReturn(expectedProof);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getV1RegisterProof()).thenReturn(expectedProof);
 
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
         RegisterProof actualProof = vlResource.registerProof();
 
-        verify(registerMock, times(1)).getRegisterProof();
+        verify(entryLogMock, times(1)).getV1RegisterProof();
         assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
         assertThat(actualProof.getRootHash(), equalTo(expectedProof.getRootHash()));
     }
@@ -46,14 +47,14 @@ public class VerifiableLogResourceTest {
         List<HashValue> expectedAuditPath = Arrays.asList(expectedHash1, expectedHash2);
 
         EntryProof expectedProof = new EntryProof("3", expectedAuditPath);
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        when(registerMock.getEntryProof(entryNumber, totalEntries)).thenReturn(expectedProof);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        when(entryLogMock.getV1EntryProof(entryNumber, totalEntries)).thenReturn(expectedProof);
 
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
         EntryProof actualProof = vlResource.entryProof(entryNumber, totalEntries);
 
-        verify(registerMock, times(1)).getEntryProof(entryNumber, totalEntries);
+        verify(entryLogMock, times(1)).getV1EntryProof(entryNumber, totalEntries);
         assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
         assertThat(actualProof.getEntryNumber(), equalTo(expectedProof.getEntryNumber()));
         assertThat(actualProof.getAuditPath(), IsIterableContainingInOrder.contains(expectedHash1, expectedHash2));
@@ -68,14 +69,14 @@ public class VerifiableLogResourceTest {
         List<HashValue> expectedConsistencyNodes = Arrays.asList(expectedHash1, expectedHash2);
 
         ConsistencyProof expectedProof = new ConsistencyProof(expectedConsistencyNodes);
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        when(registerMock.getConsistencyProof(totalEntries1, totalEntries2)).thenReturn(expectedProof);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        when(entryLogMock.getV1ConsistencyProof(totalEntries1, totalEntries2)).thenReturn(expectedProof);
 
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
         ConsistencyProof actualProof = vlResource.consistencyProof(totalEntries1, totalEntries2);
 
-        verify(registerMock, times(1)).getConsistencyProof(totalEntries1, totalEntries2);
+        verify(entryLogMock, times(1)).getV1ConsistencyProof(totalEntries1, totalEntries2);
         assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
 
         assertThat(actualProof.getConsistencyNodes(), IsIterableContainingInOrder.contains(expectedHash1, expectedHash2));
@@ -83,54 +84,54 @@ public class VerifiableLogResourceTest {
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfEntryNumberTooSmall() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.entryProof(0, 5);
     }
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfEntryNumberGreaterThanTotalEntries() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.entryProof(5, 3);
     }
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfTotalEntriesGreaterThanSizeOfRegister() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.entryProof(5, 10);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries1TooSmall() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.consistencyProof(0, 5);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofshouldThrowBadRequestExceptionIfTotalEntries2SmallerThanTotalEntries1() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.consistencyProof(5, 3);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries2GreaterThanSizeOfRegister() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.consistencyProof(5, 10);
     }

--- a/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
@@ -1,139 +1,71 @@
 package uk.gov.register.resources;
 
-import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.register.core.EntryLog;
 import uk.gov.register.core.EntryType;
-import uk.gov.register.core.HashingAlgorithm;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.RegisterContext;
 import uk.gov.register.resources.v2.VerifiableLogResource;
-import uk.gov.register.util.HashValue;
-import uk.gov.register.views.ConsistencyProof;
-import uk.gov.register.views.EntryProof;
-import uk.gov.register.views.RegisterProof;
 
 import javax.ws.rs.BadRequestException;
-import java.util.Arrays;
-import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class VerifiableLogResourceTest {
     private final String sampleHash1 = "6b85b168f7c5f0587fc22ff4ba6937e61b33f6e89b70eed53d78d895d35dc9c3";
     private final String sampleHash2 = "d3d33f57b033d18ad11e14b28ef6f33487410c98548d1759c772370dfeb6db11";
 
-    @Test
-    public void shouldUseServiceToGetRegisterProof() {
-        RegisterProof expectedProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, sampleHash1), 12345);
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getV1RegisterProof()).thenReturn(expectedProof);
+    @Mock
+    private RegisterContext registerContext;
 
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-        RegisterProof actualProof = vlResource.registerProof();
+    @Mock
+    private EntryLog entryLog;
 
-        verify(entryLogMock, times(1)).getV1RegisterProof();
-        assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
-        assertThat(actualProof.getRootHash(), equalTo(expectedProof.getRootHash()));
-    }
+    private VerifiableLogResource resource;
 
-    @Test
-    public void shouldUseServiceToGetEntryProof() {
-        int entryNumber = 2;
-        int totalEntries = 5;
-        HashValue expectedHash1 = new HashValue(HashingAlgorithm.SHA256, sampleHash1);
-        HashValue expectedHash2 = new HashValue(HashingAlgorithm.SHA256, sampleHash2);
-        List<HashValue> expectedAuditPath = Arrays.asList(expectedHash1, expectedHash2);
+    @Before
+    public void setUp() {
+        when(registerContext.buildEntryLog()).thenReturn(entryLog);
 
-        EntryProof expectedProof = new EntryProof("3", expectedAuditPath);
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        when(entryLogMock.getV1EntryProof(entryNumber, totalEntries)).thenReturn(expectedProof);
-
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-        EntryProof actualProof = vlResource.entryProof(entryNumber, totalEntries);
-
-        verify(entryLogMock, times(1)).getV1EntryProof(entryNumber, totalEntries);
-        assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
-        assertThat(actualProof.getEntryNumber(), equalTo(expectedProof.getEntryNumber()));
-        assertThat(actualProof.getAuditPath(), IsIterableContainingInOrder.contains(expectedHash1, expectedHash2));
-    }
-
-    @Test
-    public void shouldUseServiceToGetConsistencyProof() {
-        int totalEntries1 = 3;
-        int totalEntries2 = 6;
-        HashValue expectedHash1 = new HashValue(HashingAlgorithm.SHA256, sampleHash1);
-        HashValue expectedHash2 = new HashValue(HashingAlgorithm.SHA256, sampleHash2);
-        List<HashValue> expectedConsistencyNodes = Arrays.asList(expectedHash1, expectedHash2);
-
-        ConsistencyProof expectedProof = new ConsistencyProof(expectedConsistencyNodes);
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        when(entryLogMock.getV1ConsistencyProof(totalEntries1, totalEntries2)).thenReturn(expectedProof);
-
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-        ConsistencyProof actualProof = vlResource.consistencyProof(totalEntries1, totalEntries2);
-
-        verify(entryLogMock, times(1)).getV1ConsistencyProof(totalEntries1, totalEntries2);
-        assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
-
-        assertThat(actualProof.getConsistencyNodes(), IsIterableContainingInOrder.contains(expectedHash1, expectedHash2));
+        resource = new VerifiableLogResource(registerContext);
     }
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfEntryNumberTooSmall() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-
-        vlResource.entryProof(0, 5);
+        resource.entryProof(0, 5);
     }
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfEntryNumberGreaterThanTotalEntries() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-
-        vlResource.entryProof(5, 3);
+        resource.entryProof(5, 3);
     }
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfTotalEntriesGreaterThanSizeOfRegister() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
+        when(entryLog.getTotalEntries(EntryType.user)).thenReturn(8);
 
-        vlResource.entryProof(5, 10);
+        resource.entryProof(5, 10);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries1TooSmall() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-
-        vlResource.consistencyProof(0, 5);
+        resource.consistencyProof(0, 5);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofshouldThrowBadRequestExceptionIfTotalEntries2SmallerThanTotalEntries1() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-
-        vlResource.consistencyProof(5, 3);
+        resource.consistencyProof(5, 3);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries2GreaterThanSizeOfRegister() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
+        when(entryLog.getTotalEntries(EntryType.user)).thenReturn(8);
 
-        vlResource.consistencyProof(5, 10);
+        resource.consistencyProof(5, 10);
     }
 }
 

--- a/src/test/java/uk/gov/register/resources/v1/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/v1/VerifiableLogResourceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v1;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,9 +16,6 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VerifiableLogResourceTest {
-    private final String sampleHash1 = "6b85b168f7c5f0587fc22ff4ba6937e61b33f6e89b70eed53d78d895d35dc9c3";
-    private final String sampleHash2 = "d3d33f57b033d18ad11e14b28ef6f33487410c98548d1759c772370dfeb6db11";
-
     @Mock
     private RegisterContext registerContext;
 

--- a/src/test/java/uk/gov/register/resources/v2/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/v2/VerifiableLogResourceTest.java
@@ -1,0 +1,69 @@
+package uk.gov.register.resources.v2;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.register.core.EntryLog;
+import uk.gov.register.core.EntryType;
+import uk.gov.register.core.RegisterContext;
+import uk.gov.register.views.RegisterProof;
+
+import javax.ws.rs.BadRequestException;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VerifiableLogResourceTest {
+    @Mock
+    private RegisterContext registerContext;
+
+    @Mock
+    private EntryLog entryLog;
+
+    private VerifiableLogResource resource;
+
+    @Before
+    public void setUp() {
+        when(registerContext.buildEntryLog()).thenReturn(entryLog);
+
+        resource = new VerifiableLogResource(registerContext);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void entryProofShouldThrowBadRequestExceptionIfEntryNumberTooSmall() {
+        resource.entryProof(0, 5);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void entryProofShouldThrowBadRequestExceptionIfEntryNumberGreaterThanTotalEntries() {
+        resource.entryProof(5, 3);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void entryProofShouldThrowBadRequestExceptionIfTotalEntriesGreaterThanSizeOfRegister() {
+        when(entryLog.getTotalEntries(EntryType.user)).thenReturn(8);
+
+        resource.entryProof(5, 10);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries1TooSmall() {
+        resource.consistencyProof(0, 5);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void consistencyProofshouldThrowBadRequestExceptionIfTotalEntries2SmallerThanTotalEntries1() {
+        resource.consistencyProof(5, 3);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries2GreaterThanSizeOfRegister() {
+        when(entryLog.getTotalEntries(EntryType.user)).thenReturn(8);
+
+        resource.consistencyProof(5, 10);
+    }
+}
+

--- a/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.register.core.*;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.mappers.EntryToCommandMapper;
 import uk.gov.register.serialization.mappers.ItemToCommandMapper;
 import uk.gov.register.serialization.mappers.RootHashCommandMapper;
@@ -40,6 +41,9 @@ public class RSFCreatorTest {
 
     @Mock
     private Register register;
+
+    @Mock
+    private ProofGenerator proofGenerator;
 
     private Entry systemEntry;
     private Entry entry1;
@@ -94,15 +98,10 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.system)).thenReturn(Arrays.asList(systemEntry).iterator());
         when(register.getEntryIterator(EntryType.user)).thenReturn(Arrays.asList(entry1, entry2).iterator());
 
-        RegisterProof expectedRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "1231234"), 46464);
-        when(register.getV1RegisterProof()).thenReturn(expectedRegisterProof);
+        when(proofGenerator.getRootHash()).thenReturn(new HashValue(HashingAlgorithm.SHA256, "1231234"));
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register);
+        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
-
-        verify(register, times(1)).getItemIterator(EntryType.user);
-        verify(register, times(1)).getEntryIterator(EntryType.user);
-        verify(register, times(1)).getV1RegisterProof();
 
         assertThat(actualCommands.size(), equalTo(8));
         assertThat(actualCommands, contains(
@@ -119,15 +118,15 @@ public class RSFCreatorTest {
 
     @Test
     public void createRegisterSerialisationFormat_whenCalledWithBoundary_returnsPartialRSFRegister() {
-        RegisterProof oneEntryRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "oneEntryInRegisterHash"), 1);
-        RegisterProof twoEntriesRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash"), 2);
+        HashValue oneEntryRootHash = new HashValue(HashingAlgorithm.SHA256, "oneEntryInRegisterHash");
+        HashValue twoEntriesRootHash = new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash");
 
         when(register.getItemIterator(1, 2)).thenReturn(Collections.singletonList(item1).iterator());
         when(register.getEntryIterator(1, 2)).thenReturn(Collections.singletonList(entry1).iterator());
-        when(register.getV1RegisterProof(1)).thenReturn(oneEntryRegisterProof);
-        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
+        when(proofGenerator.getRootHash(1)).thenReturn(oneEntryRootHash);
+        when(proofGenerator.getRootHash(2)).thenReturn(twoEntriesRootHash);
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, 1, 2);
+        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 1, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         verify(register, never()).getItemIterator(EntryType.system);
@@ -137,25 +136,25 @@ public class RSFCreatorTest {
 
         assertThat(actualCommands.size(), equalTo(4));
         assertThat(actualCommands, contains(
-                new RegisterCommand("assert-root-hash", Collections.singletonList(oneEntryRegisterProof.getRootHash().encode())),
+                new RegisterCommand("assert-root-hash", Collections.singletonList(oneEntryRootHash.encode())),
                 addItem1Command,
                 appendEntry1Command,
-                new RegisterCommand("assert-root-hash", Collections.singletonList(twoEntriesRegisterProof.getRootHash().encode()))
+                new RegisterCommand("assert-root-hash", Collections.singletonList(twoEntriesRootHash.encode()))
         ));
     }
 
     @Test
     public void createRegisterSerialisationFormat_whenStartIsZero_returnsSystemEntries() {
-        RegisterProof twoEntriesRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash"), 2);
+        HashValue rootHash = new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash");
 
         when(register.getItemIterator(EntryType.system)).thenReturn(Arrays.asList(systemItem).iterator());
         when(register.getItemIterator(0, 2)).thenReturn(Arrays.asList(item1, item2).iterator());
         when(register.getEntryIterator(EntryType.system)).thenReturn(Arrays.asList(systemEntry).iterator());
         when(register.getEntryIterator(0, 2)).thenReturn(Arrays.asList(entry1, entry2).iterator());
 
-        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
+        when(proofGenerator.getRootHash(2)).thenReturn(rootHash);
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, 0, 2);
+        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 0, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         assertThat(actualCommands.size(), equalTo(8));
@@ -167,7 +166,7 @@ public class RSFCreatorTest {
                 appendSystemEntryCommand,
                 appendEntry1Command,
                 appendEntry2Command,
-                new RegisterCommand("assert-root-hash", Collections.singletonList(twoEntriesRegisterProof.getRootHash().encode()))
+                new RegisterCommand("assert-root-hash", Collections.singletonList(rootHash.encode()))
         ));
     }
 
@@ -178,29 +177,27 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.user)).thenReturn(Arrays.asList(entry1, entry2).iterator());
         when(register.getItemIterator(EntryType.system)).thenReturn(Arrays.asList(systemItem).iterator());
 
-        RegisterProof expectedRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "1231234"), 28828);
-        when(register.getV1RegisterProof()).thenReturn(expectedRegisterProof);
+        when(proofGenerator.getRootHash()).thenReturn(new HashValue(HashingAlgorithm.SHA256, "1231234"));
 
         expectedException.expect(RuntimeException.class);
         expectedException.expectMessage("Mapper not registered for class: uk.gov.register.util.HashValue");
 
         RSFCreator creatorWithoutMappers = new RSFCreator();
-        RegisterSerialisationFormat rsf = creatorWithoutMappers.create(register);
+        RegisterSerialisationFormat rsf = creatorWithoutMappers.create(register, proofGenerator);
         IteratorUtils.toList(rsf.getCommands());
     }
 
     @Test
     public void createRegisterSerialisationFormat_whenParametersEqual_returnsOnlyRootHash() {
-        RegisterProof twoEntriesRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash"), 2);
+        HashValue rootHash = new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash");
+        when(proofGenerator.getRootHash(2)).thenReturn(rootHash);
 
-        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
-
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, 2, 2);
+        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 2, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         assertThat(actualCommands.size(), equalTo(1));
         assertThat(actualCommands, contains(
-                new RegisterCommand("assert-root-hash", Collections.singletonList(twoEntriesRegisterProof.getRootHash().encode()))
+                new RegisterCommand("assert-root-hash", Collections.singletonList(rootHash.encode()))
         ));
     }
 
@@ -211,9 +208,9 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.system)).thenReturn(Arrays.asList(systemEntry).iterator());
         when(register.getEntryIterator(0, 0)).thenReturn(Collections.emptyIterator());
 
-        when(register.getV1RegisterProof(0)).thenReturn(new RegisterProof(emptyRegisterHash, 0));
+        when(proofGenerator.getRootHash(0)).thenReturn(emptyRegisterHash);
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, 0, 0);
+        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 0, 0);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         assertThat(actualCommands.size(), equalTo(4));

--- a/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
@@ -95,14 +95,14 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.user)).thenReturn(Arrays.asList(entry1, entry2).iterator());
 
         RegisterProof expectedRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "1231234"), 46464);
-        when(register.getRegisterProof()).thenReturn(expectedRegisterProof);
+        when(register.getV1RegisterProof()).thenReturn(expectedRegisterProof);
 
         RegisterSerialisationFormat actualRSF = sutCreator.create(register);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         verify(register, times(1)).getItemIterator(EntryType.user);
         verify(register, times(1)).getEntryIterator(EntryType.user);
-        verify(register, times(1)).getRegisterProof();
+        verify(register, times(1)).getV1RegisterProof();
 
         assertThat(actualCommands.size(), equalTo(8));
         assertThat(actualCommands, contains(
@@ -124,8 +124,8 @@ public class RSFCreatorTest {
 
         when(register.getItemIterator(1, 2)).thenReturn(Collections.singletonList(item1).iterator());
         when(register.getEntryIterator(1, 2)).thenReturn(Collections.singletonList(entry1).iterator());
-        when(register.getRegisterProof(1)).thenReturn(oneEntryRegisterProof);
-        when(register.getRegisterProof(2)).thenReturn(twoEntriesRegisterProof);
+        when(register.getV1RegisterProof(1)).thenReturn(oneEntryRegisterProof);
+        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
 
         RegisterSerialisationFormat actualRSF = sutCreator.create(register, 1, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
@@ -153,7 +153,7 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.system)).thenReturn(Arrays.asList(systemEntry).iterator());
         when(register.getEntryIterator(0, 2)).thenReturn(Arrays.asList(entry1, entry2).iterator());
 
-        when(register.getRegisterProof(2)).thenReturn(twoEntriesRegisterProof);
+        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
 
         RegisterSerialisationFormat actualRSF = sutCreator.create(register, 0, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
@@ -179,7 +179,7 @@ public class RSFCreatorTest {
         when(register.getItemIterator(EntryType.system)).thenReturn(Arrays.asList(systemItem).iterator());
 
         RegisterProof expectedRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "1231234"), 28828);
-        when(register.getRegisterProof()).thenReturn(expectedRegisterProof);
+        when(register.getV1RegisterProof()).thenReturn(expectedRegisterProof);
 
         expectedException.expect(RuntimeException.class);
         expectedException.expectMessage("Mapper not registered for class: uk.gov.register.util.HashValue");
@@ -193,7 +193,7 @@ public class RSFCreatorTest {
     public void createRegisterSerialisationFormat_whenParametersEqual_returnsOnlyRootHash() {
         RegisterProof twoEntriesRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash"), 2);
 
-        when(register.getRegisterProof(2)).thenReturn(twoEntriesRegisterProof);
+        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
 
         RegisterSerialisationFormat actualRSF = sutCreator.create(register, 2, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
@@ -211,7 +211,7 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.system)).thenReturn(Arrays.asList(systemEntry).iterator());
         when(register.getEntryIterator(0, 0)).thenReturn(Collections.emptyIterator());
 
-        when(register.getRegisterProof(0)).thenReturn(new RegisterProof(emptyRegisterHash, 0));
+        when(register.getV1RegisterProof(0)).thenReturn(new RegisterProof(emptyRegisterHash, 0));
 
         RegisterSerialisationFormat actualRSF = sutCreator.create(register, 0, 0);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());

--- a/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
@@ -12,6 +12,7 @@ import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.util.HashValue;
 
 import java.util.Optional;
@@ -43,6 +44,9 @@ public class RSFExecutorTest {
 
     @Mock
     private RegisterCommandHandler addItemHandler;
+
+    @Mock
+    private ProofGenerator proofGenerator;
 
     private Item item1;
 
@@ -95,16 +99,17 @@ public class RSFExecutorTest {
                 appendEntry2Command,
                 assertLastRootHashCommand).iterator());
 
-        sutExecutor.execute(rsf, register);
+
+        sutExecutor.execute(rsf, register, proofGenerator);
 
         InOrder inOrder = Mockito.inOrder(assertRootHashHandler, addItemHandler, appendEntryHandler);
-        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertEmptyRootHashCommand, register);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem1Command, register);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem2Command, register);
-        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry1Command, register);
-        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertMiddleRootHashCommand, register);
-        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry2Command, register);
-        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertLastRootHashCommand, register);
+        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertEmptyRootHashCommand, register, proofGenerator);
+        inOrder.verify(addItemHandler, calls(1)).execute(addItem1Command, register, proofGenerator);
+        inOrder.verify(addItemHandler, calls(1)).execute(addItem2Command, register, proofGenerator);
+        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry1Command, register, proofGenerator);
+        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertMiddleRootHashCommand, register, proofGenerator);
+        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry2Command, register, proofGenerator);
+        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertLastRootHashCommand, register, proofGenerator);
     }
 
     @Test (expected = RSFParseException.class)
@@ -127,7 +132,7 @@ public class RSFExecutorTest {
         when(register.getItemByV1Hash(entry1hashValue)).thenReturn(Optional.of(item1));
 
         RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(singletonList(appendEntry1Command).iterator());
-        sutExecutor.execute(rsf, register);
+        sutExecutor.execute(rsf, register, proofGenerator);
 
         verify(register, times(1)).getItemByV1Hash(entry1hashValue);
     }
@@ -175,10 +180,10 @@ public class RSFExecutorTest {
                 addItem1Command).iterator());
 
         try {
-            sutExecutor.execute(rsf, register);
+            sutExecutor.execute(rsf, register, proofGenerator);
         } catch (RSFParseException exception1) {
             try {
-                sutExecutor.execute(rsf2, register);
+                sutExecutor.execute(rsf2, register, proofGenerator);
             } catch (RSFParseException exception2) {
                 assertThat(exception1.getMessage(), equalTo(exception2.getMessage()));
                 throw exception2;
@@ -197,17 +202,17 @@ public class RSFExecutorTest {
                 asList("user", "entry1-field-1-value", "2016-07-24T16:55:00Z", itemHash1 + ";" + itemHash2));
 
         RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(asList(addItem1, addItem2, appendEntry).iterator());
-        sutExecutor.execute(rsf, register);
+        sutExecutor.execute(rsf, register, proofGenerator);
 
         InOrder inOrder = Mockito.inOrder(assertRootHashHandler, addItemHandler, appendEntryHandler);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem1, register);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem2, register);
-        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry, register);
+        inOrder.verify(addItemHandler, calls(1)).execute(addItem1, register, proofGenerator);
+        inOrder.verify(addItemHandler, calls(1)).execute(addItem2, register, proofGenerator);
+        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry, register, proofGenerator);
     }
 
     private void assertExceptionThrown(RegisterSerialisationFormat rsf, String exceptionMessage) throws RSFParseException {
         try {
-            sutExecutor.execute(rsf, register);
+            sutExecutor.execute(rsf, register, proofGenerator);
         } catch (RSFParseException exception) {
             assertThat(exception.getMessage(), startsWith(exceptionMessage));
             throw exception;

--- a/src/test/java/uk/gov/register/serialization/handlers/AddItemCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AddItemCommandHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.util.HashValue;
@@ -35,6 +36,9 @@ public class AddItemCommandHandlerTest {
     @Mock
     private Register register;
 
+    @Mock
+    private ProofGenerator proofGenerator;
+
     private RegisterCommand addItemCommand;
 
     @Before
@@ -50,7 +54,7 @@ public class AddItemCommandHandlerTest {
 
     @Test
     public void execute_addsItemToRegister() {
-        sutHandler.execute(addItemCommand, register);
+        sutHandler.execute(addItemCommand, register, proofGenerator);
 
         Item expectedItem = new Item(new HashValue(HashingAlgorithm.SHA256, "3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c"), new HashValue(HashingAlgorithm.SHA256, "bc7242dd795173a3632f3385b8ecd4f5b37a10130925b9c2aadfafbfc73a19c4"), jsonFactory.objectNode()
                 .put("field-1", "entry1-field-1-value")
@@ -84,7 +88,7 @@ public class AddItemCommandHandlerTest {
 
     private void assertExceptionThrown(RegisterCommand command, String exceptionMessage) throws RSFParseException {
         try {
-            sutHandler.execute(command, register);
+            sutHandler.execute(command, register, proofGenerator);
         } catch (RSFParseException exception) {
             assertThat(exception.getMessage(), startsWith(exceptionMessage));
             throw exception;

--- a/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
@@ -14,6 +14,7 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.util.HashValue;
 
@@ -41,6 +42,9 @@ public class AppendEntryCommandHandlerTest {
     @Mock
     private Register register;
 
+    @Mock
+    private ProofGenerator proofGenerator;
+
     private RegisterCommand appendEntryCommand;
     private Instant july24 = Instant.parse("2016-07-24T16:55:00Z");
 
@@ -64,7 +68,7 @@ public class AppendEntryCommandHandlerTest {
         when(item.getBlobHash()).thenReturn(new HashValue(SHA256, "blob-sha"));
         when(register.getItemByV1Hash(new HashValue(SHA256, "item-sha"))).thenReturn(Optional.of(item));
         when(register.getTotalEntries(EntryType.user)).thenReturn(2);
-        sutHandler.execute(appendEntryCommand, register);
+        sutHandler.execute(appendEntryCommand, register, proofGenerator);
         Entry expectedEntry = new Entry(3, new HashValue(SHA256, "item-sha"), new HashValue(SHA256, "blob-sha"), july24, "entry1-field-1-value", EntryType.user);
         verify(register, times(1)).appendEntry(expectedEntry);
     }
@@ -73,7 +77,7 @@ public class AppendEntryCommandHandlerTest {
     public void execute_appendsEntryToRegisterWithoutItemThrowsException() {
         expectedException.expect(RSFParseException.class);
         expectedException.expectMessage("Item not found for hash item-sha");
-        sutHandler.execute(appendEntryCommand, register);
+        sutHandler.execute(appendEntryCommand, register, proofGenerator);
     }
 
     @Test (expected = RSFParseException.class)
@@ -102,7 +106,7 @@ public class AppendEntryCommandHandlerTest {
 
     private void assertExceptionThrown(RegisterCommand command, String exceptionMessage) throws RSFParseException {
         try {
-            sutHandler.execute(command, register);
+            sutHandler.execute(command, register, proofGenerator);
         } catch (RSFParseException exception) {
             assertThat(exception.getMessage(), startsWith(exceptionMessage));
             throw exception;

--- a/src/test/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandlerTest.java
@@ -10,7 +10,6 @@ import org.mockito.stubbing.Answer;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
-import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.util.HashValue;
 import uk.gov.register.views.RegisterProof;
@@ -48,17 +47,17 @@ public class AssertRootHashCommandHandlerTest {
     @Test
     public void execute_obtainsAndAssertsRegisterProof() {
         RegisterProof registerProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "root-hash"), 123);
-        when(register.getRegisterProof()).thenReturn(registerProof);
+        when(register.getV1RegisterProof()).thenReturn(registerProof);
 
         sutHandler.execute(assertRootHashCommand, register);
 
-        verify(register, times(1)).getRegisterProof();
+        verify(register, times(1)).getV1RegisterProof();
     }
 
     @Test (expected = RSFParseException.class)
     public void execute_failsIfRootHashesDontMatch() {
         RegisterProof registerProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "different-hash"), 456);
-        when(register.getRegisterProof()).thenReturn(registerProof);
+        when(register.getV1RegisterProof()).thenReturn(registerProof);
 
         assertExceptionThrown(assertRootHashCommand, "Exception when executing command: RegisterCommand");
     }
@@ -69,7 +68,7 @@ public class AssertRootHashCommandHandlerTest {
             public Void answer(InvocationOnMock invocation) throws IOException {
                 throw new IOException("Forced exception");
             }
-        }).when(register).getRegisterProof();
+        }).when(register).getV1RegisterProof();
 
         assertExceptionThrown(assertRootHashCommand, "Exception when executing command: RegisterCommand");
     }

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -71,25 +71,24 @@ public class RegisterSerialisationFormatServiceTest {
 
         sutService.process(rsfInput);
 
-        verify(rsfExecutor, times(1)).execute(eq(rsfInput), any());
+        verify(rsfExecutor, times(1)).execute(eq(rsfInput), any(), any());
     }
 
     @Test
     public void writeTo_writesEntireRSFtoStream() {
-        when(rsfCreator.create(any())).thenReturn(
-                new RegisterSerialisationFormat(Iterators.forArray(
+        when(registerContext.withV1VerifiableLog(any())).thenReturn(
+                Iterators.forArray(
                         new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")),
                         new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}")),
                         new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}")),
                         new RegisterCommand("append-entry", Arrays.asList("user", "entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item1sha")),
                         new RegisterCommand("append-entry", Arrays.asList("user", "entry2-field-1-value", "2016-07-24T16:56:00Z", "sha-256:item2sha")),
-                        new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e")))));
+                        new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e"))));
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         sutService.writeTo(outputStream, rsfFormatter);
 
-        verify(rsfCreator, times(1)).create(any());
         String expectedRSF =
                 "assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n" +
                 "add-item\t{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}\n" +
@@ -104,7 +103,7 @@ public class RegisterSerialisationFormatServiceTest {
 
     @Test
     public void writeTo_whenCalledWithBoundary_writesPartialRSFtoStream() {
-        when(rsfCreator.create(any(), eq(1), eq(2))).thenReturn(
+        when(rsfCreator.create(any(), any(), eq(1), eq(2))).thenReturn(
                 new RegisterSerialisationFormat(Iterators.forArray(
                         new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e_uno")),
                         new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}")),
@@ -115,7 +114,7 @@ public class RegisterSerialisationFormatServiceTest {
 
         sutService.writeTo(outputStream, rsfFormatter, 1, 2);
 
-        verify(rsfCreator, times(1)).create(any(), eq(1), eq(2));
+        verify(rsfCreator, times(1)).create(any(), any(), eq(1), eq(2));
         String expectedRSF =
                 "assert-root-hash\tsha-256:K3rfuFF1e_uno\n" +
                 "add-item\t{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}\n" +

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -12,7 +12,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import uk.gov.register.core.Register;
 import uk.gov.register.core.RegisterContext;
-import uk.gov.register.serialization.*;
+import uk.gov.register.serialization.RSFCreator;
+import uk.gov.register.serialization.RSFExecutor;
+import uk.gov.register.serialization.RSFFormatter;
+import uk.gov.register.serialization.RegisterCommand;
+import uk.gov.register.serialization.RegisterSerialisationFormat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -23,12 +27,12 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RegisterSerialisationFormatServiceTest {
@@ -83,30 +87,6 @@ public class RegisterSerialisationFormatServiceTest {
                 "append-entry\tuser\tentry1-field-1-value\t2016-07-24T16:55:00Z\tsha-256:item1sha\n" +
                 "append-entry\tuser\tentry2-field-1-value\t2016-07-24T16:56:00Z\tsha-256:item2sha\n" +
                 "assert-root-hash\tsha-256:K3rfuFF1e\n";
-
-        String actualRSF = outputStream.toString();
-        assertThat(actualRSF, Matchers.equalTo(expectedRSF));
-    }
-
-    @Test
-    public void writeTo_whenCalledWithBoundary_writesPartialRSFtoStream() {
-        when(rsfCreator.create(any(), any(), eq(1), eq(2))).thenReturn(
-                new RegisterSerialisationFormat(Iterators.forArray(
-                        new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e_uno")),
-                        new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}")),
-                        new RegisterCommand("append-entry", Arrays.asList("user", "entry2-field-1-value", "2016-07-24T16:56:00Z", "sha-256:item2sha")),
-                        new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e_dos")))));
-
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-        sutService.writeTo(outputStream, rsfFormatter, 1, 2);
-
-        verify(rsfCreator, times(1)).create(any(), any(), eq(1), eq(2));
-        String expectedRSF =
-                "assert-root-hash\tsha-256:K3rfuFF1e_uno\n" +
-                "add-item\t{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}\n" +
-                "append-entry\tuser\tentry2-field-1-value\t2016-07-24T16:56:00Z\tsha-256:item2sha\n" +
-                "assert-root-hash\tsha-256:K3rfuFF1e_dos\n";
 
         String actualRSF = outputStream.toString();
         assertThat(actualRSF, Matchers.equalTo(expectedRSF));

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -62,19 +62,6 @@ public class RegisterSerialisationFormatServiceTest {
     }
 
     @Test
-    public void process_passesCommandsToExecutorAndReturnsItsResult() {
-        RegisterCommand command1 = new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
-        RegisterCommand command2 = new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}"));
-        RegisterCommand command3 = new RegisterCommand("append-entry", Arrays.asList("user", "entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item1sha"));
-        RegisterCommand command4 = new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e"));
-        RegisterSerialisationFormat rsfInput = new RegisterSerialisationFormat(Iterators.forArray(command1, command2, command3, command4));
-
-        sutService.process(rsfInput);
-
-        verify(rsfExecutor, times(1)).execute(eq(rsfInput), any(), any());
-    }
-
-    @Test
     public void writeTo_writesEntireRSFtoStream() {
         when(registerContext.withV1VerifiableLog(any())).thenReturn(
                 Iterators.forArray(


### PR DESCRIPTION
### Context
This changes the data that goes into the merkle tree for the proof API to an objecthash of `key`, `timestamp`, `entry number` and `blob hash`, rather than a JSON string produced from the entry. This enables us to add additional metadata to entries without affecting the integrity of the merkle tree.

Trello: https://trello.com/c/4NkpexnZ/3102-implement-rfc0009-hashing-algorithm-for-entries

### Changes proposed in this pull request
- [x] Rename V2 proof endpoints ([RFC 19](https://github.com/openregister/registers-rfcs/blob/master/content/proof-resource/index.md))
- [x] Add new MerkleLeafStore implementation that uses ObjectHash ([RFC 9](https://github.com/openregister/registers-rfcs/blob/master/content/entry-hash/index.md))
- [x] Make proof endpoints use the entry log directly instead of via a
  `ReadOnlyRegister` facade. Proofs are a very low level thing and I don't
think there is any reason for it to be in this higher level interface
- [x] Extract proof methods into a separate class and make `RegisterContext` build verifiable logs
- [x] Make V2 proof API use V2 proofs

### Guidance to review
The actual entry hashing part is very straightforward, but the example given in the [RFC](https://github.com/openregister/registers-rfcs/blob/master/content/entry-hash/index.md) is no longer correct due to [removing indexes](https://github.com/openregister/registers-rfcs/blob/master/content/indexes-removal/index.md), so I haven't compared the results to a known implementation. Instead I just stepped through the code in the debugger and made sure the component parts were correct.

The second commit is a very messy refactor of the proof code, and needs to be reviewed carefully. I made this change because the new entry hashes were very difficult to integrate without breaking proofs and RSF. I've tried to explain further in the commit message how I arrived at this solution.

I've removed a few tests but I think all of them are covered by others.

When reviewing this please pay special attention to the RSF code. Before merging we need to make sure that `/download-rsf` and `/load-rsf` still work the same and use V1 entry hashes.

We still need to add `/next/download-rsf` and `/next/load-rsf` in a future PR. The differences between the new and old RSF versions are:

- `assert-root-hash` uses V2 entry hashes
- `append-entry` identifies blobs using their V2 hashes