### PR TITLE
Add universal Google Analytics code

### DIFF
--- a/src/main/resources/assets/js/analytics-init.js
+++ b/src/main/resources/assets/js/analytics-init.js
@@ -6,4 +6,11 @@ ga('create', 'UA-86101042-1', 'auto');
 ga('set', 'anonymizeIp', true);
 ga('set', 'displayFeaturesTask', null);
 ga('set', 'transport', 'beacon');
+
+ga('create', 'UA-145652997-1', 'auto', 'govuk_shared', {'allowLinker': true});
+ga('govuk_shared.require', 'linker');
+ga('govuk_shared.linker.set', 'anonymizeIp', true);
+ga('govuk_shared.linker:autoLink', ['registers.service.gov.uk', 'www.gov.uk']);
+
 ga('send', 'pageview');
+ga('govuk_shared.send', 'pageview')


### PR DESCRIPTION
### Context

Because Brexit, we've been asked to add a universal GA code to all
government services on a GOV.UK service domain. This does so for
API calls to Registers APIs.

### Changes proposed in this pull request

Add a universal GA code that chucks all analytics into the global
GA account.

### Guidance to review
