### PR TITLE
Upgrade underlying OS stack

### DIFF
--- a/deploy/manifests/alpha/basic.yml
+++ b/deploy/manifests/alpha/basic.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: alpha-basic
+  stack: cflinuxfs3
   memory: 2GB
   instances: 2
   buildpack: java_buildpack

--- a/deploy/manifests/alpha/multi.yml
+++ b/deploy/manifests/alpha/multi.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: alpha-multi
+  stack: cflinuxfs3
   memory: 4GB
   instances: 2
   buildpack: java_buildpack

--- a/deploy/manifests/beta/basic.yml
+++ b/deploy/manifests/beta/basic.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: beta-basic
+  stack: cflinuxfs3
   memory: 2GB
   instances: 2
   buildpack: java_buildpack

--- a/deploy/manifests/beta/multi.yml
+++ b/deploy/manifests/beta/multi.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: beta-multi
+  stack: cflinuxfs3
   memory: 4GB
   instances: 2
   buildpack: java_buildpack

--- a/deploy/manifests/discovery/basic.yml
+++ b/deploy/manifests/discovery/basic.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: discovery-basic
+  stack: cflinuxfs3
   memory: 2GB
   instances: 2
   buildpack: java_buildpack

--- a/deploy/manifests/discovery/multi.yml
+++ b/deploy/manifests/discovery/multi.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: discovery-multi
+  stack: cflinuxfs3
   memory: 4GB
   instances: 2
   buildpack: java_buildpack

--- a/deploy/manifests/test/basic.yml
+++ b/deploy/manifests/test/basic.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: test-basic
+  stack: cflinuxfs3
   memory: 2GB
   instances: 2
   buildpack: java_buildpack

--- a/deploy/manifests/test/multi.yml
+++ b/deploy/manifests/test/multi.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: test-multi
+  stack: cflinuxfs3
   memory: 2GB
   instances: 2
   buildpack: java_buildpack


### PR DESCRIPTION
### Context

The operating system on PaaS is about to be upgraded. This means we may
find ourselves in a situation where our applications stop working.

We're bumping these ourselves before the change is enforced upon us, to
prepare ourselves for potential additional work.

### Changes proposed in this pull request

The manifests are now requesting the underlying OS to be `cflinuxfs3`.

### Guidance to review

- Sanity check