### PR TITLE
bump travis python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
   - $HOME/.m2
 before_script:
 # work around https://github.com/travis-ci/travis-ci/issues/8363
-- pyenv global system 3.6
+- pyenv global system 3.6.7
 - psql --version
 - psql -c 'create database ft_openregister_java_multi;' -U postgres
 - psql -c 'create database conformance_openregister_java;' -U postgres


### PR DESCRIPTION
### Context
master build was failing with `pyenv: version '3.6' not installed`
I suspect this is due to the build environment changing on 2019-01-14 https://docs.travis-ci.com/user/build-environment-updates/2019-01-14/

### Changes proposed in this pull request
Change to 3.6.7 which is available on this environment

### Guidance to review
Build should get past pyenv step (although still failing later on due to dependency check)