### PR TITLE
[WIP] Version 2 load-rsf endpoint

### DIFF
--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -26,6 +26,7 @@ import uk.gov.register.commands.HashDataMigrationCommand;
 import uk.gov.register.db.Factories;
 import uk.gov.register.filters.CorsBundle;
 import uk.gov.register.filters.StripTrailingSlashRedirectFilter;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.resources.SchemeContext;
 import uk.gov.register.serialization.RSFCreator;
@@ -111,7 +112,8 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
             registerContext.migrate();
             registerContext.validate();
             
-            CompletableFuture.runAsync(() -> registerContext.buildOnDemandRegister().getV1RegisterProof());
+            CompletableFuture.runAsync(() -> registerContext.withV1VerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getRootHash()));
+            CompletableFuture.runAsync(() -> registerContext.withVerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getRootHash()));
         });
 
         RSFExecutor rsfExecutor = new RSFExecutor();

--- a/src/main/java/uk/gov/register/RegisterApplication.java
+++ b/src/main/java/uk/gov/register/RegisterApplication.java
@@ -111,7 +111,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
             registerContext.migrate();
             registerContext.validate();
             
-            CompletableFuture.runAsync(() -> registerContext.buildOnDemandRegister().getRegisterProof());
+            CompletableFuture.runAsync(() -> registerContext.buildOnDemandRegister().getV1RegisterProof());
         });
 
         RSFExecutor rsfExecutor = new RSFExecutor();
@@ -153,6 +153,7 @@ public class RegisterApplication extends Application<RegisterConfiguration> {
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);
                 bind(ItemConverter.class).to(ItemConverter.class).in(Singleton.class);
                 bindFactory(Factories.PostgresRegisterFactory.class).to(Register.class).to(RegisterReadOnly.class);
+                bindFactory(Factories.EntryLogFactory.class).to(EntryLog.class);
                 bind(UriTemplateRegisterResolver.class).to(RegisterResolver.class);
                 bind(configuration);
                 bind(client).to(Client.class);

--- a/src/main/java/uk/gov/register/core/EntryLog.java
+++ b/src/main/java/uk/gov/register/core/EntryLog.java
@@ -26,11 +26,4 @@ public interface EntryLog {
     int getTotalEntries(EntryType entryType);
 
     Optional<Instant> getLastUpdatedTime();
-
-    RegisterProof getV1RegisterProof();
-    RegisterProof getV1RegisterProof(int totalEntries);
-
-    EntryProof getV1EntryProof(int entryNumber, int totalEntries);
-
-    ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2);
 }

--- a/src/main/java/uk/gov/register/core/EntryLog.java
+++ b/src/main/java/uk/gov/register/core/EntryLog.java
@@ -27,10 +27,10 @@ public interface EntryLog {
 
     Optional<Instant> getLastUpdatedTime();
 
-    RegisterProof getRegisterProof();
-    RegisterProof getRegisterProof(int totalEntries);
+    RegisterProof getV1RegisterProof();
+    RegisterProof getV1RegisterProof(int totalEntries);
 
-    EntryProof getEntryProof(int entryNumber, int totalEntries);
+    EntryProof getV1EntryProof(int entryNumber, int totalEntries);
 
-    ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2);
+    ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2);
 }

--- a/src/main/java/uk/gov/register/core/EntryLogImpl.java
+++ b/src/main/java/uk/gov/register/core/EntryLogImpl.java
@@ -1,7 +1,7 @@
 package uk.gov.register.core;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import uk.gov.register.db.EntryMerkleLeafStore;
+import uk.gov.register.db.V1EntryMerkleLeafStore;
 import uk.gov.register.exceptions.IndexingException;
 import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.util.HashValue;
@@ -76,21 +76,21 @@ public class EntryLogImpl implements EntryLog {
     }
 
     @Override
