### PR TITLE
180s is not enough time to run the latest migration

### DIFF
--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -4,8 +4,8 @@ applications:
   memory: 4GB
   instances: 2
   buildpack: java_buildpack
-  health-check-type: http
-  health-check-http-endpoint: /healthcheck
+  health-check-type: port
+  #health-check-http-endpoint: /healthcheck
   path: ../../openregister-java.jar
   services:
     - discovery-db


### PR DESCRIPTION
### Context
https://github.com/openregister/openregister-java/pull/544 was not enough to run the migrations on discovery.


### Changes proposed in this pull request

Disabling the health check means that the migration can run to
completion, but the app might not actually be reponsive for a while.


### Guidance to review
