### PR TITLE
Reset the blob order sequence to be in sync with the data

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -99,4 +99,11 @@
         <gav regex="true">^stax:stax-api:.*$</gav>
         <cve>CVE-2017-16224</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: jul-to-slf4j-1.7.24.jar
+   ]]></notes>
+        <gav regex="true">^org\.slf4j:.*$</gav>
+        <cve>CVE-2018-8088</cve>
+    </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/migration/V__18_ResetSequences.java
+++ b/src/main/java/uk/gov/migration/V__18_ResetSequences.java
@@ -1,0 +1,26 @@
+package uk.gov.migration;
+
+import org.flywaydb.core.api.migration.MigrationChecksumProvider;
+import org.flywaydb.core.api.migration.jdbc.BaseJdbcMigration;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+public class V__18_ResetSequences extends BaseJdbcMigration implements MigrationChecksumProvider {
+    @Override
+    public void migrate(Connection connection) throws Exception {
+        Statement stmt = connection.createStatement();
+
+        try {
+            stmt.execute("SELECT setval('item_item_order_seq', coalesce((select max(blob_order)+1 from item), 1), false)");
+        } finally {
+            stmt.close();
+        }
+    }
+
+
+    @Override
+    public Integer getChecksum() {
+        return 1;
+    }
+}


### PR DESCRIPTION
### Context

In a previous migration (https://github.com/openregister/openregister-java/pull/551) we added this field, and backpopulated the data so that existing blobs had an order value.

I assumed when we updated the data in this way, the sequence would automatically advance its value, but this does not seem to be true in all cases.

On production, we ended up with a register where the latest `blob_order` was 167, but the sequence thought the next value was 164:

```
openregister_java=# select max(blob_order) from item;
 max
-----
 167
(1 row)

openregister_java=# select nextval('item_item_order_seq');
 nextval
---------
     164
(1 row)
```

This caused inserts of new blobs to silently fail, because:

1. ORJ tries to insert a row with a duplicate `blob_order`
2. The column has a unique constraint on it, so the statement cannot be executed
3. the insert query ends with "on conflict do nothing", so the conflict is ignored
4. load-rsf then returns a 200 response even though the blob data wasn't added to the DB

The postgres wiki says:

> A common problem when copying or recreating a database is that
> database sequences are not updated just by inserting records in the
> table that sequence is used in.
https://wiki.postgresql.org/wiki/Fixing_Sequences

So it seems that we need to tell postgres what the next value of the sequence should be after populating the historical data.

### Changes proposed in this pull request
Resetting a sequence can be done with the setval function, documented here:
https://www.postgresql.org/docs/10/functions-sequence.html

This migration runs this for every register so that future inserts will not try to reuse existing `blob-order` numbers.

### Guidance to review
