### PR TITLE
fix v2 root redirect

### DIFF
--- a/src/main/java/uk/gov/register/resources/RedirectResource.java
+++ b/src/main/java/uk/gov/register/resources/RedirectResource.java
@@ -39,7 +39,7 @@ public class RedirectResource {
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV})
     @Path("/next")
     public Response redirectV2GetToRecords(@Context HttpServletRequest request) {
-        return redirectByPath(request, "/next", "/next/register");
+        return redirectByPath(request, "/next", "/next/context");
     }
 
     /*

--- a/src/main/java/uk/gov/register/resources/RedirectResource.java
+++ b/src/main/java/uk/gov/register/resources/RedirectResource.java
@@ -16,7 +16,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriBuilder;
 
 import java.net.URI;

--- a/src/main/java/uk/gov/register/resources/RedirectResource.java
+++ b/src/main/java/uk/gov/register/resources/RedirectResource.java
@@ -31,14 +31,14 @@ public class RedirectResource {
     @GET
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV})
     @Path("/v1")
-    public Response redirectV1GetToRecords(@Context HttpServletRequest request) {
+    public Response redirectV1RootToRegisterResource(@Context HttpServletRequest request) {
         return redirectByPath(request, "/v1", "/register");
     }
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV})
     @Path("/next")
-    public Response redirectV2GetToRecords(@Context HttpServletRequest request) {
+    public Response redirectV2RootToContextResource(@Context HttpServletRequest request) {
         return redirectByPath(request, "/next", "/next/context");
     }
 

--- a/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
+++ b/src/test/java/uk/gov/register/resources/RedirectResourceTest.java
@@ -65,7 +65,7 @@ public class RedirectResourceTest  {
     public void getNextRedirectJsonExtension() {
         Response response = register.getRequest(TestRegister.register, "/next.json", WILDCARD);
         assertThat(response.getStatus(), equalTo(301));
-        assertThat(response.getLocation().getPath(), equalTo("/next/register.json"));
+        assertThat(response.getLocation().getPath(), equalTo("/next/context.json"));
     }
 
     @Test


### PR DESCRIPTION
### Context
Bug fix after https://github.com/openregister/openregister-java/pull/561
`/next` was redirecting to `/next/register` which was a 404

### Changes proposed in this pull request
`/next` should redirect to `/next/context`

### Guidance to review
Tests should pass in Travis CI
`/next` should not 404
