### PR TITLE
Validate entry key

### DIFF
--- a/src/main/java/uk/gov/register/serialization/RSFExecutor.java
+++ b/src/main/java/uk/gov/register/serialization/RSFExecutor.java
@@ -7,6 +7,7 @@ import uk.gov.register.core.Item;
 import uk.gov.register.core.Register;
 import uk.gov.register.exceptions.RSFParseException;
 import uk.gov.register.proofs.ProofGenerator;
+import uk.gov.register.service.EntryValidator;
 import uk.gov.register.util.HashValue;
 
 import java.nio.charset.StandardCharsets;
@@ -16,7 +17,7 @@ import static java.util.stream.Collectors.toList;
 import static uk.gov.register.core.HashingAlgorithm.SHA256;
 
 public class RSFExecutor {
-    public static final int RSF_HASH_POSITION = 3;
+    private static final int APPEND_ENTRY_HASH_POSITION = 3;
 
     private Map<String, RegisterCommandHandler> registeredHandlers;
 
@@ -67,11 +68,13 @@ public class RSFExecutor {
     }
 
     private void validateAppendEntry(RegisterCommand command, int rsfLine, Register register, Map<HashValue, Integer> hashRefLine) throws RSFParseException {
-        String delimitedHashes = command.getCommandArguments().get(RSF_HASH_POSITION);
+        List<String> commandArguments = command.getCommandArguments();
+
+        String delimitedHashes = commandArguments.get(APPEND_ENTRY_HASH_POSITION);
         if (StringUtils.isEmpty(delimitedHashes)) {
             return;
         }
-        
+
         List<HashValue> hashes = Splitter.on(";").splitToList(delimitedHashes).stream()
                 .map(s -> HashValue.decode(SHA256, s)).collect(toList());
 

--- a/src/main/java/uk/gov/register/service/EntryValidator.java
+++ b/src/main/java/uk/gov/register/service/EntryValidator.java
@@ -1,0 +1,14 @@
+package uk.gov.register.service;
+
+public class EntryValidator {
+    public static void validateKey(String key)
+    {
+        if(!key.matches("[A-Za-z\\d][A-Za-z\\d-_./]*")) {
+            throw new RuntimeException("Key is not valid: " + key);
+        }
+
+        if(key.matches(".*[-_./]{2}.*")) {
+            throw new RuntimeException("Key is invalid due to consecutive restricted characters: " + key);
+        }
+    }
+}

--- a/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
+++ b/src/test/java/uk/gov/register/functional/DataUploadFunctionalTest.java
@@ -229,7 +229,7 @@ public class DataUploadFunctionalTest {
     @Test
     public void validation_FailsToLoadEntryWhenBlankKeyField() {
         String rsf = "add-item\t{\"register\":\"  \"}\n" +
-                "append-entry\tuser\t  \t2018-07-26T13:58:25Z\tsha-256:adeec959e9f6a1481f1bd77d541f19c8e430b668c174e96bfe8ad5a224e3e6ee";
+                "append-entry\tuser\tabc\t2018-07-26T13:58:25Z\tsha-256:adeec959e9f6a1481f1bd77d541f19c8e430b668c174e96bfe8ad5a224e3e6ee";
 
         Response response = register.loadRsf(TestRegister.register, rsf);
         assertThat(response.getStatus(), equalTo(400));
@@ -238,6 +238,20 @@ public class DataUploadFunctionalTest {
 
         assertThat(result.getMessage(), equalTo("Failed to load RSF"));
         assertThat(result.getDetails(), containsString("Primary key field 'register' must have a valid value"));
+    }
+
+    @Test
+    public void validation_FailsToLoadEntryWhenBlankKey() {
+        String rsf = "add-item\t{\"register\":\"abc\"}\n" +
+                "append-entry\tuser\t \t2018-07-26T13:58:25Z\tsha-256:50c35e58d91de803ff327187eaceb5519d214d1dacea21a38af0249b89076ba3";
+
+        Response response = register.loadRsf(TestRegister.register, rsf);
+        assertThat(response.getStatus(), equalTo(400));
+
+        RegisterResult result = response.readEntity(RegisterResult.class);
+
+        assertThat(result.getMessage(), equalTo("Failed to load RSF"));
+        assertThat(result.getDetails(), containsString("Key is not valid:  "));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/service/EntryValidatorTest.java
+++ b/src/test/java/uk/gov/register/service/EntryValidatorTest.java
@@ -1,0 +1,119 @@
+package uk.gov.register.service;
+
+import org.junit.Rule;
+import org.junit.experimental.theories.DataPoint;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeThat;
+
+@RunWith(Theories.class)
+public class EntryValidatorTest {
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @DataPoint
+    public static String NULL = null;
+
+    @DataPoint
+    public static String EMPTY = "";
+
+    @DataPoint
+    public static String EMOJI = "HELLO-❤️-WORLD";
+
+    @DataPoint
+    public static String NON_ASCII_LETTERS = "cliché";
+
+    @DataPoint
+    public static String NUMBER = "1";
+
+    @DataPoint
+    public static String COUNTRY_CODE = "GB";
+
+    @DataPoint
+    public static String LONG_NUMBER = "01";
+
+    @DataPoint
+    public static String NUMBER_WITH_DOT = "10.5";
+
+    @DataPoint
+    public static String LETTERS_WITH_HYPHEN = "CA-ZX";
+
+    @DataPoint
+    public static String SNAKE_CASE = "an_id";
+
+    @DataPoint
+    public static String LEGACY_SEPARATOR = "10.2/3";
+
+    @DataPoint
+    public static String LEADING_UNDERSCORE = "_1";
+
+    @DataPoint
+    public static String LEADING_DOT = ".34";
+
+    @DataPoint
+    public static String CONSECUTIVE_DOTS = "A..B";
+
+    @DataPoint
+    public static String CONSECUTIVE_HYPHENS = "ALPHA--";
+
+    @DataPoint
+    public static String CONSECUTIVE_UNDERSCORES = "C__34";
+
+    @DataPoint
+    public static String CONSECUTIVE_RESTRICTED = "C_/34";
+
+    @Theory
+    public void leadingCharactersMustBeAlphanumeric(String key) {
+        assumeNotNull(key);
+        assumeThat(key, not(""));
+        assumeFalse(startsWithAlphanumeric(key));
+
+        exception.expect(RuntimeException.class);
+
+        EntryValidator.validateKey(key);
+    }
+
+    @Theory
+    public void asciiOnly(String key) {
+        assumeThat(key, isOneOf(EMOJI, NON_ASCII_LETTERS));
+
+        exception.expect(RuntimeException.class);
+
+        EntryValidator.validateKey(key);
+    }
+
+    @Theory
+    public void noConsecutiveRestrictedCharacters(String key) {
+        assumeThat(key, isOneOf(CONSECUTIVE_DOTS, CONSECUTIVE_HYPHENS, CONSECUTIVE_RESTRICTED, CONSECUTIVE_UNDERSCORES));
+
+        exception.expect(RuntimeException.class);
+
+        EntryValidator.validateKey(key);
+    }
+
+    @Theory
+    public void alphanumericAllowed(String key) {
+        assumeThat(key, isOneOf(NUMBER, COUNTRY_CODE, LONG_NUMBER));
+
+        EntryValidator.validateKey(key);
+    }
+
+    @Theory
+    public void separatorsAllowedInMiddle(String key) {
+        assumeThat(key, isOneOf(NUMBER_WITH_DOT, LETTERS_WITH_HYPHEN, SNAKE_CASE, LEGACY_SEPARATOR));
+
+        EntryValidator.validateKey(key);
+    }
+
+    private Boolean startsWithAlphanumeric(String key) {
+        return key.matches("[A-Za-z0-9].*");
+    }
+
+}


### PR DESCRIPTION
### Context
https://github.com/openregister/registers-rfcs/blob/master/content/entry-key-constraints/index.md

### Changes proposed in this pull request
This validates that the entry key only allows IDs.

### Guidance to review
This PR doesn't include the constraint that an entry key must match the corresponding field in the blob (the field with the same name as the register). I had a go at this but it required a lot of rework of the RSF parsing code.