### PR TITLE
Upgrade to Gradle 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,11 @@ apply plugin: "com.github.johnrengelman.shadow"
 apply plugin: 'org.owasp.dependencycheck'
 
 dependencyCheck {
+    analyzers {
+        nodeEnabled=false
+        nodeAuditEnabled=false
+        bundleAuditEnabled=false
+    }
     failBuildOnCVSS = 0
     suppressionFile = 'dependency-check-suppressions.xml'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,6 @@ assemble {
     dependsOn << shadowJar
     doLast {
         new File("deploy/openregister-java.jar").bytes = shadowJar.archivePath.bytes
-        createDeployableBundle.execute()
     }
 }
 
@@ -221,6 +220,8 @@ task createDeployableBundle(type: Zip) {
     include('manifests/**/*.yml')
     destinationDir file('deployable_bundle') // directory that you want your archive to be placed in
 }
+
+assemble.finalizedBy createDeployableBundle
 
 task(run, type: JavaExec, dependsOn: ['classes']) {
     main = 'uk.gov.register.RegisterApplication'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath "com.github.ben-manes:gradle-versions-plugin:0.13.0"
         classpath "com.github.jengelman.gradle.plugins:shadow:4.0.3"
-        classpath 'org.owasp:dependency-check-gradle:3.1.2'
+        classpath 'org.owasp:dependency-check-gradle:4.0.2'
     }
 }
 

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -3,6 +3,8 @@ ext {
     dropwizard_metrics_version = '3.1.0'
     jersey_version = '2.25.1'
     jackson_version = '2.8.11'
+    jetty_version = '9.4.14.v20181114'
+    
 
     jacksonDatabind = 'com.fasterxml.jackson.core:jackson-databind:2.8.11.1'
 
@@ -56,16 +58,16 @@ ext {
     dropwizardLogstash = "uk.gov.ida:dropwizard-logstash:1.1.2-build_46"
 
     jetty = [
-            "org.eclipse.jetty:jetty-continuation:9.4.14.v20181114",
-            "org.eclipse.jetty:jetty-http:9.4.14.v20181114",
-            "org.eclipse.jetty:jetty-io:9.4.14.v20181114",
-            "org.eclipse.jetty:jetty-security:9.4.14.v20181114",
-            "org.eclipse.jetty:jetty-server:9.4.14.v20181114",
-            "org.eclipse.jetty:jetty-servlet:9.4.14.v20181114",
-            "org.eclipse.jetty:jetty-servlets:9.4.14.v20181114",
-            "org.eclipse.jetty:jetty-util:9.4.14.v20181114",
-            "org.eclipse.jetty:jetty-webapp:9.4.14.v20181114",
-            "org.eclipse.jetty:jetty-xml:9.4.14.v20181114"
+            "org.eclipse.jetty:jetty-continuation:${jetty_version}",
+            "org.eclipse.jetty:jetty-http:${jetty_version}",
+            "org.eclipse.jetty:jetty-io:${jetty_version}",
+            "org.eclipse.jetty:jetty-security:${jetty_version}",
+            "org.eclipse.jetty:jetty-server:${jetty_version}",
+            "org.eclipse.jetty:jetty-servlet:${jetty_version}",
+            "org.eclipse.jetty:jetty-servlets:${jetty_version}",
+            "org.eclipse.jetty:jetty-util:${jetty_version}",
+            "org.eclipse.jetty:jetty-webapp:${jetty_version}",
+            "org.eclipse.jetty:jetty-xml:${jetty_version}"
     ]
 
     // test dependencies

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -56,16 +56,16 @@ ext {
     dropwizardLogstash = "uk.gov.ida:dropwizard-logstash:1.1.2-build_46"
 
     jetty = [
-            "org.eclipse.jetty:jetty-continuation:9.4.6.v20170531",
-            "org.eclipse.jetty:jetty-http:9.4.6.v20170531",
-            "org.eclipse.jetty:jetty-io:9.4.6.v20170531",
-            "org.eclipse.jetty:jetty-security:9.4.6.v20170531",
-            "org.eclipse.jetty:jetty-server:9.4.6.v20170531",
-            "org.eclipse.jetty:jetty-servlet:9.4.6.v20170531",
-            "org.eclipse.jetty:jetty-servlets:9.4.6.v20170531",
-            "org.eclipse.jetty:jetty-util:9.4.6.v20170531",
-            "org.eclipse.jetty:jetty-webapp:9.4.6.v20170531",
-            "org.eclipse.jetty:jetty-xml:9.4.6.v20170531"
+            "org.eclipse.jetty:jetty-continuation:9.4.14.v20181114",
+            "org.eclipse.jetty:jetty-http:9.4.14.v20181114",
+            "org.eclipse.jetty:jetty-io:9.4.14.v20181114",
+            "org.eclipse.jetty:jetty-security:9.4.14.v20181114",
+            "org.eclipse.jetty:jetty-server:9.4.14.v20181114",
+            "org.eclipse.jetty:jetty-servlet:9.4.14.v20181114",
+            "org.eclipse.jetty:jetty-servlets:9.4.14.v20181114",
+            "org.eclipse.jetty:jetty-util:9.4.14.v20181114",
+            "org.eclipse.jetty:jetty-webapp:9.4.14.v20181114",
+            "org.eclipse.jetty:jetty-xml:9.4.14.v20181114"
     ]
 
     // test dependencies

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Context
Prerequisite to running JDK 11 in Travis CI

### Changes proposed in this pull request
* Upgrade to Gradle 5
* Upgrade dependencyCheck plugin to compatible version
* Fix dependencyCheck warnings

### Guidance to review
Build should pass in Travis CI