### PR TITLE
Implement RFC0025 Snapshot resource for records

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 csvvalidator==1.2
 jsonschema==2.5.1
--e git+https://github.com/openregister/conformance-test.git@26675dac36c7786189623dc754df7de0356210fb#egg=openregister_conformance-master
+-e git+https://github.com/openregister/conformance-test.git@9508abc6a291c5fb97d8525ba8d30ff05de8ebeb#egg=openregister_conformance-snapshot-records
 py==1.7.0
 pytest==3.10.0
 PyYAML==3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 csvvalidator==1.2
 jsonschema==2.5.1
--e git+https://github.com/openregister/conformance-test.git@ac46102ddd9d6241cf228c54bfba2b7ca7a11637#egg=openregister_master
+-e git+https://github.com/openregister/conformance-test.git@659f0f29fc2950c0422356aaa747d97ca6c92163#egg=openregister_master
 py==1.7.0
 pytest==3.10.0
 PyYAML==3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 csvvalidator==1.2
 jsonschema==2.5.1
--e git+https://github.com/openregister/conformance-test.git@9508abc6a291c5fb97d8525ba8d30ff05de8ebeb#egg=openregister_conformance-snapshot-records
+-e git+https://github.com/openregister/conformance-test.git@ac46102ddd9d6241cf228c54bfba2b7ca7a11637#egg=openregister_master
 py==1.7.0
 pytest==3.10.0
 PyYAML==3.11

