### PR TITLE
Return gone for removed formats

### DIFF
--- a/src/main/java/uk/gov/register/resources/RedirectResource.java
+++ b/src/main/java/uk/gov/register/resources/RedirectResource.java
@@ -126,6 +126,7 @@ public class RedirectResource {
     {
         return redirectByPath(request, "/record/", "/records/");
     }
+
     @GET
     @Path("/record/{record-key}/entries")
     public Response getRecordEntriesRedirect(
@@ -133,6 +134,12 @@ public class RedirectResource {
     )
     {
         return redirectByPath(request, "/record/", "/records/");
+    }
+
+    @GET
+    @Path("{extension: .+\\.(tsv|ttl|xlsx|yaml)$}")
+    public Response getRemovedFormat() {
+        return status(Response.Status.GONE).build();
     }
 
     public static Response redirectByPath(@Context HttpServletRequest request, String oldPath, String newPath, Response.Status responseStatus) {

--- a/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
@@ -21,69 +21,69 @@ public class RedirectResourceTest  {
 
 
     @Before
-    public void publishTestMessages() throws Throwable {
+    public void publishTestMessages() {
         register.wipe();
         register.loadRsf(TestRegister.register, RsfRegisterDefinition.REGISTER_REGISTER);
     }
 
     @Test
-    public void getEntryByNumberRedirect() throws Exception {
+    public void getEntryByNumberRedirect() {
         Response response = register.getRequest(TestRegister.register, "/entry/1", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getLocation().getPath(), equalTo("/entries/1"));
     }
 
     @Test
-    public void getItemRedirect() throws Exception {
+    public void getItemRedirect() {
         Response response = register.getRequest(TestRegister.register, "/item/sha-256:9432331d3343a7ceaaee46308069d01836460294c672223b236727a790acf786", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getLocation().getPath(), equalTo("/items/sha-256:9432331d3343a7ceaaee46308069d01836460294c672223b236727a790acf786"));
     }
 
     @Test
-    public void getV1RedirectAcceptHtml() throws Exception {
+    public void getV1RedirectAcceptHtml() {
         Response response = register.getRequest(TestRegister.register, "/v1", MediaType.TEXT_HTML);
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getLocation().getPath(), equalTo("/"));
     }
 
     @Test
-    public void getV1RedirectJsonExtension() throws Exception {
+    public void getV1RedirectJsonExtension() {
         Response response = register.getRequest(TestRegister.register, "/v1.json", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getLocation().getPath(), equalTo("/register.json"));
     }
 
     @Test
-    public void getV1RedirectAcceptJson() throws Exception {
+    public void getV1RedirectAcceptJson() {
         Response response = register.getRequest(TestRegister.register, "/v1", MediaType.APPLICATION_JSON);
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getLocation().getPath(), equalTo("/register"));
     }
 
     @Test
-    public void getNextRedirectJsonExtension() throws Exception {
+    public void getNextRedirectJsonExtension() {
         Response response = register.getRequest(TestRegister.register, "/next.json", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getLocation().getPath(), equalTo("/next/register.json"));
     }
 
     @Test
-    public void getV1ItemRedirect() throws Exception {
+    public void getV1ItemRedirect() {
         Response response = register.getRequest(TestRegister.register, "/v1/items/sha-256:9432331d3343a7ceaaee46308069d01836460294c672223b236727a790acf786", WILDCARD);
         assertThat(response.getStatus(), equalTo(307));
         assertThat(response.getLocation().getPath(), equalTo("/items/sha-256:9432331d3343a7ceaaee46308069d01836460294c672223b236727a790acf786"));
     }
 
     @Test
-    public void getV1RecordsRedirect() throws Exception {
+    public void getV1RecordsRedirect() {
         Response response = register.getRequest(TestRegister.register, "/v1/records", WILDCARD);
         assertThat(response.getStatus(), equalTo(307));
         assertThat(response.getLocation().getPath(), equalTo("/records"));
     }
 
     @Test
-    public void getV1TrailingSlashRedirect() throws Exception {
+    public void getV1TrailingSlashRedirect() {
         // Trailing slashes are handled by a filter so the immediate request doesn't strip the v1
         Response response = register.getRequest(TestRegister.register, "/v1/records/", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));
@@ -91,31 +91,54 @@ public class RedirectResourceTest  {
     }
 
     @Test
-    public void getProofRedirect() throws Exception {
+    public void getProofRedirect() {
         Response response = register.getRequest(TestRegister.register, "/proof/entry/1/2/merkle:sha-256", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getLocation().getPath(), equalTo("/proof/entries/1/2/merkle:sha-256"));
     }
 
     @Test
-    public void getRecordByKeyRedirect() throws Exception {
+    public void getRecordByKeyRedirect() {
         Response response = register.getRequest(TestRegister.register, "/record/6789", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getLocation().getPath(), equalTo("/records/6789"));
     }
 
     @Test
-    public void getRecordByKeyRedirectRetainsFormat() throws Exception {
+    public void getRecordByKeyRedirectRetainsFormat() {
         Response response = register.getRequest(TestRegister.register, "/record/6789.json", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getLocation().getPath(), equalTo("/records/6789.json"));
     }
 
     @Test
-    public void getRecordEntriesRedirect() throws Exception {
+    public void getRecordEntriesRedirect() {
         Response response = register.getRequest(TestRegister.register, "/record/6789/entries", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getLocation().getPath(), equalTo("/records/6789/entries"));
     }
 
+    @Test
+    public void getTurtleFormat() {
+        Response response = register.getRequest(TestRegister.register, "/records.ttl", WILDCARD);
+        assertThat(response.getStatus(), equalTo(410));
+    }
+
+    @Test
+    public void getSpreadsheet() {
+        Response response = register.getRequest(TestRegister.register, "/records.xlsx", WILDCARD);
+        assertThat(response.getStatus(), equalTo(410));
+    }
+
+    @Test
+    public void getTsv() {
+        Response response = register.getRequest(TestRegister.register, "/records.tsv", WILDCARD);
+        assertThat(response.getStatus(), equalTo(410));
+    }
+
+    @Test
+    public void getYaml() {
+        Response response = register.getRequest(TestRegister.register, "/records.yaml", WILDCARD);
+        assertThat(response.getStatus(), equalTo(410));
+    }
 }


### PR DESCRIPTION
### Context
We removed tsv, ttl, xlsx and yaml formats at the beginning of december.

If these formats are requested via content type negotiation, ORJ correctly returns `HTTP/1.1 406 Not Acceptable`. But if the user uses an extension in the URL, such as `records.yaml`, they now get a 404 response.

### Changes proposed in this pull request
It's more appropriate to return `410 Gone`, since these URLs used to be available but were deliberately removed.

### Guidance to review
cc @tijmenb