-    public RegisterProof getRegisterProof() {
+    public RegisterProof getV1RegisterProof() {
         String rootHash = withVerifiableLog(verifiableLog -> bytesToString(verifiableLog.getCurrentRootHash()));
 
         return new RegisterProof(new HashValue(HashingAlgorithm.SHA256, rootHash), getTotalEntries(EntryType.user));
     }
 
     @Override
-    public RegisterProof getRegisterProof(int totalEntries) {
+    public RegisterProof getV1RegisterProof(int totalEntries) {
         String rootHash = withVerifiableLog(verifiableLog -> bytesToString(verifiableLog.getSpecificRootHash(totalEntries)));
 
         return new RegisterProof(new HashValue(HashingAlgorithm.SHA256, rootHash), totalEntries);
     }
 
     @Override
-    public EntryProof getEntryProof(int entryNumber, int totalEntries) {
+    public EntryProof getV1EntryProof(int entryNumber, int totalEntries) {
         List<HashValue> auditProof = withVerifiableLog(verifiableLog ->
                 verifiableLog.auditProof(entryNumber - 1, totalEntries)
                         .stream()
@@ -101,7 +101,7 @@ public class EntryLogImpl implements EntryLog {
     }
 
     @Override
-    public ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2) {
+    public ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2) {
         List<HashValue> consistencyProof = withVerifiableLog(verifiableLog ->
             verifiableLog.consistencyProof(totalEntries1, totalEntries2)
                     .stream()
@@ -117,7 +117,7 @@ public class EntryLogImpl implements EntryLog {
 
     private <R> R withVerifiableLog(Function<VerifiableLog, R> callback) {
         return dataAccessLayer.withEntryIterator(entryIterator -> {
-            VerifiableLog verifiableLog = new VerifiableLog(DigestUtils.getSha256Digest(), new EntryMerkleLeafStore(entryIterator), memoizationStore);
+            VerifiableLog verifiableLog = new VerifiableLog(DigestUtils.getSha256Digest(), new V1EntryMerkleLeafStore(entryIterator), memoizationStore);
             return callback.apply(verifiableLog);
         });
     }

--- a/src/main/java/uk/gov/register/core/EntryLogImpl.java
+++ b/src/main/java/uk/gov/register/core/EntryLogImpl.java
@@ -1,7 +1,7 @@
 package uk.gov.register.core;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import uk.gov.register.db.V1EntryMerkleLeafStore;
+import uk.gov.register.proofs.V1EntryMerkleLeafStore;
 import uk.gov.register.exceptions.IndexingException;
 import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.util.HashValue;

--- a/src/main/java/uk/gov/register/core/EntryLogImpl.java
+++ b/src/main/java/uk/gov/register/core/EntryLogImpl.java
@@ -1,32 +1,18 @@
 package uk.gov.register.core;
 
-import org.apache.commons.codec.digest.DigestUtils;
-import uk.gov.register.proofs.V1EntryMerkleLeafStore;
 import uk.gov.register.exceptions.IndexingException;
 import uk.gov.register.store.DataAccessLayer;
-import uk.gov.register.util.HashValue;
-import uk.gov.register.views.ConsistencyProof;
-import uk.gov.register.views.EntryProof;
-import uk.gov.register.views.RegisterProof;
-import uk.gov.verifiablelog.VerifiableLog;
-import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
-import javax.xml.bind.DatatypeConverter;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class EntryLogImpl implements EntryLog {
     private final DataAccessLayer dataAccessLayer;
-    private final MemoizationStore memoizationStore;
 
-    public EntryLogImpl(DataAccessLayer dataAccessLayer, MemoizationStore memoizationStore) {
+    public EntryLogImpl(DataAccessLayer dataAccessLayer) {
         this.dataAccessLayer = dataAccessLayer;
-        this.memoizationStore = memoizationStore;
     }
 
     @Override
@@ -73,52 +59,5 @@ public class EntryLogImpl implements EntryLog {
     @Override
     public Optional<Instant> getLastUpdatedTime() {
         return dataAccessLayer.getLastUpdatedTime();
-    }
-
-    @Override
-    public RegisterProof getV1RegisterProof() {
-        String rootHash = withVerifiableLog(verifiableLog -> bytesToString(verifiableLog.getCurrentRootHash()));
-
-        return new RegisterProof(new HashValue(HashingAlgorithm.SHA256, rootHash), getTotalEntries(EntryType.user));
-    }
-
-    @Override
-    public RegisterProof getV1RegisterProof(int totalEntries) {
-        String rootHash = withVerifiableLog(verifiableLog -> bytesToString(verifiableLog.getSpecificRootHash(totalEntries)));
-
-        return new RegisterProof(new HashValue(HashingAlgorithm.SHA256, rootHash), totalEntries);
-    }
-
-    @Override
-    public EntryProof getV1EntryProof(int entryNumber, int totalEntries) {
-        List<HashValue> auditProof = withVerifiableLog(verifiableLog ->
-                verifiableLog.auditProof(entryNumber - 1, totalEntries)
-                        .stream()
-                        .map(hashBytes -> new HashValue(HashingAlgorithm.SHA256, bytesToString(hashBytes)))
-                        .collect(Collectors.toList()));
-
-        return new EntryProof(Integer.toString(entryNumber), auditProof);
-    }
-
-    @Override
-    public ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2) {
-        List<HashValue> consistencyProof = withVerifiableLog(verifiableLog ->
-            verifiableLog.consistencyProof(totalEntries1, totalEntries2)
-                    .stream()
-                    .map(hashBytes -> new HashValue(HashingAlgorithm.SHA256, bytesToString(hashBytes)))
-                    .collect(Collectors.toList()));
-
-        return new ConsistencyProof(consistencyProof);
-    }
-
-    private String bytesToString(byte[] bytes) {
-        return DatatypeConverter.printHexBinary(bytes).toLowerCase();
-    }
-
-    private <R> R withVerifiableLog(Function<VerifiableLog, R> callback) {
-        return dataAccessLayer.withEntryIterator(entryIterator -> {
-            VerifiableLog verifiableLog = new VerifiableLog(DigestUtils.getSha256Digest(), new V1EntryMerkleLeafStore(entryIterator), memoizationStore);
-            return callback.apply(verifiableLog);
-        });
     }
 }

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -1,6 +1,7 @@
 package uk.gov.register.core;
 
 import com.google.common.base.Throwables;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.flywaydb.core.Flyway;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
@@ -13,17 +14,21 @@ import uk.gov.register.db.RecordSet;
 import uk.gov.register.exceptions.FieldDefinitionException;
 import uk.gov.register.exceptions.NoSuchConfigException;
 import uk.gov.register.exceptions.RegisterDefinitionException;
+import uk.gov.register.proofs.EntryMerkleLeafStore;
+import uk.gov.register.proofs.V1EntryMerkleLeafStore;
 import uk.gov.register.service.EnvironmentValidator;
 import uk.gov.register.service.ItemValidator;
 import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.store.postgres.BatchedPostgresDataAccessLayer;
 import uk.gov.register.store.postgres.PostgresDataAccessLayer;
+import uk.gov.verifiablelog.VerifiableLog;
 import uk.gov.verifiablelog.store.memoization.InMemoryPowOfTwoNoLeaves;
 import uk.gov.verifiablelog.store.memoization.MemoizationStore;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 
 public class RegisterContext implements
@@ -76,14 +81,14 @@ public class RegisterContext implements
     public EntryLog buildEntryLog() {
         DataAccessLayer dataAccessLayer = getOnDemandDataAccessLayer();
 
-        return new EntryLogImpl(dataAccessLayer, memoizationStore.get());
+        return new EntryLogImpl(dataAccessLayer);
     }
 
     public Register buildOnDemandRegister() {
         DataAccessLayer dataAccessLayer = getOnDemandDataAccessLayer();
 
         return new RegisterImpl(registerId,
-                new EntryLogImpl(dataAccessLayer, memoizationStore.get()),
+                new EntryLogImpl(dataAccessLayer),
                 new ItemStoreImpl(dataAccessLayer),
                 new RecordSet(dataAccessLayer),
                 itemValidator,
@@ -92,7 +97,7 @@ public class RegisterContext implements
 
     private Register buildTransactionalRegister(DataAccessLayer dataAccessLayer, TransactionalMemoizationStore memoizationStore) {
         return new RegisterImpl(registerId,
-                new EntryLogImpl(dataAccessLayer, memoizationStore),
+                new EntryLogImpl(dataAccessLayer),
                 new ItemStoreImpl(dataAccessLayer),
                 new RecordSet(dataAccessLayer),
                 itemValidator,
@@ -137,6 +142,26 @@ public class RegisterContext implements
                 dbi.onDemand(ItemQueryDAO.class),
                 dbi.onDemand(RecordQueryDAO.class),
                 schema);
+    }
+
+    public <R> R withV1VerifiableLog(Function<VerifiableLog, R> callback) {
+        return getOnDemandDataAccessLayer().withEntryIterator(entryIterator -> {
+            VerifiableLog verifiableLog = new VerifiableLog(
+                    DigestUtils.getSha256Digest(),
+                    new V1EntryMerkleLeafStore(entryIterator),
+                    memoizationStore.get());
+            return callback.apply(verifiableLog);
+        });
+    }
+
+    public <R> R withVerifiableLog(Function<VerifiableLog, R> callback) {
+        return getOnDemandDataAccessLayer().withEntryIterator(entryIterator -> {
+            VerifiableLog verifiableLog = new VerifiableLog(
+                    DigestUtils.getSha256Digest(),
+                    new EntryMerkleLeafStore(entryIterator),
+                    memoizationStore.get());
+            return callback.apply(verifiableLog);
+        });
     }
 
     private BatchedPostgresDataAccessLayer getTransactionalDataAccessLayer(Handle handle) {

--- a/src/main/java/uk/gov/register/core/RegisterContext.java
+++ b/src/main/java/uk/gov/register/core/RegisterContext.java
@@ -73,6 +73,12 @@ public class RegisterContext implements
         return flyway.migrate();
     }
 
+    public EntryLog buildEntryLog() {
+        DataAccessLayer dataAccessLayer = getOnDemandDataAccessLayer();
+
+        return new EntryLogImpl(dataAccessLayer, memoizationStore.get());
+    }
+
     public Register buildOnDemandRegister() {
         DataAccessLayer dataAccessLayer = getOnDemandDataAccessLayer();
 

--- a/src/main/java/uk/gov/register/core/RegisterImpl.java
+++ b/src/main/java/uk/gov/register/core/RegisterImpl.java
@@ -184,30 +184,6 @@ public class RegisterImpl implements Register {
 
     //endregion
 
-    //region Verifiable Log
-
-    @Override
-    public RegisterProof getV1RegisterProof() {
-        return entryLog.getV1RegisterProof();
-    }
-
-    @Override
-    public RegisterProof getV1RegisterProof(int totalEntries) {
-        return entryLog.getV1RegisterProof(totalEntries);
-    }
-
-    @Override
-    public EntryProof getV1EntryProof(int entryNumber, int totalEntries) {
-        return entryLog.getV1EntryProof(entryNumber, totalEntries);
-    }
-
-    @Override
-    public ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2) {
-        return entryLog.getV1ConsistencyProof(totalEntries1, totalEntries2);
-    }
-
-    //endregion
-
     //region Metadata
 
     @Override

--- a/src/main/java/uk/gov/register/core/RegisterImpl.java
+++ b/src/main/java/uk/gov/register/core/RegisterImpl.java
@@ -187,23 +187,23 @@ public class RegisterImpl implements Register {
     //region Verifiable Log
 
     @Override
-    public RegisterProof getRegisterProof() {
-        return entryLog.getRegisterProof();
+    public RegisterProof getV1RegisterProof() {
+        return entryLog.getV1RegisterProof();
     }
 
     @Override
-    public RegisterProof getRegisterProof(int totalEntries) {
-        return entryLog.getRegisterProof(totalEntries);
+    public RegisterProof getV1RegisterProof(int totalEntries) {
+        return entryLog.getV1RegisterProof(totalEntries);
     }
 
     @Override
-    public EntryProof getEntryProof(int entryNumber, int totalEntries) {
-        return entryLog.getEntryProof(entryNumber, totalEntries);
+    public EntryProof getV1EntryProof(int entryNumber, int totalEntries) {
+        return entryLog.getV1EntryProof(entryNumber, totalEntries);
     }
 
     @Override
-    public ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2) {
-        return entryLog.getConsistencyProof(totalEntries1, totalEntries2);
+    public ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2) {
+        return entryLog.getV1ConsistencyProof(totalEntries1, totalEntries2);
     }
 
     //endregion

--- a/src/main/java/uk/gov/register/core/RegisterReadOnly.java
+++ b/src/main/java/uk/gov/register/core/RegisterReadOnly.java
@@ -36,11 +36,6 @@ public interface RegisterReadOnly {
     List<Record> max100RecordsFacetedByKeyValue(String key, String value) throws NoSuchFieldException;
     int getTotalRecords(EntryType entryType);
 
-    RegisterProof getV1RegisterProof();
-    RegisterProof getV1RegisterProof(int entryNo);
-    EntryProof getV1EntryProof(int entryNumber, int totalEntries);
-    ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2);
-
     RegisterId getRegisterId();
     Optional<String> getRegisterName();
     Optional<String> getCustodianName();

--- a/src/main/java/uk/gov/register/core/RegisterReadOnly.java
+++ b/src/main/java/uk/gov/register/core/RegisterReadOnly.java
@@ -36,10 +36,10 @@ public interface RegisterReadOnly {
     List<Record> max100RecordsFacetedByKeyValue(String key, String value) throws NoSuchFieldException;
     int getTotalRecords(EntryType entryType);
 
-    RegisterProof getRegisterProof();
-    RegisterProof getRegisterProof(int entryNo);
-    EntryProof getEntryProof(int entryNumber, int totalEntries);
-    ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2);
+    RegisterProof getV1RegisterProof();
+    RegisterProof getV1RegisterProof(int entryNo);
+    EntryProof getV1EntryProof(int entryNumber, int totalEntries);
+    ConsistencyProof getV1ConsistencyProof(int totalEntries1, int totalEntries2);
 
     RegisterId getRegisterId();
     Optional<String> getRegisterName();

--- a/src/main/java/uk/gov/register/db/Factories.java
+++ b/src/main/java/uk/gov/register/db/Factories.java
@@ -2,6 +2,7 @@ package uk.gov.register.db;
 
 import org.glassfish.hk2.api.Factory;
 import uk.gov.register.core.AllTheRegisters;
+import uk.gov.register.core.EntryLog;
 import uk.gov.register.core.Register;
 import uk.gov.register.core.RegisterContext;
 import uk.gov.register.core.RegisterId;
@@ -17,6 +18,20 @@ public abstract class Factories {
         @Override
         public void dispose(T instance) {
             // do nothing
+        }
+    }
+
+    public static class EntryLogFactory extends SimpleFactory<EntryLog> {
+        private final RegisterContext registerContext;
+
+        @Inject
+        public EntryLogFactory(RegisterContext registerContext) {
+            this.registerContext = registerContext;
+        }
+
+        @Override
+        public EntryLog provide() {
+            return registerContext.buildEntryLog();
         }
     }
 

--- a/src/main/java/uk/gov/register/db/V1EntryMerkleLeafStore.java
+++ b/src/main/java/uk/gov/register/db/V1EntryMerkleLeafStore.java
@@ -1,0 +1,42 @@
+package uk.gov.register.db;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import uk.gov.register.core.Entry;
+import uk.gov.register.views.EntryView;
+import uk.gov.verifiablelog.store.MerkleLeafStore;
+
+public class V1EntryMerkleLeafStore implements MerkleLeafStore {
+    private final EntryIterator entryIterator;
+
+
+    public V1EntryMerkleLeafStore(EntryIterator entryIterator) {
+        this.entryIterator = entryIterator;
+    }
+
+    @Override
+    public byte[] getLeafValue(int i) {
+        return bytesFromEntry(entryIterator.findByEntryNumber(i + 1));
+    }
+
+    @Override
+    public int totalLeaves() {
+        return entryIterator.getTotalEntries();
+    }
+
+    private byte[] bytesFromEntry(Entry entry) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+            mapper.getFactory().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
+            EntryView entryView = new EntryView(entry);
+            String value = mapper.writeValueAsString(entryView);
+            return value.getBytes();
+        } catch (JsonProcessingException e) {
+            // FIXME swallow for now and return null byte
+            return new byte[]{0x00};
+        }
+    }
+}

--- a/src/main/java/uk/gov/register/proofs/EntryIterator.java
+++ b/src/main/java/uk/gov/register/proofs/EntryIterator.java
@@ -1,7 +1,8 @@
-package uk.gov.register.db;
+package uk.gov.register.proofs;
 
 import org.skife.jdbi.v2.ResultIterator;
 import uk.gov.register.core.Entry;
+import uk.gov.register.db.EntryQueryDAO;
 
 import java.util.function.Function;
 

--- a/src/main/java/uk/gov/register/proofs/EntryMerkleLeafStore.java
+++ b/src/main/java/uk/gov/register/proofs/EntryMerkleLeafStore.java
@@ -1,4 +1,4 @@
-package uk.gov.register.db;
+package uk.gov.register.proofs;
 
 import uk.gov.objecthash.IntegerValue;
 import uk.gov.objecthash.ListValue;

--- a/src/main/java/uk/gov/register/proofs/ProofGenerator.java
+++ b/src/main/java/uk/gov/register/proofs/ProofGenerator.java
@@ -1,0 +1,54 @@
+package uk.gov.register.proofs;
+
+import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.util.HashValue;
+import uk.gov.register.views.ConsistencyProof;
+import uk.gov.register.views.EntryProof;
+import uk.gov.register.views.RegisterProof;
+import uk.gov.verifiablelog.VerifiableLog;
+
+import javax.xml.bind.DatatypeConverter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ProofGenerator {
+    private final VerifiableLog verifiableLog;
+
+    public ProofGenerator(VerifiableLog verifiableLog) {
+        this.verifiableLog = verifiableLog;
+    }
+
+    public RegisterProof getRegisterProof(int totalEntries) {
+        return new RegisterProof(getRootHash(totalEntries), totalEntries);
+    }
+
+    public HashValue getRootHash(int totalEntries) {
+        return new HashValue(HashingAlgorithm.SHA256, bytesToString(verifiableLog.getSpecificRootHash(totalEntries)));
+    }
+
+    public HashValue getRootHash() {
+        return new HashValue(HashingAlgorithm.SHA256, bytesToString(verifiableLog.getCurrentRootHash()));
+    }
+
+    public EntryProof getEntryProof(int entryNumber, int totalEntries) {
+        List<HashValue> auditProof = verifiableLog.auditProof(entryNumber - 1, totalEntries)
+                        .stream()
+                        .map(hashBytes -> new HashValue(HashingAlgorithm.SHA256, bytesToString(hashBytes)))
+                        .collect(Collectors.toList());
+
+        return new EntryProof(Integer.toString(entryNumber), auditProof);
+    }
+
+    public ConsistencyProof getConsistencyProof(int totalEntries1, int totalEntries2) {
+        List<HashValue> consistencyProof = verifiableLog.consistencyProof(totalEntries1, totalEntries2)
+                        .stream()
+                        .map(hashBytes -> new HashValue(HashingAlgorithm.SHA256, bytesToString(hashBytes)))
+                        .collect(Collectors.toList());
+
+        return new ConsistencyProof(consistencyProof);
+    }
+
+    private String bytesToString(byte[] bytes) {
+        return DatatypeConverter.printHexBinary(bytes).toLowerCase();
+    }
+}

--- a/src/main/java/uk/gov/register/proofs/V1EntryMerkleLeafStore.java
+++ b/src/main/java/uk/gov/register/proofs/V1EntryMerkleLeafStore.java
@@ -1,4 +1,4 @@
-package uk.gov.register.db;
+package uk.gov.register.proofs;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/uk/gov/register/resources/v1/DataUpload.java
+++ b/src/main/java/uk/gov/register/resources/v1/DataUpload.java
@@ -1,20 +1,11 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v1;
 
 import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Iterables;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import uk.gov.register.core.*;
-import uk.gov.register.exceptions.ItemValidationException;
-import uk.gov.register.exceptions.LoadException;
 import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.serialization.RSFFormatter;
 import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.serialization.RegisterSerialisationFormat;
 import uk.gov.register.service.RegisterSerialisationFormatService;
-import uk.gov.register.util.ObjectReconstructor;
 import uk.gov.register.views.representations.ExtraMediaType;
 
 import javax.annotation.security.PermitAll;
@@ -28,8 +19,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.InputStream;
-import java.time.Instant;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @Path("/")
 public class DataUpload {
@@ -52,7 +41,7 @@ public class DataUpload {
     @Path("/load-rsf")
     @Timed
     public Response loadRsf(InputStream inputStream) throws RSFParseException {
-        RegisterSerialisationFormat rsf = rsfService.readFrom(inputStream, rsfFormatter);
+        RegisterSerialisationFormat rsf = rsfService.readFromV1(inputStream, rsfFormatter);
         rsfService.process(rsf);
         return Response.status(Response.Status.OK).entity(RegisterResult.createSuccessResult()).build();
     }

--- a/src/main/java/uk/gov/register/resources/v1/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/VerifiableLogResource.java
@@ -38,7 +38,7 @@ public class VerifiableLogResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public RegisterProof registerProof() {
-        return registerContext.withVerifiableLog(verifiableLog -> {
+        return registerContext.withV1VerifiableLog(verifiableLog -> {
             int totalEntries = entryLog.getTotalEntries(EntryType.user);
             return new ProofGenerator(verifiableLog).getRegisterProof(totalEntries);
         });
@@ -59,7 +59,7 @@ public class VerifiableLogResource {
     @Timed
     public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) {
         validateEntryProofParams(entryNumber, totalEntries);
-        return registerContext.withVerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getEntryProof(entryNumber, totalEntries));
+        return registerContext.withV1VerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getEntryProof(entryNumber, totalEntries));
     }
 
     @GET
@@ -68,7 +68,7 @@ public class VerifiableLogResource {
     @Timed
     public ConsistencyProof consistencyProof(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) {
         validateConsistencyProofParams(totalEntries1, totalEntries2);
-        return registerContext.withVerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getConsistencyProof(totalEntries1, totalEntries2));
+        return registerContext.withV1VerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getConsistencyProof(totalEntries1, totalEntries2));
     }
 
     private void validateEntryProofParams(int entryNumber, int totalEntries) {

--- a/src/main/java/uk/gov/register/resources/v1/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v1/VerifiableLogResource.java
@@ -1,14 +1,82 @@
 package uk.gov.register.resources.v1;
 
-import uk.gov.register.core.RegisterReadOnly;
+import com.codahale.metrics.annotation.Timed;
+import uk.gov.register.core.EntryLog;
+import uk.gov.register.core.EntryType;
+import uk.gov.register.views.ConsistencyProof;
+import uk.gov.register.views.EntryProof;
+import uk.gov.register.views.RegisterProof;
 
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static uk.gov.register.resources.RedirectResource.redirectByPath;
 
 @Path("/proof")
-public class VerifiableLogResource extends uk.gov.register.resources.v2.VerifiableLogResource {
+public class VerifiableLogResource {
+    private final EntryLog entryLog;
+
     @Inject
-    public VerifiableLogResource(RegisterReadOnly register) {
-        super(register);
+    public VerifiableLogResource(EntryLog entryLog) {
+        this.entryLog = entryLog;
+    }
+
+    @GET
+    @Path("/register/merkle:sha-256")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    public RegisterProof registerProof() {
+        return entryLog.getV1RegisterProof();
+    }
+
+    @GET
+    @Path("/entry/{entry-number}/{total-entries}/merkle:sha-256")
+    public Response getProofRedirect(
+            @Context HttpServletRequest request
+    )
+    {
+        return redirectByPath(request, "/entry/", "/entries/");
+    }
+
+    @GET
+    @Path("/entries/{entry-number}/{total-entries}/merkle:sha-256")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) {
+        validateEntryProofParams(entryNumber, totalEntries);
+        return entryLog.getV1EntryProof(entryNumber, totalEntries);
+    }
+
+    @GET
+    @Path("/consistency/{total-entries-1}/{total-entries-2}/merkle:sha-256")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    public ConsistencyProof consistencyProof(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) {
+        validateConsistencyProofParams(totalEntries1, totalEntries2);
+        return entryLog.getV1ConsistencyProof(totalEntries1, totalEntries2);
+    }
+
+    private void validateEntryProofParams(int entryNumber, int totalEntries) {
+        if (entryNumber < 1 ||
+                entryNumber > totalEntries ||
+                totalEntries > entryLog.getTotalEntries(EntryType.user)) {
+            throw new BadRequestException("Invalid parameters");
+        }
+    }
+
+    private void validateConsistencyProofParams(int totalEntries1, int totalEntries2) {
+        if (totalEntries1 < 1 ||
+                totalEntries1 > totalEntries2 ||
+                totalEntries2 > entryLog.getTotalEntries(EntryType.user)) {
+            throw new BadRequestException("Invalid parameters");
+        }
     }
 }

--- a/src/main/java/uk/gov/register/resources/v2/DataUploadResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/DataUploadResource.java
@@ -1,0 +1,48 @@
+package uk.gov.register.resources.v2;
+
+import com.codahale.metrics.annotation.Timed;
+import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.serialization.RSFFormatter;
+import uk.gov.register.serialization.RegisterResult;
+import uk.gov.register.serialization.RegisterSerialisationFormat;
+import uk.gov.register.service.RegisterSerialisationFormatService;
+import uk.gov.register.views.representations.ExtraMediaType;
+
+import javax.annotation.security.PermitAll;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.InputStream;
+
+@Path("/next/load-rsf")
+public class DataUploadResource {
+    private final RegisterSerialisationFormatService rsfService;
+    private final RSFFormatter rsfFormatter;
+
+    @Inject
+    public DataUploadResource(RegisterSerialisationFormatService rsfService) {
+        this.rsfService = rsfService;
+        this.rsfFormatter = new RSFFormatter();
+    }
+
+    @Context
+    HttpServletRequest httpServletRequest;
+
+    @POST
+    @PermitAll
+    @Consumes(ExtraMediaType.APPLICATION_RSF)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/")
+    @Timed
+    public Response loadRsf(InputStream inputStream) throws RSFParseException {
+        RegisterSerialisationFormat rsf = rsfService.readFromV2(inputStream, rsfFormatter);
+        rsfService.process(rsf);
+        return Response.status(Response.Status.OK).entity(RegisterResult.createSuccessResult()).build();
+    }
+}

--- a/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
@@ -1,69 +1,59 @@
 package uk.gov.register.resources.v2;
 
 import com.codahale.metrics.annotation.Timed;
+import uk.gov.register.core.EntryLog;
 import uk.gov.register.core.EntryType;
-import uk.gov.register.core.RegisterReadOnly;
 import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.*;
-import javax.ws.rs.core.Context;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
-import static uk.gov.register.resources.RedirectResource.redirectByPath;
 
 @Path("/next/proof")
 public class VerifiableLogResource {
-    private final RegisterReadOnly register;
+    private final EntryLog entryLog;
 
     @Inject
-    public VerifiableLogResource(RegisterReadOnly register) {
-        this.register = register;
+    public VerifiableLogResource(EntryLog entryLog) {
+        this.entryLog = entryLog;
     }
 
     @GET
-    @Path("/register/merkle:sha-256")
+    @Path("/register")
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public RegisterProof registerProof() {
-        return register.getRegisterProof();
+        return entryLog.getV1RegisterProof();
     }
 
     @GET
-    @Path("/entry/{entry-number}/{total-entries}/merkle:sha-256")
-    public Response getProofRedirect(
-            @Context HttpServletRequest request
-    )
-    {
-        return redirectByPath(request, "/entry/", "/entries/");
-    }
-
-    @GET
-    @Path("/entries/{entry-number}/{total-entries}/merkle:sha-256")
+    @Path("/entry/{entry-number}/{total-entries}")
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) {
         validateEntryProofParams(entryNumber, totalEntries);
-        return register.getEntryProof(entryNumber, totalEntries);
+        return entryLog.getV1EntryProof(entryNumber, totalEntries);
     }
 
     @GET
-    @Path("/consistency/{total-entries-1}/{total-entries-2}/merkle:sha-256")
+    @Path("/consistency/{total-entries-1}/{total-entries-2}")
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public ConsistencyProof consistencyProof(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) {
         validateConsistencyProofParams(totalEntries1, totalEntries2);
-        return register.getConsistencyProof(totalEntries1, totalEntries2);
+        return entryLog.getV1ConsistencyProof(totalEntries1, totalEntries2);
     }
 
     private void validateEntryProofParams(int entryNumber, int totalEntries) {
         if (entryNumber < 1 ||
                 entryNumber > totalEntries ||
-                totalEntries > register.getTotalEntries(EntryType.user)) {
+                totalEntries > entryLog.getTotalEntries(EntryType.user)) {
             throw new BadRequestException("Invalid parameters");
         }
     }
@@ -71,7 +61,7 @@ public class VerifiableLogResource {
     private void validateConsistencyProofParams(int totalEntries1, int totalEntries2) {
         if (totalEntries1 < 1 ||
                 totalEntries1 > totalEntries2 ||
-                totalEntries2 > register.getTotalEntries(EntryType.user)) {
+                totalEntries2 > entryLog.getTotalEntries(EntryType.user)) {
             throw new BadRequestException("Invalid parameters");
         }
     }

--- a/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/VerifiableLogResource.java
@@ -3,6 +3,8 @@ package uk.gov.register.resources.v2;
 import com.codahale.metrics.annotation.Timed;
 import uk.gov.register.core.EntryLog;
 import uk.gov.register.core.EntryType;
+import uk.gov.register.core.RegisterContext;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.views.ConsistencyProof;
 import uk.gov.register.views.EntryProof;
 import uk.gov.register.views.RegisterProof;
@@ -18,10 +20,12 @@ import javax.ws.rs.core.MediaType;
 @Path("/next/proof")
 public class VerifiableLogResource {
     private final EntryLog entryLog;
+    private final RegisterContext registerContext;
 
     @Inject
-    public VerifiableLogResource(EntryLog entryLog) {
-        this.entryLog = entryLog;
+    public VerifiableLogResource(RegisterContext registerContext) {
+        this.registerContext = registerContext;
+        this.entryLog = registerContext.buildEntryLog();
     }
 
     @GET
@@ -29,7 +33,10 @@ public class VerifiableLogResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
     public RegisterProof registerProof() {
-        return entryLog.getV1RegisterProof();
+        return registerContext.withVerifiableLog(verifiableLog -> {
+            int totalEntries = entryLog.getTotalEntries(EntryType.user);
+            return new ProofGenerator(verifiableLog).getRegisterProof(totalEntries);
+        });
     }
 
     @GET
@@ -38,7 +45,7 @@ public class VerifiableLogResource {
     @Timed
     public EntryProof entryProof(@PathParam("entry-number") int entryNumber, @PathParam("total-entries") int totalEntries) {
         validateEntryProofParams(entryNumber, totalEntries);
-        return entryLog.getV1EntryProof(entryNumber, totalEntries);
+        return registerContext.withVerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getEntryProof(entryNumber, totalEntries));
     }
 
     @GET
@@ -47,7 +54,7 @@ public class VerifiableLogResource {
     @Timed
     public ConsistencyProof consistencyProof(@PathParam("total-entries-1") int totalEntries1, @PathParam("total-entries-2") int totalEntries2) {
         validateConsistencyProofParams(totalEntries1, totalEntries2);
-        return entryLog.getV1ConsistencyProof(totalEntries1, totalEntries2);
+        return registerContext.withVerifiableLog(verifiableLog -> new ProofGenerator(verifiableLog).getConsistencyProof(totalEntries1, totalEntries2));
     }
 
     private void validateEntryProofParams(int entryNumber, int totalEntries) {
@@ -65,4 +72,6 @@ public class VerifiableLogResource {
             throw new BadRequestException("Invalid parameters");
         }
     }
+
+
 }

--- a/src/main/java/uk/gov/register/serialization/RSFCreator.java
+++ b/src/main/java/uk/gov/register/serialization/RSFCreator.java
@@ -27,7 +27,7 @@ public class RSFCreator {
                 register.getItemIterator(EntryType.user),
                 register.getEntryIterator(EntryType.system),
                 register.getEntryIterator(EntryType.user),
-                Iterators.singletonIterator(register.getRegisterProof().getRootHash()));
+                Iterators.singletonIterator(register.getV1RegisterProof().getRootHash()));
 
         Iterator<RegisterCommand> commands = Iterators.transform(iterators, obj -> (RegisterCommand) getMapper(obj.getClass()).apply(obj));
         return new RegisterSerialisationFormat(commands);
@@ -37,11 +37,11 @@ public class RSFCreator {
         Iterator<?> iterators;
 
         if (totalEntries1 > 0 && totalEntries1 == totalEntries2) {
-            iterators = Iterators.singletonIterator(register.getRegisterProof(totalEntries1).getRootHash());
+            iterators = Iterators.singletonIterator(register.getV1RegisterProof(totalEntries1).getRootHash());
         } else {
 
-            HashValue previousRootHash = totalEntries1 == 0 ? EMPTY_ROOT_HASH : register.getRegisterProof(totalEntries1).getRootHash();
-            HashValue nextRootHash = register.getRegisterProof(totalEntries2).getRootHash();
+            HashValue previousRootHash = totalEntries1 == 0 ? EMPTY_ROOT_HASH : register.getV1RegisterProof(totalEntries1).getRootHash();
+            HashValue nextRootHash = register.getV1RegisterProof(totalEntries2).getRootHash();
             Iterator<Item> metadataItemIterator = totalEntries1 == 0 ? register.getItemIterator(EntryType.system) : Collections.emptyIterator();
             Iterator<Entry> metadataEntryIterator = totalEntries1 == 0 ? register.getEntryIterator(EntryType.system) : Collections.emptyIterator();
 

--- a/src/main/java/uk/gov/register/serialization/RSFCreator.java
+++ b/src/main/java/uk/gov/register/serialization/RSFCreator.java
@@ -6,6 +6,7 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.util.HashValue;
 
 import java.util.*;
@@ -20,28 +21,28 @@ public class RSFCreator {
         this.registeredMappers = new HashMap<>();
     }
 
-    public RegisterSerialisationFormat create(Register register) {
+    public RegisterSerialisationFormat create(Register register, ProofGenerator proofGenerator) {
         Iterator<?> iterators = Iterators.concat(
                 Iterators.singletonIterator(EMPTY_ROOT_HASH),
                 register.getItemIterator(EntryType.system),
                 register.getItemIterator(EntryType.user),
                 register.getEntryIterator(EntryType.system),
                 register.getEntryIterator(EntryType.user),
-                Iterators.singletonIterator(register.getV1RegisterProof().getRootHash()));
+                Iterators.singletonIterator(proofGenerator.getRootHash()));
 
         Iterator<RegisterCommand> commands = Iterators.transform(iterators, obj -> (RegisterCommand) getMapper(obj.getClass()).apply(obj));
         return new RegisterSerialisationFormat(commands);
     }
 
-    public RegisterSerialisationFormat create(Register register, int totalEntries1, int totalEntries2) {
+    public RegisterSerialisationFormat create(Register register, ProofGenerator proofGenerator, int totalEntries1, int totalEntries2) {
         Iterator<?> iterators;
 
         if (totalEntries1 > 0 && totalEntries1 == totalEntries2) {
-            iterators = Iterators.singletonIterator(register.getV1RegisterProof(totalEntries1).getRootHash());
+            iterators = Iterators.singletonIterator(proofGenerator.getRootHash(totalEntries1));
         } else {
 
-            HashValue previousRootHash = totalEntries1 == 0 ? EMPTY_ROOT_HASH : register.getV1RegisterProof(totalEntries1).getRootHash();
-            HashValue nextRootHash = register.getV1RegisterProof(totalEntries2).getRootHash();
+            HashValue previousRootHash = totalEntries1 == 0 ? EMPTY_ROOT_HASH : proofGenerator.getRootHash(totalEntries1);
+            HashValue nextRootHash = proofGenerator.getRootHash(totalEntries2);
             Iterator<Item> metadataItemIterator = totalEntries1 == 0 ? register.getItemIterator(EntryType.system) : Collections.emptyIterator();
             Iterator<Entry> metadataEntryIterator = totalEntries1 == 0 ? register.getEntryIterator(EntryType.system) : Collections.emptyIterator();
 

--- a/src/main/java/uk/gov/register/serialization/RSFCreator.java
+++ b/src/main/java/uk/gov/register/serialization/RSFCreator.java
@@ -21,7 +21,7 @@ public class RSFCreator {
         this.registeredMappers = new HashMap<>();
     }
 
-    public RegisterSerialisationFormat create(Register register, ProofGenerator proofGenerator) {
+    public RegisterSerialisationFormat createV1(Register register, ProofGenerator proofGenerator) {
         Iterator<?> iterators = Iterators.concat(
                 Iterators.singletonIterator(EMPTY_ROOT_HASH),
                 register.getItemIterator(EntryType.system),
@@ -31,10 +31,10 @@ public class RSFCreator {
                 Iterators.singletonIterator(proofGenerator.getRootHash()));
 
         Iterator<RegisterCommand> commands = Iterators.transform(iterators, obj -> (RegisterCommand) getMapper(obj.getClass()).apply(obj));
-        return new RegisterSerialisationFormat(commands);
+        return new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, commands);
     }
 
-    public RegisterSerialisationFormat create(Register register, ProofGenerator proofGenerator, int totalEntries1, int totalEntries2) {
+    public RegisterSerialisationFormat createV1(Register register, ProofGenerator proofGenerator, int totalEntries1, int totalEntries2) {
         Iterator<?> iterators;
 
         if (totalEntries1 > 0 && totalEntries1 == totalEntries2) {
@@ -55,7 +55,7 @@ public class RSFCreator {
                     Iterators.singletonIterator(nextRootHash));
         }
         Iterator<RegisterCommand> commands = Iterators.transform(iterators, obj -> (RegisterCommand) getMapper(obj.getClass()).apply(obj));
-        return new RegisterSerialisationFormat(commands);
+        return new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, commands);
     }
 
     public void register(RegisterCommandMapper commandMapper) {

--- a/src/main/java/uk/gov/register/serialization/RSFExecutor.java
+++ b/src/main/java/uk/gov/register/serialization/RSFExecutor.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.util.HashValue;
 
 import java.nio.charset.StandardCharsets;
@@ -27,7 +28,7 @@ public class RSFExecutor {
         registeredHandlers.put(registerCommandHandler.getCommandName(), registerCommandHandler);
     }
 
-    public void execute(RegisterSerialisationFormat rsf, Register register) throws RSFParseException {
+    public void execute(RegisterSerialisationFormat rsf, Register register, ProofGenerator proofGenerator) throws RSFParseException {
         // HashValue and RSF file line number
         Map<HashValue, Integer> hashRefLine = new HashMap<>();
         Iterator<RegisterCommand> commands = rsf.getCommands();
@@ -36,7 +37,7 @@ public class RSFExecutor {
             RegisterCommand command = commands.next();
 
             validate(command, register, rsfLine, hashRefLine);
-            execute(command, register);
+            execute(command, register, proofGenerator);
 
             rsfLine++;
         }
@@ -44,10 +45,10 @@ public class RSFExecutor {
         validateOrphanAddItems(hashRefLine);
     }
 
-    private void execute(RegisterCommand command, Register register) throws RSFParseException {
+    private void execute(RegisterCommand command, Register register, ProofGenerator proofGenerator) throws RSFParseException {
         if (registeredHandlers.containsKey(command.getCommandName())) {
             RegisterCommandHandler registerCommandHandler = registeredHandlers.get(command.getCommandName());
-            registerCommandHandler.execute(command, register);
+            registerCommandHandler.execute(command, register, proofGenerator);
         } else {
             throw new RSFParseException("Handler not registered for command: " + command.getCommandName());
         }

--- a/src/main/java/uk/gov/register/serialization/RSFExecutor.java
+++ b/src/main/java/uk/gov/register/serialization/RSFExecutor.java
@@ -35,9 +35,10 @@ public class RSFExecutor {
         int rsfLine = 1;
         while (commands.hasNext()) {
             RegisterCommand command = commands.next();
+            RegisterCommandContext context = new RegisterCommandContext(rsf, proofGenerator);
 
             validate(command, register, rsfLine, hashRefLine);
-            execute(command, register, proofGenerator);
+            execute(command, register, context);
 
             rsfLine++;
         }
@@ -45,10 +46,10 @@ public class RSFExecutor {
         validateOrphanAddItems(hashRefLine);
     }
 
-    private void execute(RegisterCommand command, Register register, ProofGenerator proofGenerator) throws RSFParseException {
+    private void execute(RegisterCommand command, Register register, RegisterCommandContext context) throws RSFParseException {
         if (registeredHandlers.containsKey(command.getCommandName())) {
             RegisterCommandHandler registerCommandHandler = registeredHandlers.get(command.getCommandName());
-            registerCommandHandler.execute(command, register, proofGenerator);
+            registerCommandHandler.execute(command, register, context);
         } else {
             throw new RSFParseException("Handler not registered for command: " + command.getCommandName());
         }

--- a/src/main/java/uk/gov/register/serialization/RegisterCommandContext.java
+++ b/src/main/java/uk/gov/register/serialization/RegisterCommandContext.java
@@ -1,15 +1,16 @@
 package uk.gov.register.serialization;
 
-import uk.gov.register.core.Register;
 import uk.gov.register.proofs.ProofGenerator;
 
 public class RegisterCommandContext {
     private final RegisterSerialisationFormat rsf;
     private final ProofGenerator proofGenerator;
+    private final int rsfLineNo;
 
-    public RegisterCommandContext(RegisterSerialisationFormat rsf, ProofGenerator proofGenerator) {
+    public RegisterCommandContext(RegisterSerialisationFormat rsf, ProofGenerator proofGenerator, int rsfLineNo) {
         this.rsf = rsf;
         this.proofGenerator = proofGenerator;
+        this.rsfLineNo = rsfLineNo;
     }
 
     public RegisterSerialisationFormat.Version getVersion() {
@@ -18,5 +19,9 @@ public class RegisterCommandContext {
 
     public ProofGenerator getProofGenerator() {
         return proofGenerator;
+    }
+
+    public int getRsfLineNo() {
+        return rsfLineNo;
     }
 }

--- a/src/main/java/uk/gov/register/serialization/RegisterCommandContext.java
+++ b/src/main/java/uk/gov/register/serialization/RegisterCommandContext.java
@@ -1,0 +1,22 @@
+package uk.gov.register.serialization;
+
+import uk.gov.register.core.Register;
+import uk.gov.register.proofs.ProofGenerator;
+
+public class RegisterCommandContext {
+    private final RegisterSerialisationFormat rsf;
+    private final ProofGenerator proofGenerator;
+
+    public RegisterCommandContext(RegisterSerialisationFormat rsf, ProofGenerator proofGenerator) {
+        this.rsf = rsf;
+        this.proofGenerator = proofGenerator;
+    }
+
+    public RegisterSerialisationFormat.Version getVersion() {
+        return rsf.getVersion();
+    }
+
+    public ProofGenerator getProofGenerator() {
+        return proofGenerator;
+    }
+}

--- a/src/main/java/uk/gov/register/serialization/RegisterCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/RegisterCommandHandler.java
@@ -2,15 +2,16 @@ package uk.gov.register.serialization;
 
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 
 public abstract class RegisterCommandHandler {
-    protected abstract void executeCommand(RegisterCommand command, Register register);
+    protected abstract void executeCommand(RegisterCommand command, Register register, ProofGenerator proofGenerator);
 
     public abstract String getCommandName();
 
-    public void execute(RegisterCommand command, Register register) {
+    public void execute(RegisterCommand command, Register register, ProofGenerator proofGenerator) {
         if (command.getCommandName().equals(getCommandName())) {
-            executeCommand(command, register);
+            executeCommand(command, register, proofGenerator);
         } else {
             throw new RSFParseException("Incompatible handler (" + getCommandName() + ") and command type (" + command.getCommandName() + ")");
         }

--- a/src/main/java/uk/gov/register/serialization/RegisterCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/RegisterCommandHandler.java
@@ -1,17 +1,18 @@
 package uk.gov.register.serialization;
 
 import uk.gov.register.core.Register;
+import uk.gov.register.core.RegisterContext;
 import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.proofs.ProofGenerator;
 
 public abstract class RegisterCommandHandler {
-    protected abstract void executeCommand(RegisterCommand command, Register register, ProofGenerator proofGenerator);
+    protected abstract void executeCommand(RegisterCommand command, Register register, RegisterCommandContext registerContext);
 
     public abstract String getCommandName();
 
-    public void execute(RegisterCommand command, Register register, ProofGenerator proofGenerator) {
+    public void execute(RegisterCommand command, Register register, RegisterCommandContext context) {
         if (command.getCommandName().equals(getCommandName())) {
-            executeCommand(command, register, proofGenerator);
+            executeCommand(command, register, context);
         } else {
             throw new RSFParseException("Incompatible handler (" + getCommandName() + ") and command type (" + command.getCommandName() + ")");
         }

--- a/src/main/java/uk/gov/register/serialization/RegisterSerialisationFormat.java
+++ b/src/main/java/uk/gov/register/serialization/RegisterSerialisationFormat.java
@@ -3,13 +3,20 @@ package uk.gov.register.serialization;
 import java.util.Iterator;
 
 public class RegisterSerialisationFormat {
+    public enum Version {V1, V2};
+    private final Version version;
     private Iterator<RegisterCommand> commands;
 
-    public RegisterSerialisationFormat(Iterator<RegisterCommand> commands) {
+    public RegisterSerialisationFormat(Version version, Iterator<RegisterCommand> commands) {
         this.commands = commands;
+        this.version = version;
     }
 
     public Iterator<RegisterCommand> getCommands() {
         return commands;
+    }
+
+    public Version getVersion() {
+        return version;
     }
 }

--- a/src/main/java/uk/gov/register/serialization/handlers/AddItemCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AddItemCommandHandler.java
@@ -5,6 +5,7 @@ import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RSFFormatter;
+import uk.gov.register.serialization.RegisterCommandContext;
 import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.serialization.RegisterCommandHandler;
@@ -18,7 +19,7 @@ public class AddItemCommandHandler extends RegisterCommandHandler {
     }
 
     @Override
-    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator _proofGenerator) {
+    protected void executeCommand(RegisterCommand command, Register register, RegisterCommandContext context) {
         try {
             String jsonContent = command.getCommandArguments().get(RSFFormatter.RSF_ITEM_ARGUMENT_POSITION);
             Item item = new Item(objectReconstructor.reconstruct(jsonContent));

--- a/src/main/java/uk/gov/register/serialization/handlers/AddItemCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AddItemCommandHandler.java
@@ -3,6 +3,7 @@ package uk.gov.register.serialization.handlers;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RSFFormatter;
 import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.serialization.RegisterCommand;
@@ -17,7 +18,7 @@ public class AddItemCommandHandler extends RegisterCommandHandler {
     }
 
     @Override
-    protected void executeCommand(RegisterCommand command, Register register) {
+    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator _proofGenerator) {
         try {
             String jsonContent = command.getCommandArguments().get(RSFFormatter.RSF_ITEM_ARGUMENT_POSITION);
             Item item = new Item(objectReconstructor.reconstruct(jsonContent));

--- a/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
@@ -8,6 +8,7 @@ import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RSFFormatter;
 import uk.gov.register.serialization.RegisterCommand;
+import uk.gov.register.serialization.RegisterCommandContext;
 import uk.gov.register.serialization.RegisterCommandHandler;
 import uk.gov.register.util.HashValue;
 
@@ -18,7 +19,7 @@ import static uk.gov.register.core.HashingAlgorithm.SHA256;
 
 public class AppendEntryCommandHandler extends RegisterCommandHandler {
     @Override
-    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator proofGenerator) {
+    protected void executeCommand(RegisterCommand command, Register register, RegisterCommandContext context) {
         try {
             List<String> parts = command.getCommandArguments();
             HashValue itemHash = HashValue.decode(SHA256, parts.get(RSFFormatter.RSF_HASH_POSITION));

--- a/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandler.java
@@ -5,6 +5,7 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RSFFormatter;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.serialization.RegisterCommandHandler;
@@ -17,7 +18,7 @@ import static uk.gov.register.core.HashingAlgorithm.SHA256;
 
 public class AppendEntryCommandHandler extends RegisterCommandHandler {
     @Override
-    protected void executeCommand(RegisterCommand command, Register register) {
+    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator proofGenerator) {
         try {
             List<String> parts = command.getCommandArguments();
             HashValue itemHash = HashValue.decode(SHA256, parts.get(RSFFormatter.RSF_HASH_POSITION));

--- a/src/main/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandler.java
@@ -4,6 +4,7 @@ import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.AssertRootHashException;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RSFFormatter;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.serialization.RegisterCommandHandler;
@@ -12,10 +13,10 @@ import uk.gov.register.util.HashValue;
 
 public class AssertRootHashCommandHandler extends RegisterCommandHandler {
     @Override
-    protected void executeCommand(RegisterCommand command, Register register) {
+    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator proofGenerator) {
         try {
             HashValue expectedHash = HashValue.decode(HashingAlgorithm.SHA256, command.getCommandArguments().get(RSFFormatter.RSF_ASSERT_ROOT_HASH_ARGUMENT_POSITION));
-            HashValue actualHash = register.getV1RegisterProof().getRootHash();
+            HashValue actualHash = proofGenerator.getRootHash();
             if (!actualHash.equals(expectedHash)) {
                 throw new AssertRootHashException(expectedHash, actualHash);
             }

--- a/src/main/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandler.java
@@ -15,7 +15,7 @@ public class AssertRootHashCommandHandler extends RegisterCommandHandler {
     protected void executeCommand(RegisterCommand command, Register register) {
         try {
             HashValue expectedHash = HashValue.decode(HashingAlgorithm.SHA256, command.getCommandArguments().get(RSFFormatter.RSF_ASSERT_ROOT_HASH_ARGUMENT_POSITION));
-            HashValue actualHash = register.getRegisterProof().getRootHash();
+            HashValue actualHash = register.getV1RegisterProof().getRootHash();
             if (!actualHash.equals(expectedHash)) {
                 throw new AssertRootHashException(expectedHash, actualHash);
             }

--- a/src/main/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandler.java
+++ b/src/main/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandler.java
@@ -7,16 +7,17 @@ import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RSFFormatter;
 import uk.gov.register.serialization.RegisterCommand;
+import uk.gov.register.serialization.RegisterCommandContext;
 import uk.gov.register.serialization.RegisterCommandHandler;
 import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.util.HashValue;
 
 public class AssertRootHashCommandHandler extends RegisterCommandHandler {
     @Override
-    protected void executeCommand(RegisterCommand command, Register register, ProofGenerator proofGenerator) {
+    protected void executeCommand(RegisterCommand command, Register register, RegisterCommandContext context) {
         try {
             HashValue expectedHash = HashValue.decode(HashingAlgorithm.SHA256, command.getCommandArguments().get(RSFFormatter.RSF_ASSERT_ROOT_HASH_ARGUMENT_POSITION));
-            HashValue actualHash = proofGenerator.getRootHash();
+            HashValue actualHash = context.getProofGenerator().getRootHash();
             if (!actualHash.equals(expectedHash)) {
                 throw new AssertRootHashException(expectedHash, actualHash);
             }

--- a/src/main/java/uk/gov/register/store/DataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/DataAccessLayer.java
@@ -4,7 +4,7 @@ import uk.gov.register.core.Entry;
 import uk.gov.register.core.EntryType;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
-import uk.gov.register.db.EntryIterator;
+import uk.gov.register.proofs.EntryIterator;
 import uk.gov.register.exceptions.IndexingException;
 import uk.gov.register.util.HashValue;
 

--- a/src/main/java/uk/gov/register/store/postgres/BatchedPostgresDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/BatchedPostgresDataAccessLayer.java
@@ -2,7 +2,7 @@ package uk.gov.register.store.postgres;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.register.core.*;
-import uk.gov.register.db.*;
+import uk.gov.register.proofs.EntryIterator;
 import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.util.HashValue;
 

--- a/src/main/java/uk/gov/register/store/postgres/PostgresDataAccessLayer.java
+++ b/src/main/java/uk/gov/register/store/postgres/PostgresDataAccessLayer.java
@@ -5,7 +5,7 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Record;
 import uk.gov.register.db.EntryDAO;
-import uk.gov.register.db.EntryIterator;
+import uk.gov.register.proofs.EntryIterator;
 import uk.gov.register.db.EntryQueryDAO;
 import uk.gov.register.db.ItemDAO;
 import uk.gov.register.db.ItemQueryDAO;

--- a/src/test/java/uk/gov/register/db/EntryMerkleLeafStoreTest.java
+++ b/src/test/java/uk/gov/register/db/EntryMerkleLeafStoreTest.java
@@ -1,0 +1,44 @@
+package uk.gov.register.db;
+
+import org.junit.Test;
+import uk.gov.register.core.Entry;
+import uk.gov.register.core.EntryType;
+import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.util.HashValue;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EntryMerkleLeafStoreTest {
+    @Test
+    public void testEntryMerkleLeafStoreComputesObjecthash() {
+        Entry entry = new Entry(
+                6,
+                new HashValue(HashingAlgorithm.SHA256, "v1Hash"),
+                new HashValue(HashingAlgorithm.SHA256, "6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb"),
+                OffsetDateTime.of(2016,4,5,13, 23, 5, 0, ZoneOffset.UTC).toInstant(),
+                "GB",
+                EntryType.user
+        );
+        EntryIterator entryIterator = mock(EntryIterator.class);
+        when(entryIterator.findByEntryNumber(1)).thenReturn(entry);
+        EntryMerkleLeafStore store = new EntryMerkleLeafStore(entryIterator);
+
+        byte[] value = store.getLeafValue(0);
+        String valueHex = bytesToHex(value);
+
+        assertEquals("34e124de59e73cb802474faba5b5434983eaeef902d6ec24e3421ebb78bf2c69", valueHex);
+    }
+
+    private String bytesToHex(byte[] value) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : value) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/uk/gov/register/db/EntryMerkleLeafStoreTest.java
+++ b/src/test/java/uk/gov/register/db/EntryMerkleLeafStoreTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import uk.gov.register.core.Entry;
 import uk.gov.register.core.EntryType;
 import uk.gov.register.core.HashingAlgorithm;
+import uk.gov.register.proofs.EntryIterator;
+import uk.gov.register.proofs.EntryMerkleLeafStore;
 import uk.gov.register.util.HashValue;
 
 import java.time.OffsetDateTime;

--- a/src/test/java/uk/gov/register/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/functional/ApplicationTest.java
@@ -27,7 +27,7 @@ public class ApplicationTest {
     @Before
     public void setup() {
         register.wipe();
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
     }
 
     @Test
@@ -100,7 +100,7 @@ public class ApplicationTest {
 
     @Test
     public void returns400BadRequest() {
-        Response response = register.loadRsf(address, "nope");
+        Response response = register.loadRsfV1(address, "nope");
 
         assertThat(response.getStatus(), equalTo(400));
     }

--- a/src/test/java/uk/gov/register/functional/AuthenticationTest.java
+++ b/src/test/java/uk/gov/register/functional/AuthenticationTest.java
@@ -22,8 +22,8 @@ public class AuthenticationTest {
 
     @Before
     public void setup() {
-        register.loadRsf(TestRegister.address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
-        register.loadRsf(TestRegister.postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
+        register.loadRsfV1(TestRegister.address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
+        register.loadRsfV1(TestRegister.postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
     }
     
     @Test

--- a/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadFunctionalTest.java
@@ -42,8 +42,8 @@ public class DataDownloadFunctionalTest {
     @Before
     public void publishTestMessages() {
         register.wipe();
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_NAME + RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
-        register.loadRsf(
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_NAME + RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
+        register.loadRsfV1(
             address,
             "add-item\t{\"custodian\":\"John Smith\"}\n" +
             "add-item\t{\"address\":\"12345\",\"street\":\"ellis\"}\n" +

--- a/src/test/java/uk/gov/register/functional/DataDownloadResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataDownloadResourceFunctionalTest.java
@@ -26,8 +26,8 @@ public class DataDownloadResourceFunctionalTest {
 
     @Before
     public void setup() {
-        register.loadRsf(REGISTER_WITH_DOWNLOAD_ENABLED, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
-        register.loadRsf(REGISTER_WITH_DOWNLOAD_DISABLED, RsfRegisterDefinition.REGISTER_REGISTER);
+        register.loadRsfV1(REGISTER_WITH_DOWNLOAD_ENABLED, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
+        register.loadRsfV1(REGISTER_WITH_DOWNLOAD_DISABLED, RsfRegisterDefinition.REGISTER_REGISTER);
     }
 
     private final String targetUrl;

--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataAvailabilityFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataAvailabilityFunctionalTest.java
@@ -31,7 +31,7 @@ public class DeleteRegisterDataAvailabilityFunctionalTest {
     
     @Before
     public void setup() {
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
     }
 
     private final Boolean isAuthenticated;

--- a/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DeleteRegisterDataFunctionalTest.java
@@ -23,14 +23,14 @@ public class DeleteRegisterDataFunctionalTest {
 
     @Test
     public void deleteRegisterData_deletesAllDataFromDb() throws Exception {
-        register.loadRsf(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
+        register.loadRsfV1(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
 
         String rsf = "add-item\t{\"postcode\":\"P1\"}\n" +
                 "add-item\t{\"postcode\":\"P2\"}\n" +
                 "append-entry\tuser\tP1\t2018-07-26T15:55:27Z\tsha-256:50a5de96d4cb6341a2f18c0b34bc401b2c92e3ac46641c0d1014dc82ed498326\n" +
                 "append-entry\tuser\tP2\t2018-07-26T15:55:27Z\tsha-256:af0cf1489bfb0f3da8130a50e6b4fa49de7c480a416dfa710418c0e42dc72949\n";
 
-        Response mintResponse = register.loadRsf(REGISTER_WHICH_ALLOWS_DELETING, rsf);
+        Response mintResponse = register.loadRsfV1(REGISTER_WHICH_ALLOWS_DELETING, rsf);
         assertThat(mintResponse.getStatus(), equalTo(200));
 
         Response entriesResponse1 = register.getRequest(REGISTER_WHICH_ALLOWS_DELETING, "/entries.json");
@@ -48,7 +48,7 @@ public class DeleteRegisterDataFunctionalTest {
 
     @Test
     public void deleteRegisterData_deletesProofCache() throws Exception {
-        register.loadRsf(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
+        register.loadRsfV1(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
 
         String rsf = "add-item\t{\"postcode\":\"P1\"}\n" +
                 "add-item\t{\"postcode\":\"P2\"}\n" +
@@ -56,15 +56,15 @@ public class DeleteRegisterDataFunctionalTest {
                 "append-entry\tuser\tP2\t2018-07-26T15:55:27Z\tsha-256:af0cf1489bfb0f3da8130a50e6b4fa49de7c480a416dfa710418c0e42dc72949\n";
 
         register.deleteRegisterData(REGISTER_WHICH_ALLOWS_DELETING);
-        register.loadRsf(REGISTER_WHICH_ALLOWS_DELETING, rsf);
+        register.loadRsfV1(REGISTER_WHICH_ALLOWS_DELETING, rsf);
 
         Response proof1Response = register.getRequest(REGISTER_WHICH_ALLOWS_DELETING, "/proof/register/merkle:sha-256");
         assertThat(proof1Response.getStatus(), equalTo(200));
         String proof1 = proof1Response.readEntity(String.class);
 
         register.deleteRegisterData(REGISTER_WHICH_ALLOWS_DELETING);
-        register.loadRsf(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
-        register.loadRsf(REGISTER_WHICH_ALLOWS_DELETING, rsf);
+        register.loadRsfV1(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
+        register.loadRsfV1(REGISTER_WHICH_ALLOWS_DELETING, rsf);
 
         Response proof2Response = register.getRequest(REGISTER_WHICH_ALLOWS_DELETING, "/proof/register/merkle:sha-256");
         assertThat(proof2Response.getStatus(), equalTo(200));

--- a/src/test/java/uk/gov/register/functional/EntriesResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntriesResourceFunctionalTest.java
@@ -33,7 +33,7 @@ public class EntriesResourceFunctionalTest {
     @Before
     public void setup() {
         register.wipe();
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class EntriesResourceFunctionalTest {
                 "append-entry\tuser\t1234\t2018-07-26T15:51:26Z\tsha-256:cb0f5233e9acf1a41f30803dcf902208e7d4918a41a9738091b179ce8c62010c\n" +
                 "append-entry\tuser\t6789\t2018-07-26T15:51:26Z\tsha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\n";
 
-        register.loadRsf(address, rsf);
+        register.loadRsfV1(address, rsf);
 
         Response response = register.getRequest(address, "/entries.json");
         assertThat(response.getStatus(), equalTo(200));
@@ -109,7 +109,7 @@ public class EntriesResourceFunctionalTest {
                 "append-entry\tuser\tregister1\t2018-07-26T15:48:03Z\tsha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983\n" +
                 "append-entry\tuser\tregister1\t2018-07-26T15:48:03Z\tsha-256:6352a25fe8c9222676b29ba6f5e675b5dfa2b886010a844dd596b0d0cd615849\n";
 
-        register.loadRsf(address, rsf);
+        register.loadRsfV1(address, rsf);
 
         Response response = addressTarget.path("/entries.json").queryParam("start",1).queryParam("limit",2)
                 .request().get();

--- a/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/EntryResourceFunctionalTest.java
@@ -41,7 +41,7 @@ public class EntryResourceFunctionalTest {
     @Before
     public void publishTestMessages() throws Throwable {
         register.wipe();
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER + addressRsf());
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER + addressRsf());
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/functional/FindEntityTest.java
@@ -26,7 +26,7 @@ public class FindEntityTest {
     @Before
     public void publishTestMessages() {
         register.wipe();
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER +
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER +
             "add-item\t{\"address\":\"12345\",\"street\":\"ellis\"}\n" +
             "append-entry\tuser\t12345\t2017-06-13T09:20:41Z\tsha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\n" +
             "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}\n" +

--- a/src/test/java/uk/gov/register/functional/HomePageFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/HomePageFunctionalTest.java
@@ -26,7 +26,7 @@ public class HomePageFunctionalTest {
 
     @Before
     public void setup() {
-        register.loadRsf(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
+        register.loadRsfV1(postcode, RsfRegisterDefinition.POSTCODE_REGISTER);
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/ItemResourceFunctionalTest.java
@@ -25,14 +25,14 @@ public class ItemResourceFunctionalTest {
     @Before
     public void publishTestMessages() throws Throwable {
         register.wipe();
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
 
         String rsf = "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}\n" +
                 "add-item\t{\"address\":\"145678\",\"street\":\"ellis\"}\n" +
                 "append-entry\tuser\tregister1\t2018-07-26T15:43:12Z\tsha-256:bd239db51960376826b937a615f0f3397485f00611d35bb7e951e357bf73b934\n" +
                 "append-entry\tuser\tregister1\t2018-07-26T15:43:12Z\tsha-256:8ac926428ee49fb83c02bdd2556e62e84cfd9e636cd35eb1306ac8cb661e4983\n";
 
-        register.loadRsf(address, rsf);
+        register.loadRsfV1(address, rsf);
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/LoadSerializedFunctionalTest.java
@@ -149,9 +149,9 @@ public class LoadSerializedFunctionalTest {
     @Test
     public void shouldReturnBadRequestWhenLoadingDuplicateItemForExistingRecord() throws IOException {
         String metadataRsf = new String(Files.readAllBytes(Paths.get("src/test/resources/fixtures/local-authority-eng-metadata.rsf")));
-        register.loadRsf(TestRegister.local_authority_eng, metadataRsf);
+        register.loadRsfV1(TestRegister.local_authority_eng, metadataRsf);
 
-        Response initialResponse = register.loadRsf(TestRegister.local_authority_eng,
+        Response initialResponse = register.loadRsfV1(TestRegister.local_authority_eng,
             "add-item\t{\"local-authority-eng\":\"Notts\",\"local-authority-type\":\"MD\"}\n" +
             "add-item\t{\"local-authority-eng\":\"London\",\"local-authority-type\":\"UA\"}\n" +
             "add-item\t{\"local-authority-eng\":\"Leics\",\"local-authority-type\":\"CTY\"}\n" +
@@ -161,7 +161,7 @@ public class LoadSerializedFunctionalTest {
 
         assertThat(initialResponse.getStatus(), equalTo(200));
 
-        Response duplicateItemResponse = register.loadRsf(TestRegister.local_authority_eng,
+        Response duplicateItemResponse = register.loadRsfV1(TestRegister.local_authority_eng,
             "add-item\t{\"local-authority-eng\":\"Notts\",\"local-authority-type\":\"MD\"}\n" +
             "append-entry\tuser\tNotts\t2016-04-05T13:23:05Z\tsha-256:d57e3435709718d26dcc527676bca19583c4309fc1e4c116b2a6ca528f62c125");
 
@@ -172,9 +172,9 @@ public class LoadSerializedFunctionalTest {
     @Test
     public void shouldReturnBadRequestWhenLoadingDuplicateItemForNewUserRecord() throws IOException {
         String metadataRsf = new String(Files.readAllBytes(Paths.get("src/test/resources/fixtures/local-authority-eng-metadata.rsf")));
-        register.loadRsf(TestRegister.local_authority_eng, metadataRsf);
+        register.loadRsfV1(TestRegister.local_authority_eng, metadataRsf);
 
-        Response response = register.loadRsf(TestRegister.local_authority_eng,
+        Response response = register.loadRsfV1(TestRegister.local_authority_eng,
             "add-item\t{\"local-authority-eng\":\"Notts\",\"local-authority-type\":\"MD\"}\n" +
             "append-entry\tuser\tNotts\t2016-04-05T13:23:05Z\tsha-256:d57e3435709718d26dcc527676bca19583c4309fc1e4c116b2a6ca528f62c125\n" +
             "append-entry\tuser\tNotts\t2016-04-05T13:23:05Z\tsha-256:d57e3435709718d26dcc527676bca19583c4309fc1e4c116b2a6ca528f62c125");
@@ -186,9 +186,9 @@ public class LoadSerializedFunctionalTest {
     @Test
     public void shouldReturnBadRequestWhenLoadingDuplicateItemForNewMetadataRecord() throws IOException {
         String metadataRsf = new String(Files.readAllBytes(Paths.get("src/test/resources/fixtures/local-authority-eng-metadata.rsf")));
-        register.loadRsf(TestRegister.local_authority_eng, metadataRsf);
+        register.loadRsfV1(TestRegister.local_authority_eng, metadataRsf);
 
-        Response response = register.loadRsf(TestRegister.local_authority_eng,
+        Response response = register.loadRsfV1(TestRegister.local_authority_eng,
                 "add-item\t{\"local-authority-eng\":\"Notts\",\"local-authority-type\":\"MD\"}\n" +
                         "append-entry\tsystem\tregister-name\t2016-04-05T13:23:05Z\tsha-256:d57e3435709718d26dcc527676bca19583c4309fc1e4c116b2a6ca528f62c125\n" +
                         "append-entry\tsystem\tregister-name\t2016-04-05T13:23:05Z\tsha-256:d57e3435709718d26dcc527676bca19583c4309fc1e4c116b2a6ca528f62c125");
@@ -200,15 +200,15 @@ public class LoadSerializedFunctionalTest {
     @Test
     public void shouldReturnBadRequestWhenLoadingDuplicateItemsForExistingRecord() throws IOException {
         String metadataRsf = new String(Files.readAllBytes(Paths.get("src/test/resources/fixtures/local-authority-eng-metadata.rsf")));
-        register.loadRsf(TestRegister.local_authority_eng, metadataRsf);
+        register.loadRsfV1(TestRegister.local_authority_eng, metadataRsf);
 
-        Response initialResponse = register.loadRsf(TestRegister.local_authority_eng,
+        Response initialResponse = register.loadRsfV1(TestRegister.local_authority_eng,
             "add-item\t{\"local-authority-eng\":\"Notts\",\"local-authority-type\":\"MD\"}\n" +
             "append-entry\tuser\tEastMidlands\t2016-04-05T13:23:05Z\tsha-256:d57e3435709718d26dcc527676bca19583c4309fc1e4c116b2a6ca528f62c125");
 
         assertThat(initialResponse.getStatus(), equalTo(200));
 
-        Response duplicateItemResponse = register.loadRsf(TestRegister.local_authority_eng,
+        Response duplicateItemResponse = register.loadRsfV1(TestRegister.local_authority_eng,
             "add-item\t{\"local-authority-eng\":\"Notts\",\"local-authority-type\":\"MD\"}\n" +
             "append-entry\tuser\tEastMidlands\t2016-04-05T13:23:05Z\tsha-256:d57e3435709718d26dcc527676bca19583c4309fc1e4c116b2a6ca528f62c125");
 
@@ -262,7 +262,7 @@ public class LoadSerializedFunctionalTest {
 
 	@Test
 	public void shouldReturnBadRequestWhenRegisterIsMissingFieldsDefinedInEnvironment() throws Exception {
-		Response response = register.loadRsf(TestRegister.postcode,
+		Response response = register.loadRsfV1(TestRegister.postcode,
 				"add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
 						"append-entry\tsystem\tfield:postcode\t2017-06-09T12:59:51Z\tsha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a\n" +
 						"add-item\t{\"fields\":[\"postcode\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
@@ -273,7 +273,7 @@ public class LoadSerializedFunctionalTest {
 
     @Test
     public void shouldReturnBadRequestWhenLocalFieldDoesNotExistInEnvironment() throws Exception {
-        Response response = register.loadRsf(TestRegister.postcode,
+        Response response = register.loadRsfV1(TestRegister.postcode,
             "add-item\t{\"cardinality\":\"1\",\"datatype\":\"string\",\"field\":\"test-postcode\",\"phase\":\"alpha\",\"text\":\"UK Postcodes.\"}\n" +
             "append-entry\tsystem\tfield:test-postcode\t2017-06-09T12:59:51Z\tsha-256:eb0381c0c768767e60b3edf140e6bdf241f5e6f01a98c3751da488c3e6ffb3fe\n" +
             "add-item\t{\"fields\":[\"test-postcode\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
@@ -292,13 +292,13 @@ public class LoadSerializedFunctionalTest {
             "add-item\t{\"fields\":[\"postcode\",\"point\"],\"phase\":\"alpha\",\"register\":\"test\",\"registry\":\"cabinet-office\",\"text\":\"Register of postcodes\"}\n" +
             "append-entry\tsystem\tregister:postcode\t2017-06-06T09:54:11Z\tsha-256:ee2fd6546a8362d98e3cd63d914ca55d93f15801c35fdd108b9294c4f0a1d01e\n";
 
-        Response response = register.loadRsf(TestRegister.postcode, rsf);
+        Response response = register.loadRsfV1(TestRegister.postcode, rsf);
         assertThat(response.getStatus(), equalTo(400));
         assertThat(response.readEntity(String.class), equalTo("{\"success\":false,\"message\":\"Failed to load RSF\",\"details\":\"Exception when executing command: RegisterCommand{commandName='append-entry', arguments=[system, field:postcode, 2017-06-09T12:59:51Z, sha-256:689e7a836844817b102d0049c6d402fc630f1c9f284ee96d9b7ec24bc7e0c36a]}: Failed to append entry with entry-number 1 and key 'field:postcode': Definition of field postcode does not match Field Register\"}"));
     }
 
     private Response send(String payload) {
-        return register.loadRsf(testRegister, RsfRegisterDefinition.REGISTER_REGISTER + payload);
+        return register.loadRsfV1(testRegister, RsfRegisterDefinition.REGISTER_REGISTER + payload);
     }
 
     private JsonNode nodeOf(String jsonString) throws IOException {

--- a/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordListResourceFunctionalTest.java
@@ -30,8 +30,8 @@ public class RecordListResourceFunctionalTest {
     @Before
     public void publishTestMessages() {
         register.wipe();
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
-        register.loadRsf(address, 
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER);
+        register.loadRsfV1(address,
             "add-item\t{\"address\":\"12345\",\"street\":\"ellis\"}\n" +
             "append-entry\tuser\t12345\t2017-07-28T13:08:48Z\tsha-256:19205fafe65406b9b27fce1b689abc776df4ddcf150c28b29b73b4ea054af6b9\n" +
             "add-item\t{\"address\":\"6789\",\"street\":\"presley\"}\n" +

--- a/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RecordResourceFunctionalTest.java
@@ -27,7 +27,7 @@ public class RecordResourceFunctionalTest {
     @Before
     public void publishTestMessages() throws Throwable {
         register.wipe();
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER + addressRsf());
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_FIELDS + RsfRegisterDefinition.ADDRESS_REGISTER + addressRsf());
     }
 
     @Test

--- a/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RegisterResourceFunctionalTest.java
@@ -27,7 +27,7 @@ public class RegisterResourceFunctionalTest {
     @Before
     public void setup() {
         register.wipe();
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_FIELDS +  RsfRegisterDefinition.ADDRESS_REGISTER );
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_FIELDS +  RsfRegisterDefinition.ADDRESS_REGISTER );
     }
 
     private final Map<?, ?> expectedAddressRegisterMap = getAddressRegisterMap();
@@ -44,7 +44,7 @@ public class RegisterResourceFunctionalTest {
                 "add-item\t{\"address\":\"145678\"}\n" +
                 "append-entry\tuser\t145678\t2017-05-23T10:12:34Z\tsha-256:921c14161f7c13a18a52e8418c0c69ac7211d40cbaf53c58513dc668d68376d8";
 
-        register.loadRsf(address, payload);
+        register.loadRsfV1(address, payload);
 
         Response registerResourceFromAddressRegisterResponse = register.getRequest(address, "/register.json");
         assertThat(registerResourceFromAddressRegisterResponse.getStatus(), equalTo(200));
@@ -63,7 +63,7 @@ public class RegisterResourceFunctionalTest {
 
     @Test
     public void registerJsonShouldContainCorrectFieldsForRegister() {
-        register.loadRsf(address, RsfRegisterDefinition.ADDRESS_REGISTER);
+        register.loadRsfV1(address, RsfRegisterDefinition.ADDRESS_REGISTER);
         Response registerResourceFromAddressRegisterResponse = register.getRequest(address, "/register.json");
         Map registerResourceMapFromAddressRegister = registerResourceFromAddressRegisterResponse.readEntity(Map.class);
         Map<?, ?> registerRecordMapFromAddressRegister = (Map) registerResourceMapFromAddressRegister.get("register-record");

--- a/src/test/java/uk/gov/register/functional/RepresentationsFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/RepresentationsFunctionalTest.java
@@ -13,14 +13,9 @@ import uk.gov.register.functional.app.RsfRegisterDefinition;
 import uk.gov.register.functional.app.TestRegister;
 
 import javax.ws.rs.core.Response;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -44,7 +39,7 @@ public class RepresentationsFunctionalTest {
     @Before
     public void publishTestMessages() {
         register.wipe();
-        register.loadRsf(TestRegister.register, RsfRegisterDefinition.REGISTER_REGISTER +
+        register.loadRsfV1(TestRegister.register, RsfRegisterDefinition.REGISTER_REGISTER +
                 "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
                 "append-entry\tuser\tvalue1\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\n" +

--- a/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/VerifiableLogResourceFunctionalTest.java
@@ -4,7 +4,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.register.functional.app.RegisterRule;
-import uk.gov.register.views.RegisterProof;
 
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -33,7 +32,7 @@ public class VerifiableLogResourceFunctionalTest {
     @Before
     public void publishTestMessages() throws Throwable {
         register.wipe();
-        register.loadRsf(address, ADDRESS_FIELDS + ADDRESS_REGISTER +
+        register.loadRsfV1(address, ADDRESS_FIELDS + ADDRESS_REGISTER +
             "add-item\t{\"address\":\"1111\",\"street\":\"elvis\"}\n" +
             "append-entry\tuser\t1111\t2017-06-12T14:05:01Z\tsha-256:c4ede5d49a5d0ea7babbc097b0905acf2bb5146f288c8b33ba3e29762196566f\n" +
             "add-item\t{\"address\":\"2222\",\"street\":\"presley\"}\n" +
@@ -45,7 +44,7 @@ public class VerifiableLogResourceFunctionalTest {
             "add-item\t{\"address\":\"5555\",\"street\":\"elfsley\"}\n" +
             "append-entry\tuser\t5555\t2017-06-12T14:05:01Z\tsha-256:4882ebcc80b9005597f571019efc23e8a36422623cd4811c2213f44d4faf9545");
 
-        register.loadRsf(postcode, POSTCODE_REGISTER +
+        register.loadRsfV1(postcode, POSTCODE_REGISTER +
             "add-item\t{\"postcode\":\"P1\"}\n" +
             "append-entry\tuser\tP1\t2017-06-12T14:06:30Z\tsha-256:50a5de96d4cb6341a2f18c0b34bc401b2c92e3ac46641c0d1014dc82ed498326\n" +
             "add-item\t{\"postcode\":\"P2\"}\n" +

--- a/src/test/java/uk/gov/register/functional/app/RegisterRule.java
+++ b/src/test/java/uk/gov/register/functional/app/RegisterRule.java
@@ -67,8 +67,14 @@ public class RegisterRule implements TestRule {
         return target(register.getHostname());
     }
 
-    public Response loadRsf(TestRegister register, String rsf) {
+    public Response loadRsfV1(TestRegister register, String rsf) {
         return authenticatedTarget(register).path("/load-rsf")
+                .request()
+                .post(entity(rsf, APPLICATION_RSF_TYPE));
+    }
+
+    public Response loadRsf(TestRegister register, String rsf) {
+        return authenticatedTarget(register).path("/next/load-rsf")
                 .request()
                 .post(entity(rsf, APPLICATION_RSF_TYPE));
     }

--- a/src/test/java/uk/gov/register/functional/db/EntryIteratorFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/db/EntryIteratorFunctionalTest.java
@@ -28,7 +28,7 @@ public class EntryIteratorFunctionalTest {
     @Before
     public void publishTestMessages() {
         register.wipe();
-        register.loadRsf(TestRegister.register, RsfRegisterDefinition.REGISTER_REGISTER);
+        register.loadRsfV1(TestRegister.register, RsfRegisterDefinition.REGISTER_REGISTER);
 
         entryQueryDAO = mock(EntryQueryDAO.class);
         when(entryQueryDAO.entriesIteratorFrom(anyInt(), eq(schema))).thenAnswer(invocation ->
@@ -37,7 +37,7 @@ public class EntryIteratorFunctionalTest {
 
     @Test
     public void testCanIterateInOrder() {
-        register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+        register.loadRsfV1(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
                 "append-entry\tuser\tvalue1\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\n" +
                 "append-entry\tuser\tvalue2\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\n");
@@ -51,7 +51,7 @@ public class EntryIteratorFunctionalTest {
 
     @Test
     public void testCanIterateNotInOrder() {
-        register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+        register.loadRsfV1(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                 "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
                 "append-entry\tuser\tvalue1\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\n" +
                 "append-entry\tuser\tvalue2\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\n");
@@ -66,12 +66,12 @@ public class EntryIteratorFunctionalTest {
     @Test
     public void testCanStillIterateAfterIteratorEndsThenNewEntriesAdded() {
         EntryIterator.withEntryIterator(entryQueryDAO, entryIteratorDAO -> {
-            register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+            register.loadRsfV1(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                     "append-entry\tuser\tvalue1\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\n");
 
             assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
 
-            register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
+            register.loadRsfV1(TestRegister.register, "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
                     "append-entry\tuser\tvalue2\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\n");
 
             assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));
@@ -82,14 +82,14 @@ public class EntryIteratorFunctionalTest {
     @Test
     public void testCanStillIterateAfterIteratorDoesNotThenNewEntriesAddedd() {
         EntryIterator.withEntryIterator(entryQueryDAO, entryIteratorDAO -> {
-            register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
+            register.loadRsfV1(TestRegister.register, "add-item\t{\"fields\":[\"field1\"],\"register\":\"value1\",\"text\":\"The Entry 1\"}\n" +
                     "add-item\t{\"fields\":[\"field1\",\"field2\"],\"register\":\"value2\",\"text\":\"The Entry 2\"}\n" +
                     "append-entry\tuser\tvalue1\t2016-03-01T01:02:03Z\tsha-256:877d8bd1ab71dc6e48f64b4ca83c6d7bf645a1eb56b34d50fa8a833e1101eb18\n" +
                     "append-entry\tuser\tvalue2\t2016-03-02T02:03:04Z\tsha-256:63e5a0453b088e39265ca9f20fd03e2b206422e32989649adaca84426b531cd7\n");
 
             assertThat(entryIteratorDAO.findByEntryNumber(1).getEntryNumber(), equalTo(1));
 
-            register.loadRsf(TestRegister.register, "add-item\t{\"fields\":[\"field1\",\"field2\",\"field3\"],\"register\":\"value3\",\"text\":\"The Entry 3\"}\n" +
+            register.loadRsfV1(TestRegister.register, "add-item\t{\"fields\":[\"field1\",\"field2\",\"field3\"],\"register\":\"value3\",\"text\":\"The Entry 3\"}\n" +
                     "append-entry\tuser\tvalue1\t2016-03-01T01:02:03Z\tsha-256:8d5c2ed1e59f8871dff6e2132171008f12f43aa37e70ab158d598bc6b6db848f\n");
 
             assertThat(entryIteratorDAO.findByEntryNumber(2).getEntryNumber(), equalTo(2));

--- a/src/test/java/uk/gov/register/functional/db/EntryIteratorFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/db/EntryIteratorFunctionalTest.java
@@ -3,7 +3,7 @@ package uk.gov.register.functional.db;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import uk.gov.register.db.EntryIterator;
+import uk.gov.register.proofs.EntryIterator;
 import uk.gov.register.db.EntryQueryDAO;
 import uk.gov.register.functional.app.RegisterRule;
 import uk.gov.register.functional.app.RsfRegisterDefinition;

--- a/src/test/java/uk/gov/register/functional/store/postgres/RegisterImplTransactionalFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/store/postgres/RegisterImplTransactionalFunctionalTest.java
@@ -47,7 +47,6 @@ import uk.gov.register.store.DataAccessLayer;
 import uk.gov.register.store.postgres.BatchedPostgresDataAccessLayer;
 import uk.gov.register.store.postgres.PostgresDataAccessLayer;
 import uk.gov.register.util.HashValue;
-import uk.gov.verifiablelog.store.memoization.DoNothing;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -231,7 +230,7 @@ public class RegisterImplTransactionalFunctionalTest {
     }
 
     private RegisterImpl getPostgresRegister(DataAccessLayer dataAccessLayer) {
-        EntryLog entryLog = new EntryLogImpl(dataAccessLayer, new DoNothing());
+        EntryLog entryLog = new EntryLogImpl(dataAccessLayer);
         ItemValidator itemValidator = mock(ItemValidator.class);
         ItemStore itemStore = new ItemStoreImpl(dataAccessLayer);
         RegisterId registerId = new RegisterId("address");

--- a/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
@@ -23,7 +23,7 @@ public class RedirectResourceTest  {
     @Before
     public void publishTestMessages() throws Throwable {
         register.wipe();
-        register.loadRsf(TestRegister.register, RsfRegisterDefinition.REGISTER_REGISTER);
+        register.loadRsfV1(TestRegister.register, RsfRegisterDefinition.REGISTER_REGISTER);
     }
 
     @Test

--- a/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
@@ -2,6 +2,7 @@ package uk.gov.register.resources;
 
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
+import uk.gov.register.core.EntryLog;
 import uk.gov.register.core.EntryType;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.RegisterReadOnly;
@@ -26,13 +27,13 @@ public class VerifiableLogResourceTest {
     @Test
     public void shouldUseServiceToGetRegisterProof() {
         RegisterProof expectedProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, sampleHash1), 12345);
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getRegisterProof()).thenReturn(expectedProof);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getV1RegisterProof()).thenReturn(expectedProof);
 
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
         RegisterProof actualProof = vlResource.registerProof();
 
-        verify(registerMock, times(1)).getRegisterProof();
+        verify(entryLogMock, times(1)).getV1RegisterProof();
         assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
         assertThat(actualProof.getRootHash(), equalTo(expectedProof.getRootHash()));
     }
@@ -46,14 +47,14 @@ public class VerifiableLogResourceTest {
         List<HashValue> expectedAuditPath = Arrays.asList(expectedHash1, expectedHash2);
 
         EntryProof expectedProof = new EntryProof("3", expectedAuditPath);
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        when(registerMock.getEntryProof(entryNumber, totalEntries)).thenReturn(expectedProof);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        when(entryLogMock.getV1EntryProof(entryNumber, totalEntries)).thenReturn(expectedProof);
 
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
         EntryProof actualProof = vlResource.entryProof(entryNumber, totalEntries);
 
-        verify(registerMock, times(1)).getEntryProof(entryNumber, totalEntries);
+        verify(entryLogMock, times(1)).getV1EntryProof(entryNumber, totalEntries);
         assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
         assertThat(actualProof.getEntryNumber(), equalTo(expectedProof.getEntryNumber()));
         assertThat(actualProof.getAuditPath(), IsIterableContainingInOrder.contains(expectedHash1, expectedHash2));
@@ -68,14 +69,14 @@ public class VerifiableLogResourceTest {
         List<HashValue> expectedConsistencyNodes = Arrays.asList(expectedHash1, expectedHash2);
 
         ConsistencyProof expectedProof = new ConsistencyProof(expectedConsistencyNodes);
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        when(registerMock.getConsistencyProof(totalEntries1, totalEntries2)).thenReturn(expectedProof);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        when(entryLogMock.getV1ConsistencyProof(totalEntries1, totalEntries2)).thenReturn(expectedProof);
 
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
         ConsistencyProof actualProof = vlResource.consistencyProof(totalEntries1, totalEntries2);
 
-        verify(registerMock, times(1)).getConsistencyProof(totalEntries1, totalEntries2);
+        verify(entryLogMock, times(1)).getV1ConsistencyProof(totalEntries1, totalEntries2);
         assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
 
         assertThat(actualProof.getConsistencyNodes(), IsIterableContainingInOrder.contains(expectedHash1, expectedHash2));
@@ -83,54 +84,54 @@ public class VerifiableLogResourceTest {
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfEntryNumberTooSmall() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.entryProof(0, 5);
     }
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfEntryNumberGreaterThanTotalEntries() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.entryProof(5, 3);
     }
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfTotalEntriesGreaterThanSizeOfRegister() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.entryProof(5, 10);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries1TooSmall() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.consistencyProof(0, 5);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofshouldThrowBadRequestExceptionIfTotalEntries2SmallerThanTotalEntries1() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.consistencyProof(5, 3);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries2GreaterThanSizeOfRegister() {
-        RegisterReadOnly registerMock = mock(RegisterReadOnly.class);
-        when(registerMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(registerMock);
+        EntryLog entryLogMock = mock(EntryLog.class);
+        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
+        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
 
         vlResource.consistencyProof(5, 10);
     }

--- a/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/VerifiableLogResourceTest.java
@@ -1,139 +1,71 @@
 package uk.gov.register.resources;
 
-import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.register.core.EntryLog;
 import uk.gov.register.core.EntryType;
-import uk.gov.register.core.HashingAlgorithm;
-import uk.gov.register.core.RegisterReadOnly;
+import uk.gov.register.core.RegisterContext;
 import uk.gov.register.resources.v2.VerifiableLogResource;
-import uk.gov.register.util.HashValue;
-import uk.gov.register.views.ConsistencyProof;
-import uk.gov.register.views.EntryProof;
-import uk.gov.register.views.RegisterProof;
 
 import javax.ws.rs.BadRequestException;
-import java.util.Arrays;
-import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class VerifiableLogResourceTest {
     private final String sampleHash1 = "6b85b168f7c5f0587fc22ff4ba6937e61b33f6e89b70eed53d78d895d35dc9c3";
     private final String sampleHash2 = "d3d33f57b033d18ad11e14b28ef6f33487410c98548d1759c772370dfeb6db11";
 
-    @Test
-    public void shouldUseServiceToGetRegisterProof() {
-        RegisterProof expectedProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, sampleHash1), 12345);
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getV1RegisterProof()).thenReturn(expectedProof);
+    @Mock
+    private RegisterContext registerContext;
 
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-        RegisterProof actualProof = vlResource.registerProof();
+    @Mock
+    private EntryLog entryLog;
 
-        verify(entryLogMock, times(1)).getV1RegisterProof();
-        assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
-        assertThat(actualProof.getRootHash(), equalTo(expectedProof.getRootHash()));
-    }
+    private VerifiableLogResource resource;
 
-    @Test
-    public void shouldUseServiceToGetEntryProof() {
-        int entryNumber = 2;
-        int totalEntries = 5;
-        HashValue expectedHash1 = new HashValue(HashingAlgorithm.SHA256, sampleHash1);
-        HashValue expectedHash2 = new HashValue(HashingAlgorithm.SHA256, sampleHash2);
-        List<HashValue> expectedAuditPath = Arrays.asList(expectedHash1, expectedHash2);
+    @Before
+    public void setUp() {
+        when(registerContext.buildEntryLog()).thenReturn(entryLog);
 
-        EntryProof expectedProof = new EntryProof("3", expectedAuditPath);
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        when(entryLogMock.getV1EntryProof(entryNumber, totalEntries)).thenReturn(expectedProof);
-
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-        EntryProof actualProof = vlResource.entryProof(entryNumber, totalEntries);
-
-        verify(entryLogMock, times(1)).getV1EntryProof(entryNumber, totalEntries);
-        assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
-        assertThat(actualProof.getEntryNumber(), equalTo(expectedProof.getEntryNumber()));
-        assertThat(actualProof.getAuditPath(), IsIterableContainingInOrder.contains(expectedHash1, expectedHash2));
-    }
-
-    @Test
-    public void shouldUseServiceToGetConsistencyProof() {
-        int totalEntries1 = 3;
-        int totalEntries2 = 6;
-        HashValue expectedHash1 = new HashValue(HashingAlgorithm.SHA256, sampleHash1);
-        HashValue expectedHash2 = new HashValue(HashingAlgorithm.SHA256, sampleHash2);
-        List<HashValue> expectedConsistencyNodes = Arrays.asList(expectedHash1, expectedHash2);
-
-        ConsistencyProof expectedProof = new ConsistencyProof(expectedConsistencyNodes);
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        when(entryLogMock.getV1ConsistencyProof(totalEntries1, totalEntries2)).thenReturn(expectedProof);
-
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-        ConsistencyProof actualProof = vlResource.consistencyProof(totalEntries1, totalEntries2);
-
-        verify(entryLogMock, times(1)).getV1ConsistencyProof(totalEntries1, totalEntries2);
-        assertThat(actualProof.getProofIdentifier(), equalTo(expectedProof.getProofIdentifier()));
-
-        assertThat(actualProof.getConsistencyNodes(), IsIterableContainingInOrder.contains(expectedHash1, expectedHash2));
+        resource = new VerifiableLogResource(registerContext);
     }
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfEntryNumberTooSmall() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-
-        vlResource.entryProof(0, 5);
+        resource.entryProof(0, 5);
     }
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfEntryNumberGreaterThanTotalEntries() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-
-        vlResource.entryProof(5, 3);
+        resource.entryProof(5, 3);
     }
 
     @Test(expected = BadRequestException.class)
     public void entryProofShouldThrowBadRequestExceptionIfTotalEntriesGreaterThanSizeOfRegister() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
+        when(entryLog.getTotalEntries(EntryType.user)).thenReturn(8);
 
-        vlResource.entryProof(5, 10);
+        resource.entryProof(5, 10);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries1TooSmall() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-
-        vlResource.consistencyProof(0, 5);
+        resource.consistencyProof(0, 5);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofshouldThrowBadRequestExceptionIfTotalEntries2SmallerThanTotalEntries1() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
-
-        vlResource.consistencyProof(5, 3);
+        resource.consistencyProof(5, 3);
     }
 
     @Test(expected = BadRequestException.class)
     public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries2GreaterThanSizeOfRegister() {
-        EntryLog entryLogMock = mock(EntryLog.class);
-        when(entryLogMock.getTotalEntries(EntryType.user)).thenReturn(8);
-        VerifiableLogResource vlResource = new VerifiableLogResource(entryLogMock);
+        when(entryLog.getTotalEntries(EntryType.user)).thenReturn(8);
 
-        vlResource.consistencyProof(5, 10);
+        resource.consistencyProof(5, 10);
     }
 }
 

--- a/src/test/java/uk/gov/register/resources/v1/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/v1/VerifiableLogResourceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.register.resources;
+package uk.gov.register.resources.v1;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,9 +16,6 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VerifiableLogResourceTest {
-    private final String sampleHash1 = "6b85b168f7c5f0587fc22ff4ba6937e61b33f6e89b70eed53d78d895d35dc9c3";
-    private final String sampleHash2 = "d3d33f57b033d18ad11e14b28ef6f33487410c98548d1759c772370dfeb6db11";
-
     @Mock
     private RegisterContext registerContext;
 

--- a/src/test/java/uk/gov/register/resources/v2/VerifiableLogResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/v2/VerifiableLogResourceTest.java
@@ -1,0 +1,69 @@
+package uk.gov.register.resources.v2;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.register.core.EntryLog;
+import uk.gov.register.core.EntryType;
+import uk.gov.register.core.RegisterContext;
+import uk.gov.register.views.RegisterProof;
+
+import javax.ws.rs.BadRequestException;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VerifiableLogResourceTest {
+    @Mock
+    private RegisterContext registerContext;
+
+    @Mock
+    private EntryLog entryLog;
+
+    private VerifiableLogResource resource;
+
+    @Before
+    public void setUp() {
+        when(registerContext.buildEntryLog()).thenReturn(entryLog);
+
+        resource = new VerifiableLogResource(registerContext);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void entryProofShouldThrowBadRequestExceptionIfEntryNumberTooSmall() {
+        resource.entryProof(0, 5);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void entryProofShouldThrowBadRequestExceptionIfEntryNumberGreaterThanTotalEntries() {
+        resource.entryProof(5, 3);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void entryProofShouldThrowBadRequestExceptionIfTotalEntriesGreaterThanSizeOfRegister() {
+        when(entryLog.getTotalEntries(EntryType.user)).thenReturn(8);
+
+        resource.entryProof(5, 10);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries1TooSmall() {
+        resource.consistencyProof(0, 5);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void consistencyProofshouldThrowBadRequestExceptionIfTotalEntries2SmallerThanTotalEntries1() {
+        resource.consistencyProof(5, 3);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void consistencyProofShouldThrowBadRequestExceptionIfTotalEntries2GreaterThanSizeOfRegister() {
+        when(entryLog.getTotalEntries(EntryType.user)).thenReturn(8);
+
+        resource.consistencyProof(5, 10);
+    }
+}
+

--- a/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
@@ -15,7 +15,6 @@ import uk.gov.register.serialization.mappers.EntryToCommandMapper;
 import uk.gov.register.serialization.mappers.ItemToCommandMapper;
 import uk.gov.register.serialization.mappers.RootHashCommandMapper;
 import uk.gov.register.util.HashValue;
-import uk.gov.register.views.RegisterProof;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -100,7 +99,7 @@ public class RSFCreatorTest {
 
         when(proofGenerator.getRootHash()).thenReturn(new HashValue(HashingAlgorithm.SHA256, "1231234"));
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator);
+        RegisterSerialisationFormat actualRSF = sutCreator.createV1(register, proofGenerator);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         assertThat(actualCommands.size(), equalTo(8));
@@ -126,7 +125,7 @@ public class RSFCreatorTest {
         when(proofGenerator.getRootHash(1)).thenReturn(oneEntryRootHash);
         when(proofGenerator.getRootHash(2)).thenReturn(twoEntriesRootHash);
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 1, 2);
+        RegisterSerialisationFormat actualRSF = sutCreator.createV1(register, proofGenerator, 1, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         verify(register, never()).getItemIterator(EntryType.system);
@@ -154,7 +153,7 @@ public class RSFCreatorTest {
 
         when(proofGenerator.getRootHash(2)).thenReturn(rootHash);
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 0, 2);
+        RegisterSerialisationFormat actualRSF = sutCreator.createV1(register, proofGenerator, 0, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         assertThat(actualCommands.size(), equalTo(8));
@@ -183,7 +182,7 @@ public class RSFCreatorTest {
         expectedException.expectMessage("Mapper not registered for class: uk.gov.register.util.HashValue");
 
         RSFCreator creatorWithoutMappers = new RSFCreator();
-        RegisterSerialisationFormat rsf = creatorWithoutMappers.create(register, proofGenerator);
+        RegisterSerialisationFormat rsf = creatorWithoutMappers.createV1(register, proofGenerator);
         IteratorUtils.toList(rsf.getCommands());
     }
 
@@ -192,7 +191,7 @@ public class RSFCreatorTest {
         HashValue rootHash = new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash");
         when(proofGenerator.getRootHash(2)).thenReturn(rootHash);
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 2, 2);
+        RegisterSerialisationFormat actualRSF = sutCreator.createV1(register, proofGenerator, 2, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         assertThat(actualCommands.size(), equalTo(1));
@@ -210,7 +209,7 @@ public class RSFCreatorTest {
 
         when(proofGenerator.getRootHash(0)).thenReturn(emptyRegisterHash);
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 0, 0);
+        RegisterSerialisationFormat actualRSF = sutCreator.createV1(register, proofGenerator, 0, 0);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         assertThat(actualCommands.size(), equalTo(4));

--- a/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.register.core.*;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.mappers.EntryToCommandMapper;
 import uk.gov.register.serialization.mappers.ItemToCommandMapper;
 import uk.gov.register.serialization.mappers.RootHashCommandMapper;
@@ -40,6 +41,9 @@ public class RSFCreatorTest {
 
     @Mock
     private Register register;
+
+    @Mock
+    private ProofGenerator proofGenerator;
 
     private Entry systemEntry;
     private Entry entry1;
@@ -94,15 +98,10 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.system)).thenReturn(Arrays.asList(systemEntry).iterator());
         when(register.getEntryIterator(EntryType.user)).thenReturn(Arrays.asList(entry1, entry2).iterator());
 
-        RegisterProof expectedRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "1231234"), 46464);
-        when(register.getV1RegisterProof()).thenReturn(expectedRegisterProof);
+        when(proofGenerator.getRootHash()).thenReturn(new HashValue(HashingAlgorithm.SHA256, "1231234"));
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register);
+        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
-
-        verify(register, times(1)).getItemIterator(EntryType.user);
-        verify(register, times(1)).getEntryIterator(EntryType.user);
-        verify(register, times(1)).getV1RegisterProof();
 
         assertThat(actualCommands.size(), equalTo(8));
         assertThat(actualCommands, contains(
@@ -119,15 +118,15 @@ public class RSFCreatorTest {
 
     @Test
     public void createRegisterSerialisationFormat_whenCalledWithBoundary_returnsPartialRSFRegister() {
-        RegisterProof oneEntryRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "oneEntryInRegisterHash"), 1);
-        RegisterProof twoEntriesRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash"), 2);
+        HashValue oneEntryRootHash = new HashValue(HashingAlgorithm.SHA256, "oneEntryInRegisterHash");
+        HashValue twoEntriesRootHash = new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash");
 
         when(register.getItemIterator(1, 2)).thenReturn(Collections.singletonList(item1).iterator());
         when(register.getEntryIterator(1, 2)).thenReturn(Collections.singletonList(entry1).iterator());
-        when(register.getV1RegisterProof(1)).thenReturn(oneEntryRegisterProof);
-        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
+        when(proofGenerator.getRootHash(1)).thenReturn(oneEntryRootHash);
+        when(proofGenerator.getRootHash(2)).thenReturn(twoEntriesRootHash);
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, 1, 2);
+        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 1, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         verify(register, never()).getItemIterator(EntryType.system);
@@ -137,25 +136,25 @@ public class RSFCreatorTest {
 
         assertThat(actualCommands.size(), equalTo(4));
         assertThat(actualCommands, contains(
-                new RegisterCommand("assert-root-hash", Collections.singletonList(oneEntryRegisterProof.getRootHash().encode())),
+                new RegisterCommand("assert-root-hash", Collections.singletonList(oneEntryRootHash.encode())),
                 addItem1Command,
                 appendEntry1Command,
-                new RegisterCommand("assert-root-hash", Collections.singletonList(twoEntriesRegisterProof.getRootHash().encode()))
+                new RegisterCommand("assert-root-hash", Collections.singletonList(twoEntriesRootHash.encode()))
         ));
     }
 
     @Test
     public void createRegisterSerialisationFormat_whenStartIsZero_returnsSystemEntries() {
-        RegisterProof twoEntriesRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash"), 2);
+        HashValue rootHash = new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash");
 
         when(register.getItemIterator(EntryType.system)).thenReturn(Arrays.asList(systemItem).iterator());
         when(register.getItemIterator(0, 2)).thenReturn(Arrays.asList(item1, item2).iterator());
         when(register.getEntryIterator(EntryType.system)).thenReturn(Arrays.asList(systemEntry).iterator());
         when(register.getEntryIterator(0, 2)).thenReturn(Arrays.asList(entry1, entry2).iterator());
 
-        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
+        when(proofGenerator.getRootHash(2)).thenReturn(rootHash);
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, 0, 2);
+        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 0, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         assertThat(actualCommands.size(), equalTo(8));
@@ -167,7 +166,7 @@ public class RSFCreatorTest {
                 appendSystemEntryCommand,
                 appendEntry1Command,
                 appendEntry2Command,
-                new RegisterCommand("assert-root-hash", Collections.singletonList(twoEntriesRegisterProof.getRootHash().encode()))
+                new RegisterCommand("assert-root-hash", Collections.singletonList(rootHash.encode()))
         ));
     }
 
@@ -178,29 +177,27 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.user)).thenReturn(Arrays.asList(entry1, entry2).iterator());
         when(register.getItemIterator(EntryType.system)).thenReturn(Arrays.asList(systemItem).iterator());
 
-        RegisterProof expectedRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "1231234"), 28828);
-        when(register.getV1RegisterProof()).thenReturn(expectedRegisterProof);
+        when(proofGenerator.getRootHash()).thenReturn(new HashValue(HashingAlgorithm.SHA256, "1231234"));
 
         expectedException.expect(RuntimeException.class);
         expectedException.expectMessage("Mapper not registered for class: uk.gov.register.util.HashValue");
 
         RSFCreator creatorWithoutMappers = new RSFCreator();
-        RegisterSerialisationFormat rsf = creatorWithoutMappers.create(register);
+        RegisterSerialisationFormat rsf = creatorWithoutMappers.create(register, proofGenerator);
         IteratorUtils.toList(rsf.getCommands());
     }
 
     @Test
     public void createRegisterSerialisationFormat_whenParametersEqual_returnsOnlyRootHash() {
-        RegisterProof twoEntriesRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash"), 2);
+        HashValue rootHash = new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash");
+        when(proofGenerator.getRootHash(2)).thenReturn(rootHash);
 
-        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
-
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, 2, 2);
+        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 2, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         assertThat(actualCommands.size(), equalTo(1));
         assertThat(actualCommands, contains(
-                new RegisterCommand("assert-root-hash", Collections.singletonList(twoEntriesRegisterProof.getRootHash().encode()))
+                new RegisterCommand("assert-root-hash", Collections.singletonList(rootHash.encode()))
         ));
     }
 
@@ -211,9 +208,9 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.system)).thenReturn(Arrays.asList(systemEntry).iterator());
         when(register.getEntryIterator(0, 0)).thenReturn(Collections.emptyIterator());
 
-        when(register.getV1RegisterProof(0)).thenReturn(new RegisterProof(emptyRegisterHash, 0));
+        when(proofGenerator.getRootHash(0)).thenReturn(emptyRegisterHash);
 
-        RegisterSerialisationFormat actualRSF = sutCreator.create(register, 0, 0);
+        RegisterSerialisationFormat actualRSF = sutCreator.create(register, proofGenerator, 0, 0);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         assertThat(actualCommands.size(), equalTo(4));

--- a/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFCreatorTest.java
@@ -95,14 +95,14 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.user)).thenReturn(Arrays.asList(entry1, entry2).iterator());
 
         RegisterProof expectedRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "1231234"), 46464);
-        when(register.getRegisterProof()).thenReturn(expectedRegisterProof);
+        when(register.getV1RegisterProof()).thenReturn(expectedRegisterProof);
 
         RegisterSerialisationFormat actualRSF = sutCreator.create(register);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
 
         verify(register, times(1)).getItemIterator(EntryType.user);
         verify(register, times(1)).getEntryIterator(EntryType.user);
-        verify(register, times(1)).getRegisterProof();
+        verify(register, times(1)).getV1RegisterProof();
 
         assertThat(actualCommands.size(), equalTo(8));
         assertThat(actualCommands, contains(
@@ -124,8 +124,8 @@ public class RSFCreatorTest {
 
         when(register.getItemIterator(1, 2)).thenReturn(Collections.singletonList(item1).iterator());
         when(register.getEntryIterator(1, 2)).thenReturn(Collections.singletonList(entry1).iterator());
-        when(register.getRegisterProof(1)).thenReturn(oneEntryRegisterProof);
-        when(register.getRegisterProof(2)).thenReturn(twoEntriesRegisterProof);
+        when(register.getV1RegisterProof(1)).thenReturn(oneEntryRegisterProof);
+        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
 
         RegisterSerialisationFormat actualRSF = sutCreator.create(register, 1, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
@@ -153,7 +153,7 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.system)).thenReturn(Arrays.asList(systemEntry).iterator());
         when(register.getEntryIterator(0, 2)).thenReturn(Arrays.asList(entry1, entry2).iterator());
 
-        when(register.getRegisterProof(2)).thenReturn(twoEntriesRegisterProof);
+        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
 
         RegisterSerialisationFormat actualRSF = sutCreator.create(register, 0, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
@@ -179,7 +179,7 @@ public class RSFCreatorTest {
         when(register.getItemIterator(EntryType.system)).thenReturn(Arrays.asList(systemItem).iterator());
 
         RegisterProof expectedRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "1231234"), 28828);
-        when(register.getRegisterProof()).thenReturn(expectedRegisterProof);
+        when(register.getV1RegisterProof()).thenReturn(expectedRegisterProof);
 
         expectedException.expect(RuntimeException.class);
         expectedException.expectMessage("Mapper not registered for class: uk.gov.register.util.HashValue");
@@ -193,7 +193,7 @@ public class RSFCreatorTest {
     public void createRegisterSerialisationFormat_whenParametersEqual_returnsOnlyRootHash() {
         RegisterProof twoEntriesRegisterProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "twoEntriesInRegisterHash"), 2);
 
-        when(register.getRegisterProof(2)).thenReturn(twoEntriesRegisterProof);
+        when(register.getV1RegisterProof(2)).thenReturn(twoEntriesRegisterProof);
 
         RegisterSerialisationFormat actualRSF = sutCreator.create(register, 2, 2);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());
@@ -211,7 +211,7 @@ public class RSFCreatorTest {
         when(register.getEntryIterator(EntryType.system)).thenReturn(Arrays.asList(systemEntry).iterator());
         when(register.getEntryIterator(0, 0)).thenReturn(Collections.emptyIterator());
 
-        when(register.getRegisterProof(0)).thenReturn(new RegisterProof(emptyRegisterHash, 0));
+        when(register.getV1RegisterProof(0)).thenReturn(new RegisterProof(emptyRegisterHash, 0));
 
         RegisterSerialisationFormat actualRSF = sutCreator.create(register, 0, 0);
         List<RegisterCommand> actualCommands = IteratorUtils.toList(actualRSF.getCommands());

--- a/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
@@ -12,6 +12,7 @@ import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.util.HashValue;
 
 import java.util.Optional;
@@ -43,6 +44,9 @@ public class RSFExecutorTest {
 
     @Mock
     private RegisterCommandHandler addItemHandler;
+
+    @Mock
+    private ProofGenerator proofGenerator;
 
     private Item item1;
 
@@ -95,16 +99,17 @@ public class RSFExecutorTest {
                 appendEntry2Command,
                 assertLastRootHashCommand).iterator());
 
-        sutExecutor.execute(rsf, register);
+
+        sutExecutor.execute(rsf, register, proofGenerator);
 
         InOrder inOrder = Mockito.inOrder(assertRootHashHandler, addItemHandler, appendEntryHandler);
-        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertEmptyRootHashCommand, register);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem1Command, register);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem2Command, register);
-        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry1Command, register);
-        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertMiddleRootHashCommand, register);
-        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry2Command, register);
-        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertLastRootHashCommand, register);
+        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertEmptyRootHashCommand, register, proofGenerator);
+        inOrder.verify(addItemHandler, calls(1)).execute(addItem1Command, register, proofGenerator);
+        inOrder.verify(addItemHandler, calls(1)).execute(addItem2Command, register, proofGenerator);
+        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry1Command, register, proofGenerator);
+        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertMiddleRootHashCommand, register, proofGenerator);
+        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry2Command, register, proofGenerator);
+        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertLastRootHashCommand, register, proofGenerator);
     }
 
     @Test (expected = RSFParseException.class)
@@ -127,7 +132,7 @@ public class RSFExecutorTest {
         when(register.getItemByV1Hash(entry1hashValue)).thenReturn(Optional.of(item1));
 
         RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(singletonList(appendEntry1Command).iterator());
-        sutExecutor.execute(rsf, register);
+        sutExecutor.execute(rsf, register, proofGenerator);
 
         verify(register, times(1)).getItemByV1Hash(entry1hashValue);
     }
@@ -175,10 +180,10 @@ public class RSFExecutorTest {
                 addItem1Command).iterator());
 
         try {
-            sutExecutor.execute(rsf, register);
+            sutExecutor.execute(rsf, register, proofGenerator);
         } catch (RSFParseException exception1) {
             try {
-                sutExecutor.execute(rsf2, register);
+                sutExecutor.execute(rsf2, register, proofGenerator);
             } catch (RSFParseException exception2) {
                 assertThat(exception1.getMessage(), equalTo(exception2.getMessage()));
                 throw exception2;
@@ -197,17 +202,17 @@ public class RSFExecutorTest {
                 asList("user", "entry1-field-1-value", "2016-07-24T16:55:00Z", itemHash1 + ";" + itemHash2));
 
         RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(asList(addItem1, addItem2, appendEntry).iterator());
-        sutExecutor.execute(rsf, register);
+        sutExecutor.execute(rsf, register, proofGenerator);
 
         InOrder inOrder = Mockito.inOrder(assertRootHashHandler, addItemHandler, appendEntryHandler);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem1, register);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem2, register);
-        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry, register);
+        inOrder.verify(addItemHandler, calls(1)).execute(addItem1, register, proofGenerator);
+        inOrder.verify(addItemHandler, calls(1)).execute(addItem2, register, proofGenerator);
+        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry, register, proofGenerator);
     }
 
     private void assertExceptionThrown(RegisterSerialisationFormat rsf, String exceptionMessage) throws RSFParseException {
         try {
-            sutExecutor.execute(rsf, register);
+            sutExecutor.execute(rsf, register, proofGenerator);
         } catch (RSFParseException exception) {
             assertThat(exception.getMessage(), startsWith(exceptionMessage));
             throw exception;

--- a/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
@@ -23,8 +23,10 @@ import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.calls;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RSFExecutorTest {
@@ -90,7 +92,7 @@ public class RSFExecutorTest {
 
     @Test
     public void execute_executesAllCommandsInCorrectOrder() {
-        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(asList(
+        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, asList(
                 assertEmptyRootHashCommand,
                 addItem1Command,
                 addItem2Command,
@@ -118,7 +120,7 @@ public class RSFExecutorTest {
 
         when(register.getItemByV1Hash(entry1hashValue)).thenReturn(Optional.empty());
 
-        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(asList(
+        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, asList(
                 appendEntry1Command,
                 addItem1Command).iterator());
 
@@ -131,7 +133,7 @@ public class RSFExecutorTest {
 
         when(register.getItemByV1Hash(entry1hashValue)).thenReturn(Optional.of(item1));
 
-        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(singletonList(appendEntry1Command).iterator());
+        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, singletonList(appendEntry1Command).iterator());
         sutExecutor.execute(rsf, register, proofGenerator);
 
         verify(register, times(1)).getItemByV1Hash(entry1hashValue);
@@ -139,7 +141,7 @@ public class RSFExecutorTest {
 
     @Test (expected = RSFParseException.class)
     public void execute_failsForOrphanAddItem() {
-        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(asList(
+        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, asList(
                 addItem1Command,
                 addItem2Command,
                 appendEntry1Command).iterator());
@@ -149,7 +151,7 @@ public class RSFExecutorTest {
 
     @Test (expected = RSFParseException.class)
     public void execute_failsForItemWhichWasntReferencedInRSF() {
-        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(asList(
+        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, asList(
                 addItem1Command,
                 appendEntry1Command,
                 addItem1Command).iterator());
@@ -160,7 +162,7 @@ public class RSFExecutorTest {
 
     @Test (expected = RSFParseException.class)
     public void execute_failsForUnknownCommand() {
-        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(singletonList(
+        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, singletonList(
                 new RegisterCommand("unknown-command", asList("some", "data"))).iterator());
 
         assertExceptionThrown(rsf, "Handler not registered for command: unknown-command");
@@ -168,13 +170,13 @@ public class RSFExecutorTest {
 
     @Test (expected = RSFParseException.class)
     public void execute_executingTheSameInvalidRSFGivesSameResult() {
-        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(asList(
+        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, asList(
                 addItem1Command,
                 appendEntry1Command,
                 addItem1Command).iterator());
 
         // it has to be a new iterator because after 1st execution the iterator is going to be empty
-        RegisterSerialisationFormat rsf2 = new RegisterSerialisationFormat(asList(
+        RegisterSerialisationFormat rsf2 = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, asList(
                 addItem1Command,
                 appendEntry1Command,
                 addItem1Command).iterator());
@@ -201,7 +203,7 @@ public class RSFExecutorTest {
         RegisterCommand appendEntry = new RegisterCommand("append-entry",
                 asList("user", "entry1-field-1-value", "2016-07-24T16:55:00Z", itemHash1 + ";" + itemHash2));
 
-        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(asList(addItem1, addItem2, appendEntry).iterator());
+        RegisterSerialisationFormat rsf = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, asList(addItem1, addItem2, appendEntry).iterator());
         sutExecutor.execute(rsf, register, proofGenerator);
 
         InOrder inOrder = Mockito.inOrder(assertRootHashHandler, addItemHandler, appendEntryHandler);

--- a/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
+++ b/src/test/java/uk/gov/register/serialization/RSFExecutorTest.java
@@ -23,6 +23,8 @@ import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.calls;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -105,13 +107,13 @@ public class RSFExecutorTest {
         sutExecutor.execute(rsf, register, proofGenerator);
 
         InOrder inOrder = Mockito.inOrder(assertRootHashHandler, addItemHandler, appendEntryHandler);
-        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertEmptyRootHashCommand, register, proofGenerator);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem1Command, register, proofGenerator);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem2Command, register, proofGenerator);
-        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry1Command, register, proofGenerator);
-        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertMiddleRootHashCommand, register, proofGenerator);
-        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry2Command, register, proofGenerator);
-        inOrder.verify(assertRootHashHandler, calls(1)).execute(assertLastRootHashCommand, register, proofGenerator);
+        inOrder.verify(assertRootHashHandler, calls(1)).execute(eq(assertEmptyRootHashCommand), eq(register), any());
+        inOrder.verify(addItemHandler, calls(1)).execute(eq(addItem1Command), eq(register), any());
+        inOrder.verify(addItemHandler, calls(1)).execute(eq(addItem2Command), eq(register), any());
+        inOrder.verify(appendEntryHandler, calls(1)).execute(eq(appendEntry1Command), eq(register), any());
+        inOrder.verify(assertRootHashHandler, calls(1)).execute(eq(assertMiddleRootHashCommand), eq(register), any());
+        inOrder.verify(appendEntryHandler, calls(1)).execute(eq(appendEntry2Command), eq(register), any());
+        inOrder.verify(assertRootHashHandler, calls(1)).execute(eq(assertLastRootHashCommand), eq(register), any());
     }
 
     @Test (expected = RSFParseException.class)
@@ -207,9 +209,9 @@ public class RSFExecutorTest {
         sutExecutor.execute(rsf, register, proofGenerator);
 
         InOrder inOrder = Mockito.inOrder(assertRootHashHandler, addItemHandler, appendEntryHandler);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem1, register, proofGenerator);
-        inOrder.verify(addItemHandler, calls(1)).execute(addItem2, register, proofGenerator);
-        inOrder.verify(appendEntryHandler, calls(1)).execute(appendEntry, register, proofGenerator);
+        inOrder.verify(addItemHandler, calls(1)).execute(eq(addItem1), eq(register), any());
+        inOrder.verify(addItemHandler, calls(1)).execute(eq(addItem2), eq(register), any());
+        inOrder.verify(appendEntryHandler, calls(1)).execute(eq(appendEntry), eq(register), any());
     }
 
     private void assertExceptionThrown(RegisterSerialisationFormat rsf, String exceptionMessage) throws RSFParseException {

--- a/src/test/java/uk/gov/register/serialization/handlers/AddItemCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AddItemCommandHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.util.HashValue;
@@ -35,6 +36,9 @@ public class AddItemCommandHandlerTest {
     @Mock
     private Register register;
 
+    @Mock
+    private ProofGenerator proofGenerator;
+
     private RegisterCommand addItemCommand;
 
     @Before
@@ -50,7 +54,7 @@ public class AddItemCommandHandlerTest {
 
     @Test
     public void execute_addsItemToRegister() {
-        sutHandler.execute(addItemCommand, register);
+        sutHandler.execute(addItemCommand, register, proofGenerator);
 
         Item expectedItem = new Item(new HashValue(HashingAlgorithm.SHA256, "3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c"), new HashValue(HashingAlgorithm.SHA256, "bc7242dd795173a3632f3385b8ecd4f5b37a10130925b9c2aadfafbfc73a19c4"), jsonFactory.objectNode()
                 .put("field-1", "entry1-field-1-value")
@@ -84,7 +88,7 @@ public class AddItemCommandHandlerTest {
 
     private void assertExceptionThrown(RegisterCommand command, String exceptionMessage) throws RSFParseException {
         try {
-            sutHandler.execute(command, register);
+            sutHandler.execute(command, register, proofGenerator);
         } catch (RSFParseException exception) {
             assertThat(exception.getMessage(), startsWith(exceptionMessage));
             throw exception;

--- a/src/test/java/uk/gov/register/serialization/handlers/AddItemCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AddItemCommandHandlerTest.java
@@ -13,6 +13,7 @@ import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.proofs.ProofGenerator;
+import uk.gov.register.serialization.RegisterCommandContext;
 import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.util.HashValue;
@@ -37,7 +38,7 @@ public class AddItemCommandHandlerTest {
     private Register register;
 
     @Mock
-    private ProofGenerator proofGenerator;
+    private RegisterCommandContext context;
 
     private RegisterCommand addItemCommand;
 
@@ -54,7 +55,7 @@ public class AddItemCommandHandlerTest {
 
     @Test
     public void execute_addsItemToRegister() {
-        sutHandler.execute(addItemCommand, register, proofGenerator);
+        sutHandler.execute(addItemCommand, register, context);
 
         Item expectedItem = new Item(new HashValue(HashingAlgorithm.SHA256, "3b0c026a0197e3f6392940a7157e0846028f55c3d3db6b6e9b3400fea4a9612c"), new HashValue(HashingAlgorithm.SHA256, "bc7242dd795173a3632f3385b8ecd4f5b37a10130925b9c2aadfafbfc73a19c4"), jsonFactory.objectNode()
                 .put("field-1", "entry1-field-1-value")
@@ -88,7 +89,7 @@ public class AddItemCommandHandlerTest {
 
     private void assertExceptionThrown(RegisterCommand command, String exceptionMessage) throws RSFParseException {
         try {
-            sutHandler.execute(command, register, proofGenerator);
+            sutHandler.execute(command, register, context);
         } catch (RSFParseException exception) {
             assertThat(exception.getMessage(), startsWith(exceptionMessage));
             throw exception;

--- a/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
@@ -14,6 +14,7 @@ import uk.gov.register.core.EntryType;
 import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
+import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.util.HashValue;
 
@@ -41,6 +42,9 @@ public class AppendEntryCommandHandlerTest {
     @Mock
     private Register register;
 
+    @Mock
+    private ProofGenerator proofGenerator;
+
     private RegisterCommand appendEntryCommand;
     private Instant july24 = Instant.parse("2016-07-24T16:55:00Z");
 
@@ -64,7 +68,7 @@ public class AppendEntryCommandHandlerTest {
         when(item.getBlobHash()).thenReturn(new HashValue(SHA256, "blob-sha"));
         when(register.getItemByV1Hash(new HashValue(SHA256, "item-sha"))).thenReturn(Optional.of(item));
         when(register.getTotalEntries(EntryType.user)).thenReturn(2);
-        sutHandler.execute(appendEntryCommand, register);
+        sutHandler.execute(appendEntryCommand, register, proofGenerator);
         Entry expectedEntry = new Entry(3, new HashValue(SHA256, "item-sha"), new HashValue(SHA256, "blob-sha"), july24, "entry1-field-1-value", EntryType.user);
         verify(register, times(1)).appendEntry(expectedEntry);
     }
@@ -73,7 +77,7 @@ public class AppendEntryCommandHandlerTest {
     public void execute_appendsEntryToRegisterWithoutItemThrowsException() {
         expectedException.expect(RSFParseException.class);
         expectedException.expectMessage("Item not found for hash item-sha");
-        sutHandler.execute(appendEntryCommand, register);
+        sutHandler.execute(appendEntryCommand, register, proofGenerator);
     }
 
     @Test (expected = RSFParseException.class)
@@ -102,7 +106,7 @@ public class AppendEntryCommandHandlerTest {
 
     private void assertExceptionThrown(RegisterCommand command, String exceptionMessage) throws RSFParseException {
         try {
-            sutHandler.execute(command, register);
+            sutHandler.execute(command, register, proofGenerator);
         } catch (RSFParseException exception) {
             assertThat(exception.getMessage(), startsWith(exceptionMessage));
             throw exception;

--- a/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AppendEntryCommandHandlerTest.java
@@ -16,6 +16,7 @@ import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RegisterCommand;
+import uk.gov.register.serialization.RegisterCommandContext;
 import uk.gov.register.util.HashValue;
 
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class AppendEntryCommandHandlerTest {
     private Register register;
 
     @Mock
-    private ProofGenerator proofGenerator;
+    private RegisterCommandContext context;
 
     private RegisterCommand appendEntryCommand;
     private Instant july24 = Instant.parse("2016-07-24T16:55:00Z");
@@ -68,7 +69,7 @@ public class AppendEntryCommandHandlerTest {
         when(item.getBlobHash()).thenReturn(new HashValue(SHA256, "blob-sha"));
         when(register.getItemByV1Hash(new HashValue(SHA256, "item-sha"))).thenReturn(Optional.of(item));
         when(register.getTotalEntries(EntryType.user)).thenReturn(2);
-        sutHandler.execute(appendEntryCommand, register, proofGenerator);
+        sutHandler.execute(appendEntryCommand, register, context);
         Entry expectedEntry = new Entry(3, new HashValue(SHA256, "item-sha"), new HashValue(SHA256, "blob-sha"), july24, "entry1-field-1-value", EntryType.user);
         verify(register, times(1)).appendEntry(expectedEntry);
     }
@@ -77,7 +78,7 @@ public class AppendEntryCommandHandlerTest {
     public void execute_appendsEntryToRegisterWithoutItemThrowsException() {
         expectedException.expect(RSFParseException.class);
         expectedException.expectMessage("Item not found for hash item-sha");
-        sutHandler.execute(appendEntryCommand, register, proofGenerator);
+        sutHandler.execute(appendEntryCommand, register, context);
     }
 
     @Test (expected = RSFParseException.class)
@@ -106,7 +107,7 @@ public class AppendEntryCommandHandlerTest {
 
     private void assertExceptionThrown(RegisterCommand command, String exceptionMessage) throws RSFParseException {
         try {
-            sutHandler.execute(command, register, proofGenerator);
+            sutHandler.execute(command, register, context);
         } catch (RSFParseException exception) {
             assertThat(exception.getMessage(), startsWith(exceptionMessage));
             throw exception;

--- a/src/test/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandlerTest.java
@@ -12,6 +12,8 @@ import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.proofs.ProofGenerator;
 import uk.gov.register.serialization.RegisterCommand;
+import uk.gov.register.serialization.RegisterCommandContext;
+import uk.gov.register.serialization.RegisterSerialisationFormat;
 import uk.gov.register.util.HashValue;
 
 import java.io.IOException;
@@ -37,11 +39,17 @@ public class AssertRootHashCommandHandlerTest {
     @Mock
     private ProofGenerator proofGenerator;
 
+    @Mock
+    RegisterSerialisationFormat rsf;
+
+    private RegisterCommandContext context;
+
     private RegisterCommand assertRootHashCommand;
 
     @Before
     public void setUp() throws Exception {
         sutHandler = new AssertRootHashCommandHandler();
+        context = new RegisterCommandContext(rsf, proofGenerator);
         assertRootHashCommand = new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:root-hash"));
     }
 
@@ -54,7 +62,7 @@ public class AssertRootHashCommandHandlerTest {
     public void execute_obtainsAndAssertsRegisterProof() {
         when(proofGenerator.getRootHash()).thenReturn(new HashValue(HashingAlgorithm.SHA256, "root-hash"));
 
-        sutHandler.execute(assertRootHashCommand, register, proofGenerator);
+        sutHandler.execute(assertRootHashCommand, register, context);
 
         verify(proofGenerator, times(1)).getRootHash();
     }
@@ -91,7 +99,7 @@ public class AssertRootHashCommandHandlerTest {
 
     private void assertExceptionThrown(RegisterCommand command, String exceptionMessage) throws RSFParseException {
         try {
-            sutHandler.execute(command, register, proofGenerator);
+            sutHandler.execute(command, register, context);
         } catch (RSFParseException exception) {
             assertThat(exception.getMessage(), startsWith(exceptionMessage));
             throw exception;

--- a/src/test/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandlerTest.java
@@ -49,7 +49,7 @@ public class AssertRootHashCommandHandlerTest {
     @Before
     public void setUp() throws Exception {
         sutHandler = new AssertRootHashCommandHandler();
-        context = new RegisterCommandContext(rsf, proofGenerator);
+        context = new RegisterCommandContext(rsf, proofGenerator, 1);
         assertRootHashCommand = new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:root-hash"));
     }
 

--- a/src/test/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandlerTest.java
+++ b/src/test/java/uk/gov/register/serialization/handlers/AssertRootHashCommandHandlerTest.java
@@ -10,7 +10,6 @@ import org.mockito.stubbing.Answer;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
-import uk.gov.register.serialization.RegisterResult;
 import uk.gov.register.serialization.RegisterCommand;
 import uk.gov.register.util.HashValue;
 import uk.gov.register.views.RegisterProof;
@@ -48,17 +47,17 @@ public class AssertRootHashCommandHandlerTest {
     @Test
     public void execute_obtainsAndAssertsRegisterProof() {
         RegisterProof registerProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "root-hash"), 123);
-        when(register.getRegisterProof()).thenReturn(registerProof);
+        when(register.getV1RegisterProof()).thenReturn(registerProof);
 
         sutHandler.execute(assertRootHashCommand, register);
 
-        verify(register, times(1)).getRegisterProof();
+        verify(register, times(1)).getV1RegisterProof();
     }
 
     @Test (expected = RSFParseException.class)
     public void execute_failsIfRootHashesDontMatch() {
         RegisterProof registerProof = new RegisterProof(new HashValue(HashingAlgorithm.SHA256, "different-hash"), 456);
-        when(register.getRegisterProof()).thenReturn(registerProof);
+        when(register.getV1RegisterProof()).thenReturn(registerProof);
 
         assertExceptionThrown(assertRootHashCommand, "Exception when executing command: RegisterCommand");
     }
@@ -69,7 +68,7 @@ public class AssertRootHashCommandHandlerTest {
             public Void answer(InvocationOnMock invocation) throws IOException {
                 throw new IOException("Forced exception");
             }
-        }).when(register).getRegisterProof();
+        }).when(register).getV1RegisterProof();
 
         assertExceptionThrown(assertRootHashCommand, "Exception when executing command: RegisterCommand");
     }

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -71,25 +71,24 @@ public class RegisterSerialisationFormatServiceTest {
 
         sutService.process(rsfInput);
 
-        verify(rsfExecutor, times(1)).execute(eq(rsfInput), any());
+        verify(rsfExecutor, times(1)).execute(eq(rsfInput), any(), any());
     }
 
     @Test
     public void writeTo_writesEntireRSFtoStream() {
-        when(rsfCreator.create(any())).thenReturn(
-                new RegisterSerialisationFormat(Iterators.forArray(
+        when(registerContext.withV1VerifiableLog(any())).thenReturn(
+                Iterators.forArray(
                         new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")),
                         new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}")),
                         new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}")),
                         new RegisterCommand("append-entry", Arrays.asList("user", "entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item1sha")),
                         new RegisterCommand("append-entry", Arrays.asList("user", "entry2-field-1-value", "2016-07-24T16:56:00Z", "sha-256:item2sha")),
-                        new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e")))));
+                        new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e"))));
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         sutService.writeTo(outputStream, rsfFormatter);
 
-        verify(rsfCreator, times(1)).create(any());
         String expectedRSF =
                 "assert-root-hash\tsha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n" +
                 "add-item\t{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}\n" +
@@ -104,7 +103,7 @@ public class RegisterSerialisationFormatServiceTest {
 
     @Test
     public void writeTo_whenCalledWithBoundary_writesPartialRSFtoStream() {
-        when(rsfCreator.create(any(), eq(1), eq(2))).thenReturn(
+        when(rsfCreator.create(any(), any(), eq(1), eq(2))).thenReturn(
                 new RegisterSerialisationFormat(Iterators.forArray(
                         new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e_uno")),
                         new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}")),
@@ -115,7 +114,7 @@ public class RegisterSerialisationFormatServiceTest {
 
         sutService.writeTo(outputStream, rsfFormatter, 1, 2);
 
-        verify(rsfCreator, times(1)).create(any(), eq(1), eq(2));
+        verify(rsfCreator, times(1)).create(any(), any(), eq(1), eq(2));
         String expectedRSF =
                 "assert-root-hash\tsha-256:K3rfuFF1e_uno\n" +
                 "add-item\t{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}\n" +

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -12,7 +12,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import uk.gov.register.core.Register;
 import uk.gov.register.core.RegisterContext;
-import uk.gov.register.serialization.*;
+import uk.gov.register.serialization.RSFCreator;
+import uk.gov.register.serialization.RSFExecutor;
+import uk.gov.register.serialization.RSFFormatter;
+import uk.gov.register.serialization.RegisterCommand;
+import uk.gov.register.serialization.RegisterSerialisationFormat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -23,12 +27,12 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RegisterSerialisationFormatServiceTest {
@@ -83,30 +87,6 @@ public class RegisterSerialisationFormatServiceTest {
                 "append-entry\tuser\tentry1-field-1-value\t2016-07-24T16:55:00Z\tsha-256:item1sha\n" +
                 "append-entry\tuser\tentry2-field-1-value\t2016-07-24T16:56:00Z\tsha-256:item2sha\n" +
                 "assert-root-hash\tsha-256:K3rfuFF1e\n";
-
-        String actualRSF = outputStream.toString();
-        assertThat(actualRSF, Matchers.equalTo(expectedRSF));
-    }
-
-    @Test
-    public void writeTo_whenCalledWithBoundary_writesPartialRSFtoStream() {
-        when(rsfCreator.create(any(), any(), eq(1), eq(2))).thenReturn(
-                new RegisterSerialisationFormat(Iterators.forArray(
-                        new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e_uno")),
-                        new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}")),
-                        new RegisterCommand("append-entry", Arrays.asList("user", "entry2-field-1-value", "2016-07-24T16:56:00Z", "sha-256:item2sha")),
-                        new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e_dos")))));
-
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-        sutService.writeTo(outputStream, rsfFormatter, 1, 2);
-
-        verify(rsfCreator, times(1)).create(any(), any(), eq(1), eq(2));
-        String expectedRSF =
-                "assert-root-hash\tsha-256:K3rfuFF1e_uno\n" +
-                "add-item\t{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}\n" +
-                "append-entry\tuser\tentry2-field-1-value\t2016-07-24T16:56:00Z\tsha-256:item2sha\n" +
-                "assert-root-hash\tsha-256:K3rfuFF1e_dos\n";
 
         String actualRSF = outputStream.toString();
         assertThat(actualRSF, Matchers.equalTo(expectedRSF));

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -62,19 +62,6 @@ public class RegisterSerialisationFormatServiceTest {
     }
 
     @Test
-    public void process_passesCommandsToExecutorAndReturnsItsResult() {
-        RegisterCommand command1 = new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
-        RegisterCommand command2 = new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}"));
-        RegisterCommand command3 = new RegisterCommand("append-entry", Arrays.asList("user", "entry1-field-1-value", "2016-07-24T16:55:00Z", "sha-256:item1sha"));
-        RegisterCommand command4 = new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:K3rfuFF1e"));
-        RegisterSerialisationFormat rsfInput = new RegisterSerialisationFormat(Iterators.forArray(command1, command2, command3, command4));
-
-        sutService.process(rsfInput);
-
-        verify(rsfExecutor, times(1)).execute(eq(rsfInput), any(), any());
-    }
-
-    @Test
     public void writeTo_writesEntireRSFtoStream() {
         when(registerContext.withV1VerifiableLog(any())).thenReturn(
                 Iterators.forArray(

--- a/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
+++ b/src/test/java/uk/gov/register/service/RegisterSerialisationFormatServiceTest.java
@@ -104,9 +104,9 @@ public class RegisterSerialisationFormatServiceTest {
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream(streamValue.getBytes());
 
-        RegisterSerialisationFormat rsfReadResult = sutService.readFrom(inputStream, rsfFormatter);
+        RegisterSerialisationFormat rsfReadResult = sutService.readFromV1(inputStream, rsfFormatter);
 
-        RegisterSerialisationFormat expectedRsf = new RegisterSerialisationFormat(Iterators.forArray(
+        RegisterSerialisationFormat expectedRsf = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, Iterators.forArray(
                 new RegisterCommand("assert-root-hash", Collections.singletonList("sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")),
                 new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry1-field-1-value\",\"field-2\":\"entry1-field-2-value\"}")),
                 new RegisterCommand("add-item", Collections.singletonList("{\"field-1\":\"entry2-field-1-value\",\"field-2\":\"entry2-field-2-value\"}")),
@@ -120,9 +120,9 @@ public class RegisterSerialisationFormatServiceTest {
     @Test
     public void readFrom_readsRSFFromStreamEscaped() throws IOException {
         try (InputStream rsfStream = Files.newInputStream(Paths.get("src/test/resources/fixtures/serialized", "valid-register-escaped.tsv"))) {
-            RegisterSerialisationFormat rsfReadResult = sutService.readFrom(rsfStream, rsfFormatter);
+            RegisterSerialisationFormat rsfReadResult = sutService.readFromV1(rsfStream, rsfFormatter);
 
-            RegisterSerialisationFormat expectedRsf = new RegisterSerialisationFormat(Iterators.forArray(
+            RegisterSerialisationFormat expectedRsf = new RegisterSerialisationFormat(RegisterSerialisationFormat.Version.V1, Iterators.forArray(
                     new RegisterCommand("add-item", Collections.singletonList("{\"name\":\"New College\\\\New College School\",\"school\":\"402019\",\"school-authority\":\"681\",\"school-type\":\"30\"}")),
                     new RegisterCommand("append-entry", Arrays.asList("user", "402019", "2016-11-07T16:26:22Z", "sha-256:d6cca062b6a4ff7f60e401aa1ebf4bf5af51c2217916c0115d0a38a42182aec5"))));
 


### PR DESCRIPTION
### Context
Trello: https://trello.com/c/JBenqGkg/3103-implement-rfc0010-item-hashing-algorithm-with-redactability

The V2 API now uses a new hashing algorithm for blobs and entries. It should also be able to upload RSF that uses these hashing algorithms.

In RSF, hashes are used to link entries and blobs, and for the `assert-root-hash` command.

### Changes proposed in this pull request
Add a `load-rsf` endpoint for V2 that assumes hashes in the RSF use the new algorithms.

### Guidance to review
This is branched off of https://github.com/openregister/openregister-java/pull/542 and needs rebasing.

This doesn't work yet because of the `BatchedPostgresDataAccessLayer`. This layer stores items in memory when adding items, and only writes to the database when `writeBatchesToDatabase` is called. However it only works for V1 hashes. I will need to refactor this before I can complete this PR.