--- a/src/main/java/uk/gov/register/views/v2/RecordListView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordListView.java
@@ -35,9 +35,9 @@ public class RecordListView implements CsvRepresentationView<ArrayNode> {
     @JsonValue
     public List<JsonNode> getRecords() {
         return this.records.stream().map(r -> {
-            ObjectNode result = jsonObjectMapper.convertValue(r.getItem().getContent(), ObjectNode.class);
-            result.put("_id", r.getEntry().getKey());
-            return result;
+            ObjectNode record = (ObjectNode)(r.getItem().getContent());
+            record.put("_id", r.getEntry().getKey());
+            return record;
         }).collect(Collectors.toList());
     };
 

--- a/src/main/java/uk/gov/register/views/v2/RecordListView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordListView.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import io.dropwizard.jackson.Jackson;
 import uk.gov.register.core.Field;
 import uk.gov.register.core.Record;
-import uk.gov.register.service.ItemConverter;
 import uk.gov.register.views.CsvRepresentationView;
 import uk.gov.register.views.representations.CsvRepresentation;
 
@@ -20,15 +19,11 @@ import java.util.stream.Collectors;
 
 public class RecordListView implements CsvRepresentationView<ArrayNode> {
     private final Collection<Record> records;
-    private final ItemConverter itemConverter;
-    private final Map<String, Field> fieldsByName;
     private final List<String> fieldNames;
     private final ObjectMapper jsonObjectMapper = Jackson.newObjectMapper();
 
     public RecordListView(Collection<Record> records, final Map<String, Field> fieldsByName) {
         this.records = records;
-        this.itemConverter = new ItemConverter();
-        this.fieldsByName = fieldsByName;
         this.fieldNames = fieldsByName.values().stream().map(field -> field.fieldName).collect(Collectors.toList());
     }
 

--- a/src/main/java/uk/gov/register/views/v2/RecordListView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordListView.java
@@ -46,9 +46,7 @@ public class RecordListView implements CsvRepresentationView<ArrayNode> {
 
     public CsvSchema csvSchema() {
         CsvSchema.Builder schemaBuilder = new CsvSchema.Builder();
-        schemaBuilder.addColumn("entry-number", CsvSchema.ColumnType.NUMBER);
-        schemaBuilder.addColumn("entry-timestamp", CsvSchema.ColumnType.STRING);
-        schemaBuilder.addColumn("key", CsvSchema.ColumnType.STRING);
+        schemaBuilder.addColumn("_id", CsvSchema.ColumnType.STRING);
 
         for (String value : this.fieldNames) {
             schemaBuilder.addColumn(value, CsvSchema.ColumnType.STRING);

--- a/src/main/java/uk/gov/register/views/v2/RecordView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordView.java
@@ -31,7 +31,7 @@ public class RecordView implements CsvRepresentationView<ObjectNode> {
     }
 
     public RecordView(final Record record, final Map<String, Field> fieldsByName, ItemConverter itemConverter) throws FieldConversionException {
-        this.fields = fields = fieldsByName.values();
+        this.fields = fieldsByName.values();
         this.record = record;
         this.itemView = new ItemView(record.getItem(), fieldsByName, itemConverter);
     }
@@ -56,17 +56,13 @@ public class RecordView implements CsvRepresentationView<ObjectNode> {
     public JsonNode getContent() {
         final ObjectNode result = jsonObjectMapper.createObjectNode();
         result.putPOJO("blob", itemView);
-        result.put("entry-number", this.getEntry().getEntryNumber());
-        result.put("entry-timestamp", this.getEntry().getTimestampAsISOFormat());
-        result.put("key", this.getEntry().getKey());
+        result.put("_id", this.getEntry().getKey());
         return result;
     }
 
     protected ObjectNode getFlatRecordJson() {
         ObjectNode result = jsonObjectMapper.convertValue(itemView, ObjectNode.class);
-        result.put("entry-number", this.getEntry().getEntryNumber());
-        result.put("entry-timestamp", this.getEntry().getTimestampAsISOFormat());
-        result.put("key", this.getEntry().getKey());
+        result.put("_id", this.getEntry().getKey());
         return result;
     }
 

--- a/src/main/java/uk/gov/register/views/v2/RecordView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordView.java
@@ -65,9 +65,7 @@ public class RecordView implements CsvRepresentationView<ObjectNode> {
 
     public CsvSchema csvSchema() {
         CsvSchema.Builder schemaBuilder = new CsvSchema.Builder();
-        schemaBuilder.addColumn("entry-number", CsvSchema.ColumnType.NUMBER);
-        schemaBuilder.addColumn("entry-timestamp", CsvSchema.ColumnType.STRING);
-        schemaBuilder.addColumn("key", CsvSchema.ColumnType.STRING);
+        schemaBuilder.addColumn("_id", CsvSchema.ColumnType.STRING);
 
         for (String value : getFieldNames()) {
             schemaBuilder.addColumn(value, CsvSchema.ColumnType.STRING);

--- a/src/main/java/uk/gov/register/views/v2/RecordView.java
+++ b/src/main/java/uk/gov/register/views/v2/RecordView.java
@@ -31,7 +31,7 @@ public class RecordView implements CsvRepresentationView<ObjectNode> {
     }
 
     public RecordView(final Record record, final Map<String, Field> fieldsByName, ItemConverter itemConverter) throws FieldConversionException {
-        this.fields = fieldsByName.values();
+        this.fields = fields = fieldsByName.values();
         this.record = record;
         this.itemView = new ItemView(record.getItem(), fieldsByName, itemConverter);
     }
@@ -54,10 +54,7 @@ public class RecordView implements CsvRepresentationView<ObjectNode> {
 
     @JsonValue
     public JsonNode getContent() {
-        final ObjectNode result = jsonObjectMapper.createObjectNode();
-        result.putPOJO("blob", itemView);
-        result.put("_id", this.getEntry().getKey());
-        return result;
+        return getFlatRecordJson();
     }
 
     protected ObjectNode getFlatRecordJson() {

--- a/src/test/java/uk/gov/register/views/v2/RecordListViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/RecordListViewTest.java
@@ -69,26 +69,18 @@ public class RecordListViewTest {
         RecordListView view = new RecordListView(Arrays.asList(this.record1, this.record2), fieldsByName);
         String result = objectMapper.writeValueAsString(view);
         JsonNode jsonNode = objectMapper.readTree(result);
-
-        assertTrue(jsonNode.has("123"));
-        assertTrue(jsonNode.has("456"));
-
-        JsonNode record1Node = jsonNode.get("123");
-        JsonNode record2Node = jsonNode.get("456");
+        assertTrue(jsonNode.isArray());
+        JsonNode record1Node = jsonNode.get(0);
+        JsonNode record2Node = jsonNode.get(1);
         assertHasRecordFields(record1Node);
         assertHasRecordFields(record2Node);
 
-        assertThat(record1Node.get("entry-number").intValue(), equalTo(1));
-        assertThat(record2Node.get("entry-number").intValue(), equalTo(2));
-
-        assertThat(record1Node.get("entry-timestamp").textValue(), equalTo("2016-03-29T08:59:25Z"));
-        assertThat(record2Node.get("entry-timestamp").textValue(), equalTo("2016-03-28T09:49:26Z"));
-
-        assertThat(record1Node.get("key").textValue(), equalTo("123"));
-        assertThat(record2Node.get("key").textValue(), equalTo("456"));
-
-        assertThat(record1Node.get("blob"), equalTo(itemNode1));
-        assertThat(record2Node.get("blob"), equalTo(itemNode2));
+        assertThat(record1Node.get("_id").asInt(), equalTo(123));
+        assertThat(record1Node.get("street").asText(), equalTo("foo"));
+        assertThat(record1Node.get("address").asInt(), equalTo(123));
+        assertThat(record2Node.get("_id").asInt(), equalTo(456));
+        assertThat(record2Node.get("street").asText(), equalTo("bar"));
+        assertThat(record2Node.get("address").asInt(), equalTo(456));
     }
 
     @Test
@@ -108,15 +100,13 @@ public class RecordListViewTest {
         String result = new String(bytes, StandardCharsets.UTF_8);
 
         assertThat(result, equalTo(
-                "entry-number,entry-timestamp,key,street,address\r\n" +
-                        "1,2016-03-29T08:59:25Z,123,foo,123\r\n" +
-                        "2,2016-03-28T09:49:26Z,456,bar,456\r\n"
+                "_id,street,address\r\n123,foo,123\r\n456,bar,456\r\n"
         ));
     }
 
     private void assertHasRecordFields(JsonNode node) {
         Set<String> fields = new HashSet<>();
         node.fieldNames().forEachRemaining(fields::add);
-        assertThat(fields, equalTo(new HashSet<>(Arrays.asList("entry-number", "key", "entry-timestamp", "blob"))));
+        assertThat(fields, equalTo(new HashSet<>(Arrays.asList("address", "street", "_id"))));
     }
 }

--- a/src/test/java/uk/gov/register/views/v2/RecordViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/RecordViewTest.java
@@ -62,9 +62,8 @@ public class RecordViewTest {
         String result = objectMapper.writeValueAsString(view);
         JsonNode jsonNode = objectMapper.readTree(result);
 
-        assertThat(jsonNode.get("entry-number").intValue(), equalTo(1));
-        assertThat(jsonNode.get("entry-timestamp").textValue(), equalTo("2016-03-29T08:59:25Z"));
-        assertThat(jsonNode.get("key").textValue(), equalTo("123"));
-        assertThat(jsonNode.get("blob"), equalTo(this.itemNode1));
+        assertThat(jsonNode.get("_id").textValue(), equalTo("123"));
+        assertThat(jsonNode.get("address").textValue(), equalTo("123"));
+        assertThat(jsonNode.get("street").textValue(), equalTo("foo"));
     }
 }


### PR DESCRIPTION
### Context
https://github.com/openregister/registers-rfcs/blob/master/content/snapshot-resource/index.md

### Changes proposed in this pull request
Implements snapshot resource for records. Note this does not implement the extra log size features.

### Guidance to review
Note, this adds `_id`  at the end of the JSON array and at the start of the CSV as it was easiest to serialise that way. I believe this is spec compliant as per https://spec.openregister.org/v2/rest-api/records but let me know if you feel strongly about this

# TODO
- [x] update conformance tests 
