### PR TITLE
upgrade dropwizard to 1.3.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     compile(postgresClient) {
         exclude group: 'org.slf4j'
     }
-    compile "com.google.guava:guava:27.0-jre"
     compile jetty
 
     testCompile junit, mockito, dropwizardTest, wiremock

--- a/build.gradle
+++ b/build.gradle
@@ -67,9 +67,6 @@ dependencies {
     compile(postgresClient) {
         exclude group: 'org.slf4j'
     }
-    compile ("io.dropwizard:dropwizard-lifecycle"){
-        exclude group: 'com.google.guava', module: 'guava'
-    }
     compile "com.google.guava:guava:27.0-jre"
     compile jetty
 

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -1,12 +1,12 @@
 ext {
-    dropwizard_version = '1.1.0'
-    dropwizard_metrics_version = '3.1.0'
+    dropwizard_version = '1.3.8'
+    dropwizard_metrics_version = '4.0.5'
     jersey_version = '2.25.1'
-    jackson_version = '2.8.11'
+    jackson_version = '2.9.8'
     jetty_version = '9.4.14.v20181114'
     
 
-    jacksonDatabind = 'com.fasterxml.jackson.core:jackson-databind:2.8.11.1'
+    jacksonDatabind = "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
 
     verifiableLog = 'verifiable-log:verifiable-log:0.2.77'
     objectHash = 'objecthash-java:objecthash-java:0.1.63'
@@ -20,9 +20,7 @@ ext {
             "io.dropwizard:dropwizard-jdbi:${dropwizard_version}",
             "io.dropwizard:dropwizard-logging:${dropwizard_version}",
             "io.dropwizard:dropwizard-views:${dropwizard_version}",
-            "io.dropwizard:dropwizard-metrics-graphite:${dropwizard_version}",
             "io.dropwizard.metrics:metrics-core:${dropwizard_metrics_version}",
-            "io.dropwizard.metrics:metrics-graphite:${dropwizard_metrics_version}",
             "io.dropwizard.modules:dropwizard-flyway:1.0.0-1",
             "io.dropwizard.modules:dropwizard-java8-jdbi:0.9.0-1"
     ]

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafViewRenderer.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafViewRenderer.java
@@ -69,6 +69,6 @@ public class ThymeleafViewRenderer implements ViewRenderer {
 
     @Override
     public String getConfigurationKey() {
-        return "mustache";
+        return "freemarker";
     }
 }

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafViewRenderer.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafViewRenderer.java
@@ -68,7 +68,7 @@ public class ThymeleafViewRenderer implements ViewRenderer {
     }
 
     @Override
-    public String getSuffix() {
-        return suffix;
+    public String getConfigurationKey() {
+        return "mustache";
     }
 }


### PR DESCRIPTION
### Context
master build was failing due to dependency check warning

### Changes proposed in this pull request
Upgrade to dropwizard 1.3.8 (and associated changes to support this)
Note: I have removed `dropwizard-graphite` as I don't believe this is being used (since the move to PaaS)

### Guidance to review
Build should pass on travis
