### PR TITLE
Multihash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 csvvalidator==1.2
 jsonschema==2.5.1
--e git+https://github.com/openregister/conformance-test.git@9240886b4f6004ccc716d788bb7ad2627f08e7e1#egg=openregister_conformance-master
+-e git+https://github.com/openregister/conformance-test.git@5bd9c8f59d6adb742c5ad988388725bd19572616#egg=openregister_conformance-master
 py==1.7.0
 pytest==3.10.0
 PyYAML==3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyYAML==3.11
 requests==2.20.0
 Werkzeug==0.11.5
 rdflib==4.2.1
+py-multihash==0.2.3

--- a/src/main/java/uk/gov/register/core/HashingAlgorithm.java
+++ b/src/main/java/uk/gov/register/core/HashingAlgorithm.java
@@ -4,7 +4,9 @@ public enum HashingAlgorithm {
     SHA256 {
         @Override
         public String toString() {
-            return "sha-256";
+            return "sha-256:";
         }
-    }
+    };
+
+    public String multihashPrefix() { return "1220"; }
 }

--- a/src/main/java/uk/gov/register/resources/v2/BlobResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/BlobResource.java
@@ -52,7 +52,7 @@ public class BlobResource {
     }
 
     @GET
-    @Path("/sha-256:{blob-hash}")
+    @Path("/1220{blob-hash}")
     @Produces({
             MediaType.APPLICATION_JSON,
             ExtraMediaType.TEXT_CSV,

--- a/src/main/java/uk/gov/register/resources/v2/EntryResource.java
+++ b/src/main/java/uk/gov/register/resources/v2/EntryResource.java
@@ -10,18 +10,20 @@ import uk.gov.register.providers.params.IntegerParam;
 import uk.gov.register.resources.HttpServletResponseAdapter;
 import uk.gov.register.resources.RequestContext;
 import uk.gov.register.resources.StartLimitPagination;
-import uk.gov.register.views.AttributionView;
-import uk.gov.register.views.v2.EntryListView;
-import uk.gov.register.views.v2.EntryView;
-import uk.gov.register.views.PaginatedView;
 import uk.gov.register.views.ViewFactory;
 import uk.gov.register.views.representations.ExtraMediaType;
+import uk.gov.register.views.v2.EntryListView;
+import uk.gov.register.views.v2.EntryView;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 
 @Path("/next/entries")

--- a/src/main/java/uk/gov/register/util/HashValue.java
+++ b/src/main/java/uk/gov/register/util/HashValue.java
@@ -7,21 +7,20 @@ import uk.gov.register.exceptions.HashDecodeException;
 
 public class HashValue {
     private final String value;
-    private final String hashingAlgorithm;
+    private final HashingAlgorithm hashingAlgorithm;
 
     public HashValue(HashingAlgorithm hashingAlgorithm, String value) {
-        this.hashingAlgorithm = hashingAlgorithm.toString();
-        this.value = value;
-    }
-
-    public HashValue(String hashingAlgorithm, String value) {
         this.hashingAlgorithm = hashingAlgorithm;
         this.value = value;
     }
 
     @JsonValue
     public String encode() {
-        return hashingAlgorithm + ":" + value;
+        return hashingAlgorithm.toString() + value;
+    }
+
+    public String multihash() {
+        return this.hashingAlgorithm.multihashPrefix() + value;
     }
 
     @JsonIgnore
@@ -34,7 +33,7 @@ public class HashValue {
             throw new HashDecodeException(String.format("Hash \"%s\" has not been encoded with hashing algorithm \"%s\"", encodedHash, hashingAlgorithm));
         }
 
-        String[] parts = encodedHash.split(hashingAlgorithm + ":");
+        String[] parts = encodedHash.split(hashingAlgorithm.toString());
 
         if (parts.length != 2) {
             throw new HashDecodeException(String.format("Cannot decode hash %s", encodedHash));
@@ -52,13 +51,13 @@ public class HashValue {
 
         if (value != null ? !value.equals(hashValue.value) : hashValue.value != null) return false;
 
-        return hashingAlgorithm != null ? hashingAlgorithm.equals(hashValue.hashingAlgorithm) : hashValue.hashingAlgorithm == null;
+        return hashingAlgorithm != null ? hashingAlgorithm.toString().equals(hashValue.hashingAlgorithm.toString()) : hashValue.hashingAlgorithm == null;
     }
 
     @Override
     public int hashCode() {
         int result = value != null ? value.hashCode() : 0;
-        result = 31 * result + (hashingAlgorithm != null ? hashingAlgorithm.hashCode() : 0);
+        result = 31 * result + (hashingAlgorithm != null ? hashingAlgorithm.toString().hashCode() : 0);
         return result;
     }
 

--- a/src/main/java/uk/gov/register/views/ConsistencyProof.java
+++ b/src/main/java/uk/gov/register/views/ConsistencyProof.java
@@ -2,6 +2,7 @@ package uk.gov.register.views;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.register.core.HashingAlgorithm;
 import uk.gov.register.util.HashValue;
 
@@ -10,7 +11,7 @@ import java.util.List;
 @JsonPropertyOrder({"proof-identifier", "merkle-consistency-nodes"})
 public class ConsistencyProof {
 
-    private static final String proofIdentifier = "merkle:" + HashingAlgorithm.SHA256.toString();
+    private static final String proofIdentifier = "merkle:" + StringUtils.chop(HashingAlgorithm.SHA256.toString());
     private final List<HashValue> consistencyNodes;
 
     public ConsistencyProof(List<HashValue> consistencyNodes) {

--- a/src/main/java/uk/gov/register/views/v2/BlobView.java
+++ b/src/main/java/uk/gov/register/views/v2/BlobView.java
@@ -23,7 +23,7 @@ public class BlobView implements CsvRepresentationView<Map<String, FieldValue>> 
     public BlobView(Item item, final Map<String, Field> fieldsByName, final ItemConverter itemConverter) {
         this.fields = fieldsByName.values();
         this.fieldValueMap = new LinkedHashMap<>(itemConverter.convertItem(item, fieldsByName));
-        this.fieldValueMap.put("_id", new StringValue(item.getBlobHash().encode()));
+        this.fieldValueMap.put("_id", new StringValue(item.getBlobHash().multihash()));
     }
 
     @JsonValue

--- a/src/main/java/uk/gov/register/views/v2/EntryView.java
+++ b/src/main/java/uk/gov/register/views/v2/EntryView.java
@@ -36,8 +36,8 @@ public class EntryView implements CsvRepresentationView<EntryView> {
     }
 
     @JsonProperty("blob-hash")
-    public HashValue getBlobHash() {
-        return blobHash;
+    public String getBlobHash() {
+        return blobHash.multihash();
     }
 
     @JsonProperty("entry-number")

--- a/src/test/java/uk/gov/register/util/HashValueTest.java
+++ b/src/test/java/uk/gov/register/util/HashValueTest.java
@@ -15,7 +15,7 @@ public class HashValueTest {
         HashValue hashValue = new HashValue(HashingAlgorithm.SHA256, "hash");
         String encodedHash = hashValue.encode();
 
-        assertThat(encodedHash, equalTo(HashingAlgorithm.SHA256.toString() + ":hash"));
+        assertThat(encodedHash, equalTo(HashingAlgorithm.SHA256.toString() + "hash"));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/util/HashValueTest.java
+++ b/src/test/java/uk/gov/register/util/HashValueTest.java
@@ -67,27 +67,11 @@ public class HashValueTest {
     }
 
     @Test
-    public void equal_shouldReturnFalseWhenHashingAlgorithmNotEqual() {
-        HashValue hash1 = new HashValue(HashingAlgorithm.SHA256, "cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
-        HashValue hash2 = new HashValue("md5", "cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
-
-        assertThat(hash1.equals(hash2), is(false));
-    }
-
-    @Test
     public void hashCode_shouldBeEqual_whenBothAreEqual() {
         HashValue hash1 = new HashValue(HashingAlgorithm.SHA256, "cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
         HashValue hash2 = new HashValue(HashingAlgorithm.SHA256, "cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
 
         assertThat(hash1.hashCode(), equalTo(hash2.hashCode()));
-    }
-
-    @Test
-    public void hashCode_shouldNotBeEqual_whenHashingAlgorithmNotEqual() {
-        HashValue hash1 = new HashValue("sha-256", "cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
-        HashValue hash2 = new HashValue("md5", "cc8a7c42275c84b94c6e282ae88b3dbcc06319156fc4539a2f39af053bf30592");
-
-        assertThat(hash1.hashCode(), not(hash2.hashCode()));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/views/v2/BlobListViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/BlobListViewTest.java
@@ -39,11 +39,11 @@ public class BlobListViewTest {
     public void setup() throws IOException {
         blobNode1 = objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}");
         blob1 = new Item(blobNode1);
-        blobHash1 = blob1.getBlobHash().encode();
+        blobHash1 = blob1.getBlobHash().multihash();
 
         blobNode2 = objectMapper.readTree("{\"address\":\"456\",\"street\":\"bar\"}");
         blob2 = new Item(blobNode2);
-        blobHash2 = blob2.getBlobHash().encode();
+        blobHash2 = blob2.getBlobHash().multihash();
 
         Map<String, Field> fieldsByName = ImmutableMap.of(
                 "street", new Field("street", "string", new RegisterId("foo"), Cardinality.ONE, "bla"),

--- a/src/test/java/uk/gov/register/views/v2/BlobViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/BlobViewTest.java
@@ -35,7 +35,7 @@ public class BlobViewTest {
     public void setup() throws IOException {
         blobNode = objectMapper.readTree("{\"address\":\"123\",\"street\":\"foo\"}");
         blob = new Item(blobNode);
-        blobHash = blob.getBlobHash().encode();
+        blobHash = blob.getBlobHash().multihash();
 
 
         Map<String, Field> fieldsByName = ImmutableMap.of(

--- a/src/test/java/uk/gov/register/views/v2/EntryListViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/EntryListViewTest.java
@@ -48,13 +48,13 @@ public class EntryListViewTest {
                 "\"entry-number\":1," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:00Z\"," +
                 "\"key\":\"b\"," +
-                "\"blob-hash\":\"sha-256:ab-blob-hash\"" +
+                "\"blob-hash\":\"1220ab-blob-hash\"" +
                 "}," +
                 "{" +
                 "\"entry-number\":2," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:01Z\"," +
                 "\"key\":\"c\"," +
-                "\"blob-hash\":\"sha-256:cd-blob-hash\"" +
+                "\"blob-hash\":\"1220cd-blob-hash\"" +
                 "}" +
                 "]"));
     }
@@ -75,8 +75,8 @@ public class EntryListViewTest {
 
         assertThat(result, equalTo(
                 "entry-number,entry-timestamp,key,blob-hash\r\n" +
-                        "1,2016-08-05T13:24:00Z,b,sha-256:ab-blob-hash\r\n" +
-                        "2,2016-08-05T13:24:01Z,c,sha-256:cd-blob-hash\r\n"
+                        "1,2016-08-05T13:24:00Z,b,1220ab-blob-hash\r\n" +
+                        "2,2016-08-05T13:24:01Z,c,1220cd-blob-hash\r\n"
         ));
     }
 }

--- a/src/test/java/uk/gov/register/views/v2/EntryViewTest.java
+++ b/src/test/java/uk/gov/register/views/v2/EntryViewTest.java
@@ -39,7 +39,7 @@ public class EntryViewTest {
                 "\"entry-number\":1," +
                 "\"entry-timestamp\":\"2016-08-05T13:24:00Z\"," +
                 "\"key\":\"b\"," +
-                "\"blob-hash\":\"sha-256:cd\"" +
+                "\"blob-hash\":\"1220cd\"" +
                 "}"));
     }
 
@@ -59,7 +59,7 @@ public class EntryViewTest {
 
         assertThat(result, equalTo(
                 "entry-number,entry-timestamp,key,blob-hash\r\n" +
-                "1,2016-08-05T13:24:00Z,b,sha-256:cd\r\n"
+                "1,2016-08-05T13:24:00Z,b,1220cd\r\n"
         ));
     }
 }


### PR DESCRIPTION
### Context
The next version of the API should use multihash to format hashes. 

RFC: https://github.com/openregister/registers-rfcs/blob/master/content/multihash/index.md
Trello: https://trello.com/c/x2OuqWP8/3154-implement-rfc0013-multihash

### Changes proposed in this pull request
- [x] Make the string representation of the hashing algorithm be the full v1 prefix, including the colon
- [x] Add another method to the hashing algorithm for the multihash prefix
- [x] Add a method to HashValue for the multihash formatted string, and return that in the v2 API

Conformance tests and documentation to follow.

### Guidance to review
- Multihash should be used consistently in v2. For sha256 this is '1220'
- 'sha256:' should be used consistently in v1

The proof endpoints also need to change but I will do this in a follow up PR.